### PR TITLE
Fix values displayed in final summary

### DIFF
--- a/src/interiorpointsolver.jl
+++ b/src/interiorpointsolver.jl
@@ -628,9 +628,10 @@ function optimize!(ips::AbstractInteriorPointSolver)
             ips.opt.rethrow_error && rethrow(e)
         end
     finally
-        unscale!(ips)
         ips.cnt.total_time = time() - ips.cnt.start_time
         !(ips.status < SOLVE_SUCCEEDED) && (print_summary_1(ips);print_summary_2(ips))
+        # Unscale once the summary has been printed out
+        unscale!(ips)
         @notice(ips.logger,"EXIT: $(STATUS_OUTPUT_DICT[ips.status])")
         ips.opt.disable_garbage_collector &&
             (GC.enable(true); @warn(ips.logger,"Julia garbage collector is turned back on"))


### PR DESCRIPTION
It occurs to me that the values displayed once MadNLP has converged were a bit off. 

Before, with a scaling of the objective `sigma = 1e-4`, we get 
```
                                   (scaled)                 (unscaled)
Objective...............:   9.6881996115270114e+04    9.6881996115270114e+08
Dual infeasibility......:   8.0883483711822785e-07    8.0883483711822780e-03
Constraint violation....:   9.7949234581776246e+00    2.6250175935160769e-06
Complementarity.........:   2.0142339518343781e-10    2.0142339518343780e-06
Overall NLP error.......:   9.7949234581776246e+00    2.6250175935160769e-06
```
(final objective with order of magnitude `1e+08` instead of `1e-04`, large scaled constraint violation)

With this PR, we get: 
```
                                   (scaled)                 (unscaled)
Objective...............:   9.6881996115270113e+00    9.6881996115270114e+04
Dual infeasibility......:   8.0883483711822785e-07    8.0883483711822780e-03
Constraint violation....:   2.6250175935160769e-06    2.6250175935160769e-06
Complementarity.........:   2.0142339518343781e-10    2.0142339518343780e-06
Overall NLP error.......:   2.6250175935160769e-06    2.6250175935160769e-06
```
which I think makes more sense if we looks at the scaling we are using. 