### PR TITLE
fix MadNLPGPU on CUDA.jl 3.5

### DIFF
--- a/lib/MadNLPGPU/src/MadNLPGPU.jl
+++ b/lib/MadNLPGPU/src/MadNLPGPU.jl
@@ -2,7 +2,8 @@ module MadNLPGPU
 
 import LinearAlgebra
 # CUDA
-import CUDA: CUBLAS, CUSOLVER, CuVector, CuMatrix, CuArray, toolkit_version, R_64F, has_cuda
+import CUDA
+import CUDA: CUBLAS, CUSOLVER, CuVector, CuMatrix, CuArray, R_64F, has_cuda
 # Kernels
 import KernelAbstractions: @kernel, @index, wait
 import CUDAKernels: CUDADevice

--- a/lib/MadNLPGPU/src/lapackgpu.jl
+++ b/lib/MadNLPGPU/src/lapackgpu.jl
@@ -5,7 +5,7 @@ import ..MadNLPGPU:
     AbstractOptions, AbstractLinearSolver, set_options!,
     SymbolicException,FactorizationException,SolveException,InertiaException,
     introduce, factorize!, solve!, improve!, is_inertia, inertia, MadNLPLapackCPU, tril_to_full!,
-    CUBLAS, CUSOLVER, CuVector, CuMatrix, toolkit_version, R_64F
+    CUDA, CUBLAS, CUSOLVER, CuVector, CuMatrix, R_64F
 import .CUSOLVER:
     cusolverDnDsytrf_bufferSize, cusolverDnDsytrf,
     cusolverDnDpotrf_bufferSize, cusolverDnDpotrf, cusolverDnDpotrs,
@@ -85,7 +85,7 @@ end
 improve!(M::Solver) = false
 introduce(M::Solver) = "Lapack-GPU ($(M.opt.lapackgpu_algorithm))"
 
-if toolkit_version() >= v"11.3.1"
+if CUDA.version() >= v"11.3.1"
 
     is_inertia(M::Solver) = M.opt.lapackgpu_algorithm == CHOLESKY  # TODO: implement inertia(M::Solver) for BUNCHKAUFMAN
 


### PR DESCRIPTION
The function `CUDA.toolkit_version` is no longer defined in CUDA.jl 3.5. 