### PR TITLE
[hotfix] Fix reinitialize function

### DIFF
--- a/src/interiorpointsolver.jl
+++ b/src/interiorpointsolver.jl
@@ -579,8 +579,6 @@ end
 
 function reinitialize!(ips::AbstractInteriorPointSolver)
     view(ips.x,1:get_nvar(ips.nlp)) .= get_x0(ips.nlp)
-    view(ips.zl,1:get_nvar(ips.nlp)) .= get_zl(ips.nlp)
-    view(ips.zu,1:get_nvar(ips.nlp)) .= get_zu(ips.nlp)
 
     ips.obj_val = eval_f_wrapper(ips, ips.x)
     eval_grad_f_wrapper!(ips, ips.f, ips.x)

--- a/test/madnlp_dense.jl
+++ b/test/madnlp_dense.jl
@@ -93,3 +93,18 @@ end
     end
 end
 
+@testset "MadNLP: restart (PR #113)" begin
+    n, m = 10, 5
+    nlp = MadNLPTests.DenseDummyQP(; n=n, m=m)
+    sparse_options = Dict{Symbol, Any}(
+        :kkt_system=>MadNLP.SPARSE_KKT_SYSTEM,
+        :linear_solver=>MadNLPLapackCPU,
+        :print_level=>MadNLP.ERROR,
+    )
+    ips = MadNLP.InteriorPointSolver(nlp, option_dict=sparse_options)
+    MadNLP.optimize!(ips)
+    # Restart (should hit MadNLP.reinitialize function)
+    res = MadNLP.optimize!(ips)
+    @test ips.status == MadNLP.SOLVE_SUCCEEDED
+end
+


### PR DESCRIPTION
Apparently, it looks like the functions `get_zl` and `get_zu` do not exist anymore in NLPModels.jl ...
This PR removes the setters for the bounds' duals, and add a test for `reinitialize!`