### PR TITLE
Add ReducedKKTVector and UnreducedKKTVector

### DIFF
--- a/src/KKT/KKTsystem.jl
+++ b/src/KKT/KKTsystem.jl
@@ -242,6 +242,7 @@ end
 compress_hessian!(kkt::AbstractKKTSystem) = nothing
 
 
+include("rhs.jl")
 include("sparse.jl")
 include("dense.jl")
 

--- a/src/KKT/dense.jl
+++ b/src/KKT/dense.jl
@@ -144,6 +144,9 @@ end
 function mul!(y::AbstractVector, kkt::DenseKKTSystem, x::AbstractVector)
     mul!(y, kkt.aug_com, x)
 end
+function mul!(y::ReducedKKTVector, kkt::DenseKKTSystem, x::ReducedKKTVector)
+    mul!(y.x, kkt.aug_com, x.x)
+end
 
 function jtprod!(y::AbstractVector, kkt::DenseKKTSystem, x::AbstractVector)
     mul!(y, kkt.jac', x)

--- a/src/KKT/rhs.jl
+++ b/src/KKT/rhs.jl
@@ -1,0 +1,58 @@
+
+
+abstract type AbstractKKTVector{T, VT} end
+
+#=
+    ReducedKKTVector
+=#
+
+struct ReducedKKTVector{T, VT<:AbstractVector{T}} <: AbstractKKTVector{T, VT}
+    x::VT
+    xp::VT # unsafe view
+    xl::VT # unsafe view
+end
+
+ReducedKKTVector(n::Int, m::Int, nlb::Int, nub::Int) = ReducedKKTVector(n, m)
+function ReducedKKTVector(n::Int, m::Int)
+    x = Vector{Float64}(undef, n + m)
+    # Wrap directly array x to avoid dealing with views
+    pp = pointer(x)
+    xp = unsafe_wrap(Vector{Float64}, pp, n)
+    pd = pointer(x, n + 1)
+    xl = unsafe_wrap(Vector{Float64}, pd, m)
+    return ReducedKKTVector{Float64, Vector{Float64}}(x, xp, xl)
+end
+
+Base.length(rhs::ReducedKKTVector) = length(rhs.x)
+
+
+#=
+    UnreducedKKTVector
+=#
+
+struct UnreducedKKTVector{T, VT<:AbstractVector{T}} <: AbstractKKTVector{T, VT}
+    values::VT
+    x::VT  # unsafe view
+    xp::VT # unsafe view
+    xl::VT # unsafe view
+    xzl::VT # unsafe view
+    xzu::VT # unsafe view
+end
+
+function UnreducedKKTVector(n::Int, m::Int, nlb::Int, nub::Int)
+    values = Vector{Float64}(undef, n + m + nlb + nub)
+    # Wrap directly array x to avoid dealing with views
+    pp = pointer(values)
+    x = unsafe_wrap(Vector{Float64}, pp, n + m) # Primal-Dual
+    xp = unsafe_wrap(Vector{Float64}, pp, n) # Primal
+    pd = pointer(values, n + 1)
+    xl = unsafe_wrap(Vector{Float64}, pd, m) # Dual
+    pzl = pointer(values, n + m + 1)
+    xzl = unsafe_wrap(Vector{Float64}, pzl, nlb) # Lower bound
+    pzu = pointer(values, n + m + nlb + 1)
+    xzu = unsafe_wrap(Vector{Float64}, pzu, nub) # Upper bound
+    return UnreducedKKTVector{Float64, Vector{Float64}}(values, x, xp, xl, xzl, xzu)
+end
+
+Base.length(rhs::UnreducedKKTVector) = length(rhs.values)
+

--- a/src/KKT/sparse.jl
+++ b/src/KKT/sparse.jl
@@ -186,6 +186,9 @@ end
 is_reduced(::SparseKKTSystem) = true
 num_variables(kkt::SparseKKTSystem) = length(kkt.pr_diag)
 
+function mul!(y::ReducedKKTVector, kkt::SparseKKTSystem, x::ReducedKKTVector)
+    mul!(y.x, Symmetric(kkt.aug_com, :L), x.x)
+end
 
 #=
     SparseUnreducedKKTSystem
@@ -304,4 +307,8 @@ end
 
 is_reduced(::SparseUnreducedKKTSystem) = false
 num_variables(kkt::SparseUnreducedKKTSystem) = length(kkt.pr_diag)
+
+function mul!(y::UnreducedKKTVector, kkt::SparseUnreducedKKTSystem, x::UnreducedKKTVector)
+    mul!(y.values, Symmetric(kkt.aug_com, :L), x.values)
+end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -63,8 +63,8 @@ macro blas_safe_threads(args...)
 end
 
 # Type definitions
-SubVector{Tv}=SubArray{Tv, 1, Vector{Tv}, Tuple{Vector{Int}}, false}
-StrideOneVector{Tv}=Union{
+const SubVector{Tv} = SubArray{Tv, 1, Vector{Tv}, Tuple{Vector{Int}}, false}
+const StrideOneVector{Tv} = Union{
     Vector{Tv},
     SubArray{Tv,1,Vector{Tv},Tuple{UnitRange{Int}},true},
     SubArray{Tv, 1, Matrix{Tv}, Tuple{Base.Slice{Base.OneTo{Int}}, Int}, true}


### PR DESCRIPTION
We add these two structures to simplify the arithmetic operations with the `AbstractKKTSystem`.

- If `x` and `y` are two `AbstractKKTVector`, we can now multiply `kkt::AbstractKKTSystem` simply as 
  ```julia
  mul!(y, kkt, x) 
  ```
- Unfortunately, this PR does not implement the same kind of overloading for `ldiv!`: at the moment, the dispatch occurs at the `solve_refine_wrapper!` level. I think implementing everything by overloading `ldiv!` would be cleaner, but that will require a non trivial refactoring for `Iterator` (which currently implements `mul!` and `div!` with closures)