### PR TITLE
Add DenseCondensedKKTSystem 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,8 @@ version = "0.3.0"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+MINLPTests = "ee0a3090-8ee9-5cdb-b8cb-8eeba3165522"
+MadNLPTests = "b52a2a03-04ab-4a5f-9698-6a2deff93217"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -17,20 +19,20 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [compat]
+AmplNLReader = "~0.11"
+MINLPTests = "~0.5"
+MadNLPTests = "~0.3"
 MathOptInterface = "~0.9"
 NLPModels = "~0.17.2"
 SolverCore = "~0.1,~0.2"
 julia = "1.3"
-AmplNLReader = "~0.11"
-MINLPTests = "~0.5"
-MadNLPTests = "~0.3"
 
 [extras]
 AmplNLReader = "77dd3d4c-cb1d-5e09-9340-85030ff7ba66"
+MINLPTests = "ee0a3090-8ee9-5cdb-b8cb-8eeba3165522"
 MadNLPTests = "b52a2a03-04ab-4a5f-9698-6a2deff93217"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-MINLPTests = "ee0a3090-8ee9-5cdb-b8cb-8eeba3165522"
 
 [targets]
-test = ["Test","MadNLPTests","AmplNLReader","MINLPTests", "Random"]
+test = ["Test", "MadNLPTests", "AmplNLReader", "MINLPTests", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,8 +8,6 @@ version = "0.3.0"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
-MINLPTests = "ee0a3090-8ee9-5cdb-b8cb-8eeba3165522"
-MadNLPTests = "b52a2a03-04ab-4a5f-9698-6a2deff93217"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -19,20 +17,20 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [compat]
-AmplNLReader = "~0.11"
-MINLPTests = "~0.5"
-MadNLPTests = "~0.3"
 MathOptInterface = "~0.9"
 NLPModels = "~0.17.2"
 SolverCore = "~0.1,~0.2"
 julia = "1.3"
+AmplNLReader = "~0.11"
+MINLPTests = "~0.5"
+MadNLPTests = "~0.3"
 
 [extras]
 AmplNLReader = "77dd3d4c-cb1d-5e09-9340-85030ff7ba66"
-MINLPTests = "ee0a3090-8ee9-5cdb-b8cb-8eeba3165522"
 MadNLPTests = "b52a2a03-04ab-4a5f-9698-6a2deff93217"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+MINLPTests = "ee0a3090-8ee9-5cdb-b8cb-8eeba3165522"
 
 [targets]
-test = ["Test", "MadNLPTests", "AmplNLReader", "MINLPTests", "Random"]
+test = ["Test","MadNLPTests","AmplNLReader","MINLPTests", "Random"]

--- a/lib/MadNLPGPU/src/MadNLPGPU.jl
+++ b/lib/MadNLPGPU/src/MadNLPGPU.jl
@@ -4,7 +4,7 @@ import LinearAlgebra
 # CUDA
 import CUDA: CUBLAS, CUSOLVER, CuVector, CuMatrix, CuArray, toolkit_version, R_64F, has_cuda
 # Kernels
-import KernelAbstractions: @kernel, @index, wait
+import KernelAbstractions: @kernel, @index, wait, Event
 import CUDAKernels: CUDADevice
 
 import MadNLP

--- a/lib/MadNLPGPU/src/kernels.jl
+++ b/lib/MadNLPGPU/src/kernels.jl
@@ -31,7 +31,7 @@ end
 MadNLP.is_valid(src::CuArray) = true
 
 # Constraint scaling
-function MadNLP._set_con_scale!(con_scale::AbstractVector, jac::CuMatrix, nlp_scaling_max_gradient)
+function MadNLP.set_con_scale!(con_scale::AbstractVector, jac::CuMatrix, nlp_scaling_max_gradient)
     # Compute reduction on the GPU with built-in CUDA.jl function
     d_con_scale = maximum(abs, jac, dims=2)
     copyto!(con_scale, d_con_scale)
@@ -175,6 +175,7 @@ function MadNLP._build_ineq_jac!(
     dest::CuMatrix, jac::CuMatrix, pr_diag::CuVector,
     ind_ineq::AbstractVector, ind_fixed::AbstractVector, con_scale::CuVector, n, m_ineq,
 )
+    (m_ineq == 0) && return # nothing to do if no ineq. constraints
     ind_ineq_gpu = ind_ineq |> CuArray
     ndrange = (m_ineq, n)
     ev = _build_jacobian_condensed_kernel!(CUDADevice())(

--- a/lib/MadNLPGPU/src/kernels.jl
+++ b/lib/MadNLPGPU/src/kernels.jl
@@ -162,6 +162,11 @@ end
 #=
     DenseCondensedKKTSystem
 =#
+function get_slack_regularization(kkt::DenseCondensedKKTSystem)
+    n, ns = num_variables(kkt), kkt.n_ineq
+    return view(kkt.pr_diag, n+1:n+ns) |> Array
+end
+get_scaling_inequalities(kkt::DenseCondensedKKTSystem) = kkt.constraint_scaling[kkt.ind_ineq] |> Array
 
 @kernel function _build_jacobian_condensed_kernel!(
     dest, jac, pr_diag, ind_ineq, con_scale, n, m_ineq,
@@ -246,5 +251,18 @@ function MadNLP.mul!(y::AbstractVector, kkt::MadNLP.DenseCondensedKKTSystem{T, V
         MadNLP._mul_expanded!(d_y, kkt, d_x)
         copyto!(y, d_y)
     end
+end
+
+function jprod_ineq!(y::AbstractVector, kkt::DenseCondensedKKTSystem{T, VT, MT}, x::AbstractVector) where {T, VT<:CuVector{T}, MT<:CuMatrix{T}}
+    # Create buffers
+    haskey(kkt.etc, :jac_ineq_w1) || (kkt.etc[:jac_ineq_w1] = CuVector{T}(undef, kkt.n_ineq))
+    haskey(kkt.etc, :jac_ineq_w2) || (kkt.etc[:jac_ineq_w2] = CuVector{T}(undef, size(kkt.jac_ineq, 2)))
+
+    x_d = kkt.etc[:jac_ineq_w1]::VT
+    y_d = kkt.etc[:jac_ineq_w2]::VT
+
+    copyto!(x_d, x)
+    mul!(y_d, kkt.jac_ineq, x_d)
+    copyto!(y, y_d)
 end
 

--- a/lib/MadNLPGPU/src/kernels.jl
+++ b/lib/MadNLPGPU/src/kernels.jl
@@ -162,11 +162,11 @@ end
 #=
     DenseCondensedKKTSystem
 =#
-function get_slack_regularization(kkt::DenseCondensedKKTSystem)
-    n, ns = num_variables(kkt), kkt.n_ineq
+function MadNLP.get_slack_regularization(kkt::MadNLP.DenseCondensedKKTSystem)
+    n, ns = MadNLP.num_variables(kkt), kkt.n_ineq
     return view(kkt.pr_diag, n+1:n+ns) |> Array
 end
-get_scaling_inequalities(kkt::DenseCondensedKKTSystem) = kkt.constraint_scaling[kkt.ind_ineq] |> Array
+MadNLP.get_scaling_inequalities(kkt::MadNLP.DenseCondensedKKTSystem) = kkt.constraint_scaling[kkt.ind_ineq] |> Array
 
 @kernel function _build_jacobian_condensed_kernel!(
     dest, jac, pr_diag, ind_ineq, con_scale, n, m_ineq,
@@ -253,16 +253,16 @@ function MadNLP.mul!(y::AbstractVector, kkt::MadNLP.DenseCondensedKKTSystem{T, V
     end
 end
 
-function jprod_ineq!(y::AbstractVector, kkt::DenseCondensedKKTSystem{T, VT, MT}, x::AbstractVector) where {T, VT<:CuVector{T}, MT<:CuMatrix{T}}
+function MadNLP.jprod_ineq!(y::AbstractVector, kkt::MadNLP.DenseCondensedKKTSystem{T, VT, MT}, x::AbstractVector) where {T, VT<:CuVector{T}, MT<:CuMatrix{T}}
     # Create buffers
     haskey(kkt.etc, :jac_ineq_w1) || (kkt.etc[:jac_ineq_w1] = CuVector{T}(undef, kkt.n_ineq))
     haskey(kkt.etc, :jac_ineq_w2) || (kkt.etc[:jac_ineq_w2] = CuVector{T}(undef, size(kkt.jac_ineq, 2)))
 
-    x_d = kkt.etc[:jac_ineq_w1]::VT
-    y_d = kkt.etc[:jac_ineq_w2]::VT
+    y_d = kkt.etc[:jac_ineq_w1]::VT
+    x_d = kkt.etc[:jac_ineq_w2]::VT
 
     copyto!(x_d, x)
-    mul!(y_d, kkt.jac_ineq, x_d)
+    LinearAlgebra.mul!(y_d, kkt.jac_ineq, x_d)
     copyto!(y, y_d)
 end
 

--- a/lib/MadNLPGPU/src/lapackgpu.jl
+++ b/lib/MadNLPGPU/src/lapackgpu.jl
@@ -85,7 +85,7 @@ end
 improve!(M::Solver) = false
 introduce(M::Solver) = "Lapack-GPU ($(M.opt.lapackgpu_algorithm))"
 
-if toolkit_version() >= v"11.3.1"
+if true #toolkit_version() >= v"11.3.1"
 
     is_inertia(M::Solver) = M.opt.lapackgpu_algorithm == CHOLESKY  # TODO: implement inertia(M::Solver) for BUNCHKAUFMAN
 

--- a/lib/MadNLPGPU/test/densekkt_gpu.jl
+++ b/lib/MadNLPGPU/test/densekkt_gpu.jl
@@ -4,7 +4,7 @@ using MadNLPTests
 
 function _compare_gpu_with_cpu(kkt_system, n, m, ind_fixed)
     madnlp_options = Dict{Symbol, Any}(
-        :kkt_system=>kkt_system,
+        :kkt_system=>MadNLP.CONDENSED_KKT_SYSTEM,
         :linear_solver=>MadNLPLapackGPU,
         :print_level=>MadNLP.ERROR,
     )
@@ -14,34 +14,30 @@ function _compare_gpu_with_cpu(kkt_system, n, m, ind_fixed)
     h_ips = MadNLP.InteriorPointSolver(nlp; option_dict=copy(madnlp_options))
     MadNLP.optimize!(h_ips)
 
-    # Reinit NonlinearProgram to avoid side effect
-    ind_cons = MadNLP.get_index_constraints(nlp)
-    ns = length(ind_cons.ind_ineq)
 
     # Init KKT on the GPU
-    TKKTGPU = MadNLP.DenseKKTSystem{Float64, CuVector{Float64}, CuMatrix{Float64}}
+    TKKTGPU = kkt_system{Float64, CuVector{Float64}, CuMatrix{Float64}}
     opt = MadNLP.Options(; madnlp_options...)
     # Instantiate Solver with KKT on the GPU
     d_ips = MadNLP.InteriorPointSolver{TKKTGPU}(nlp, opt; option_linear_solver=copy(madnlp_options))
     MadNLP.optimize!(d_ips)
 
-    # Check that both results match exactly
+    # # Check that both results match exactly
     @test h_ips.cnt.k == d_ips.cnt.k
     @test h_ips.obj_val ≈ d_ips.obj_val atol=1e-10
     @test h_ips.x ≈ d_ips.x atol=1e-10
     @test h_ips.l ≈ d_ips.l atol=1e-10
 end
 
-@testset "MadNLPGPU: kkt_system = $(kkt_system)" for kkt_system in [
-        MadNLP.DENSE_KKT_SYSTEM,
-        MadNLP.CONDENSED_KKT_SYSTEM,
+@testset "MadNLPGPU ($(kkt_system))" for kkt_system in [
+        MadNLP.DenseKKTSystem,
+        MadNLP.DenseCondensedKKTSystem,
     ]
     @testset "Size: ($n, $m)" for (n, m) in [(10, 0), (10, 5), (50, 10)]
         _compare_gpu_with_cpu(kkt_system, n, m, Int[])
     end
     @testset "Fixed variables" begin
-        n, m = 10, 5
-        _compare_gpu_with_cpu(kkt_system, 10, 5, Int[1, 2])
+        n, m = 20, 0 # warning: setting m >= 1 does not work in inertia free mode
+        _compare_gpu_with_cpu(kkt_system, n, m, Int[1, 2])
     end
 end
-

--- a/lib/MadNLPGPU/test/densekkt_gpu.jl
+++ b/lib/MadNLPGPU/test/densekkt_gpu.jl
@@ -2,9 +2,9 @@
 using CUDA
 using MadNLPTests
 
-function _compare_gpu_with_cpu(n, m, ind_fixed)
+function _compare_gpu_with_cpu(kkt_system, n, m, ind_fixed)
     madnlp_options = Dict{Symbol, Any}(
-        :kkt_system=>MadNLP.DENSE_KKT_SYSTEM,
+        :kkt_system=>kkt_system,
         :linear_solver=>MadNLPLapackGPU,
         :print_level=>MadNLP.ERROR,
     )
@@ -32,13 +32,16 @@ function _compare_gpu_with_cpu(n, m, ind_fixed)
     @test h_ips.l ≈ d_ips.l atol=1e-10
 end
 
-@testset "MadNLP: dense versus sparse" begin
+@testset "MadNLPGPU: kkt_system = $(kkt_system)" for kkt_system in [
+        MadNLP.DENSE_KKT_SYSTEM,
+        MadNLP.CONDENSED_KKT_SYSTEM,
+    ]
     @testset "Size: ($n, $m)" for (n, m) in [(10, 0), (10, 5), (50, 10)]
-        _compare_gpu_with_cpu(n, m, Int[])
+        _compare_gpu_with_cpu(kkt_system, n, m, Int[])
     end
     @testset "Fixed variables" begin
         n, m = 10, 5
-        _compare_gpu_with_cpu(10, 5, Int[1, 2])
+        _compare_gpu_with_cpu(kkt_system, 10, 5, Int[1, 2])
     end
 end
 

--- a/lib/MadNLPTests/src/MadNLPTests.jl
+++ b/lib/MadNLPTests/src/MadNLPTests.jl
@@ -254,7 +254,7 @@ function MadNLP.hess_dense!(qp::DenseDummyQP, x, l,hess::AbstractMatrix; obj_wei
     copyto!(hess, obj_weight .* qp.P)
 end
 
-function DenseDummyQP(; n=100, m=10, fixed_variables=Int[])
+function DenseDummyQP(; n=100, m=10, fixed_variables=Int[], equality_cons=[])
     if m >= n
         error("The number of constraints `m` should be less than the number of variable `n`.")
     end
@@ -279,10 +279,12 @@ function DenseDummyQP(; n=100, m=10, fixed_variables=Int[])
     y0 = zeros(m)
 
     # Bound constraints
-    xu =   ones(n)
-    xl = - ones(n)
-    gl = -ones(m)
-    gu = ones(m)
+    xu = fill(1.0, n)
+    xl = fill(0.0, n)
+    gl = fill(0.0, m)
+    gu = fill(1.0, m)
+    # Update gu to load equality constraints
+    gu[equality_cons] .= 0.0
 
     xl[fixed_variables] .= xu[fixed_variables]
 

--- a/src/KKT/dense.jl
+++ b/src/KKT/dense.jl
@@ -266,10 +266,10 @@ function _build_condensed_kkt_system!(dest, hess, jac, pr_diag, du_diag, ind_eq,
     end
 end
 
-function _build_ineq_jac!(dest, jac, pr_diag, ind_ineq, n, m_ineq)
+function _build_ineq_jac!(dest, jac, pr_diag, ind_ineq, con_scale, n, m_ineq)
     for i in 1:m_ineq, j in 1:n
         is = ind_ineq[i]
-        dest[i, j] = jac[is, j] * sqrt(pr_diag[n+i])
+        dest[i, j] = jac[is, j] * sqrt(pr_diag[n+i]) / con_scale[is]
     end
 end
 
@@ -279,8 +279,9 @@ function build_kkt!(kkt::DenseCondensedKKTSystem{T, VT, MT}) where {T, VT, MT}
     m = size(kkt.jac, 1)
     ns = length(kkt.ind_ineq)
 
+    fill!(kkt.aug_com, zero(T))
     # Build √Σₛ * J
-    _build_ineq_jac!(kkt.jac_ineq, kkt.jac, kkt.pr_diag, kkt.ind_ineq, n, ns)
+    _build_ineq_jac!(kkt.jac_ineq, kkt.jac, kkt.pr_diag, kkt.ind_ineq, kkt.constraint_scaling, n, ns)
 
     # J' * Σₛ * J
     mul!(kkt.aug_com, kkt.jac_ineq', kkt.jac_ineq)

--- a/src/KKT/dense.jl
+++ b/src/KKT/dense.jl
@@ -243,6 +243,12 @@ end
 is_reduced(kkt::DenseCondensedKKTSystem) = true
 num_variables(kkt::DenseCondensedKKTSystem) = size(kkt.hess, 1)
 
+function get_slack_regularization(kkt::DenseCondensedKKTSystem)
+    n, ns = num_variables(kkt), kkt.n_ineq
+    return view(kkt.pr_diag, n+1:n+ns)
+end
+get_scaling_inequalities(kkt::DenseCondensedKKTSystem) = kkt.constraint_scaling[kkt.ind_ineq]
+
 function _build_condensed_kkt_system!(
     dest::AbstractMatrix, hess::AbstractMatrix, jac::AbstractMatrix,
     pr_diag::AbstractVector, du_diag::AbstractVector, ind_eq::AbstractVector, n, m_eq,
@@ -359,5 +365,9 @@ function mul!(y::AbstractVector, kkt::DenseCondensedKKTSystem, x::AbstractVector
     else
         _mul_expanded!(y, kkt, x)
     end
+end
+
+function jprod_ineq!(y::AbstractVector, kkt::DenseCondensedKKTSystem, x::AbstractVector)
+    mul!(y, kkt.jac_ineq, x)
 end
 

--- a/src/enums.jl
+++ b/src/enums.jl
@@ -22,7 +22,9 @@
 @enum(KKTLinearSystem::Int,
       SPARSE_KKT_SYSTEM = 1,
       SPARSE_UNREDUCED_KKT_SYSTEM = 2,
-      DENSE_KKT_SYSTEM = 3)
+      DENSE_KKT_SYSTEM = 3,
+      CONDENSED_KKT_SYSTEM = 4,
+)
 
 @enum(Status::Int,
       SOLVE_SUCCEEDED = 1,

--- a/src/interiorpointsolver.jl
+++ b/src/interiorpointsolver.jl
@@ -274,6 +274,48 @@ function solve_refine_wrapper!(ips::InteriorPointSolver, x,b)
     return solve_status
 end
 
+function solve_refine_wrapper!(ips::InteriorPointSolver{<:DenseCondensedKKTSystem}, x,b)
+    cnt = ips.cnt
+    @trace(ips.logger,"Iterative solution started.")
+    fixed_variable_treatment_vec!(b, ips.ind_fixed)
+
+    kkt = ips.kkt
+
+    n = num_variables(kkt)
+
+    Σₛ = view(kkt.pr_diag, n+1:ips.n)
+
+    # Decompose right hand side
+    bx = view(b, 1:n)
+    bs = view(b, n+1:ips.n) # ips.n includes slack variables
+    by = view(b, ips.n .+ kkt.ind_eq)
+    bz = view(b, ips.n .+ kkt.ind_ineq)
+
+    jt = zeros(ips.n)
+    v = zeros(ips.m)
+    v[kkt.ind_ineq] .= Σₛ .* bz .+ bs
+    jtprod!(jt, kkt, v)
+    b_c = [bx + jt[1:n]; by]
+    x_c = similar(b_c)
+
+    cnt.linear_solver_time += @elapsed (result = solve_refine!(x_c, ips.iterator, b_c))
+    solve_status = (result == :Solved)
+
+    # Decompose results
+    xx = view(x, 1:n)
+    xs = view(x, n+1:ips.n) # ips.n includes slack variables
+    xy = view(x, ips.n .+ ips.kkt.ind_eq)
+    xz = view(x, ips.n .+ ips.kkt.ind_ineq)
+
+    xx .= x_c[1:n]
+    xy .= x_c[1+n:end]
+    xz .= sqrt.(Σₛ) .* (kkt.jac_ineq * xx) .- Σₛ .* bz .- bs
+    xs .= (bs .+ xz) ./ Σₛ
+
+    fixed_variable_treatment_vec!(x, ips.ind_fixed)
+    return solve_status
+end
+
 function eval_f_wrapper(ips::InteriorPointSolver, x::Vector{Float64})
     nlp = ips.nlp
     cnt = ips.cnt
@@ -337,7 +379,7 @@ function eval_lag_hess_wrapper!(ipp::InteriorPointSolver, kkt::AbstractKKTSystem
     return hess
 end
 
-function eval_jac_wrapper!(ipp::InteriorPointSolver, kkt::DenseKKTSystem, x::Vector{Float64})
+function eval_jac_wrapper!(ipp::InteriorPointSolver, kkt::AbstractDenseKKTSystem, x::Vector{Float64})
     nlp = ipp.nlp
     cnt = ipp.cnt
     ns = length(ipp.ind_ineq)
@@ -351,7 +393,7 @@ function eval_jac_wrapper!(ipp::InteriorPointSolver, kkt::DenseKKTSystem, x::Vec
     return jac
 end
 
-function eval_lag_hess_wrapper!(ipp::InteriorPointSolver, kkt::DenseKKTSystem, x::Vector{Float64},l::Vector{Float64};is_resto=false)
+function eval_lag_hess_wrapper!(ipp::InteriorPointSolver, kkt::AbstractDenseKKTSystem, x::Vector{Float64},l::Vector{Float64};is_resto=false)
     nlp = ipp.nlp
     cnt = ipp.cnt
     @trace(ipp.logger,"Evaluating Lagrangian Hessian.")
@@ -383,6 +425,10 @@ function InteriorPointSolver(nlp::AbstractNLPModel;
         MT = Matrix{Float64}
         VT = Vector{Float64}
         DenseKKTSystem{Float64, VT, MT}
+    elseif opt.kkt_system == CONDENSED_KKT_SYSTEM
+        MT = Matrix{Float64}
+        VT = Vector{Float64}
+        DenseCondensedKKTSystem{Float64, VT, MT}
     end
     return InteriorPointSolver{KKTSystem}(nlp, opt; option_linear_solver=option_dict)
 end
@@ -488,9 +534,10 @@ function InteriorPointSolver{KKTSystem}(nlp::AbstractNLPModel, opt::Options;
     cnt.linear_solver_time =
         @elapsed linear_solver = opt.linear_solver.Solver(get_kkt(kkt) ; option_dict=option_linear_solver,logger=logger)
 
+    n_kkt = size(get_kkt(kkt), 1)
     @trace(logger,"Initializing iterative solver.")
     iterator = opt.iterator.Solver(
-        similar(d),
+        similar(d, n_kkt),
         (b, x)->mul!(b, kkt, x), (x)->solve!(linear_solver, x) ; option_dict=option_linear_solver)
 
     @trace(logger,"Initializing fixed variable treatment scheme.")

--- a/test/madnlp_dense.jl
+++ b/test/madnlp_dense.jl
@@ -6,11 +6,46 @@ using MadNLPTests
 using SparseArrays
 using Random
 
-@testset "MadNLP: dense API" begin
-    n = 10
+function _compare_dense_with_sparse(kkt_system, n, m, ind_fixed, ind_eq)
+    sparse_options = Dict{Symbol, Any}(
+        :kkt_system=>MadNLP.SPARSE_KKT_SYSTEM,
+        :linear_solver=>MadNLPLapackCPU,
+        :print_level=>MadNLP.ERROR,
+    )
+    dense_options = Dict{Symbol, Any}(
+        :kkt_system=>kkt_system,
+        :linear_solver=>MadNLPLapackCPU,
+        :print_level=>MadNLP.ERROR,
+    )
+
+    nlp = MadNLPTests.DenseDummyQP(; n=n, m=m, fixed_variables=ind_fixed, equality_cons=ind_eq)
+
+    ips = MadNLP.InteriorPointSolver(nlp, option_dict=sparse_options)
+    ipd = MadNLP.InteriorPointSolver(nlp, option_dict=dense_options)
+
+    MadNLP.optimize!(ips)
+    MadNLP.optimize!(ipd)
+
+    # Check that dense formulation matches exactly sparse formulation
+    @test ips.cnt.k == ipd.cnt.k
+    @test ips.obj_val ≈ ipd.obj_val atol=1e-10
+    @test ips.x ≈ ipd.x atol=1e-10
+    @test ips.l ≈ ipd.l atol=1e-10
+    @test ips.kkt.jac_com[:, 1:n] == ipd.kkt.jac
+    if isa(ipd.kkt, MadNLP.AbstractReducedKKTSystem)
+        @test Symmetric(ips.kkt.aug_com, :L) ≈ ipd.kkt.aug_com atol=1e-10
+    end
+end
+
+@testset "MadNLP: API $(kkt_type)" for (kkt_type, kkt_options) in [
+        (MadNLP.DenseKKTSystem, MadNLP.DENSE_KKT_SYSTEM),
+        (MadNLP.DenseCondensedKKTSystem, MadNLP.CONDENSED_KKT_SYSTEM),
+    ]
+
+    n = 10 # number of variables
     @testset "Unconstrained" begin
         dense_options = Dict{Symbol, Any}(
-            :kkt_system=>MadNLP.DENSE_KKT_SYSTEM,
+            :kkt_system=>kkt_options,
             :linear_solver=>MadNLPLapackCPU,
         )
         m = 0
@@ -18,9 +53,12 @@ using Random
         ipd = MadNLP.InteriorPointSolver(nlp, option_dict=dense_options)
 
         kkt = ipd.kkt
-        @test isa(kkt, MadNLP.DenseKKTSystem)
+        @test isa(kkt, kkt_type)
         @test isempty(kkt.jac)
-        @test kkt.hess === kkt.aug_com
+        # Special test for DenseKKTSystem
+        if kkt_type <: MadNLP.DenseKKTSystem
+            @test kkt.hess === kkt.aug_com
+        end
         @test ipd.linear_solver.dense === kkt.aug_com
         @test size(kkt.hess) == (n, n)
         @test length(kkt.pr_diag) == n
@@ -28,7 +66,7 @@ using Random
 
         # Test that using a sparse solver is forbidden in dense mode
         dense_options_error = Dict{Symbol, Any}(
-            :kkt_system=>MadNLP.DENSE_KKT_SYSTEM,
+            :kkt_system=>kkt_options,
             :linear_solver=>MadNLPUmfpack,
         )
         @test_throws Exception MadNLP.InteriorPointSolver(nlp, dense_options_error)
@@ -54,42 +92,17 @@ using Random
 end
 
 
-function _compare_dense_with_sparse(n, m, ind_fixed)
-    sparse_options = Dict{Symbol, Any}(
-        :kkt_system=>MadNLP.SPARSE_KKT_SYSTEM,
-        :linear_solver=>MadNLPLapackCPU,
-        :print_level=>MadNLP.ERROR,
-    )
-    dense_options = Dict{Symbol, Any}(
-        :kkt_system=>MadNLP.DENSE_KKT_SYSTEM,
-        :linear_solver=>MadNLPLapackCPU,
-        :print_level=>MadNLP.ERROR,
-    )
-
-    nlp = MadNLPTests.DenseDummyQP(; n=n, m=m, fixed_variables=ind_fixed)
-
-    ips = MadNLP.InteriorPointSolver(nlp, option_dict=sparse_options)
-    ipd = MadNLP.InteriorPointSolver(nlp, option_dict=dense_options)
-
-    MadNLP.optimize!(ips)
-    MadNLP.optimize!(ipd)
-
-    # Check that dense formulation matches exactly sparse formulation
-    @test ips.cnt.k == ipd.cnt.k
-    @test ips.obj_val ≈ ipd.obj_val atol=1e-10
-    @test ips.x ≈ ipd.x atol=1e-10
-    @test ips.l ≈ ipd.l atol=1e-10
-    @test ips.kkt.jac_com[:, 1:n] == ipd.kkt.jac
-    @test Symmetric(ips.kkt.aug_com, :L) ≈ ipd.kkt.aug_com atol=1e-10
-end
-
-@testset "MadNLP: dense versus sparse" begin
+@testset "MadNLP: option kkt_system=$(kkt_system)" for kkt_system in [MadNLP.DENSE_KKT_SYSTEM, MadNLP.CONDENSED_KKT_SYSTEM]
     @testset "Size: ($n, $m)" for (n, m) in [(10, 0), (10, 5), (50, 10)]
-        _compare_dense_with_sparse(n, m, Int[])
+        _compare_dense_with_sparse(kkt_system, n, m, Int[], Int[])
+    end
+    @testset "Equality constraints" begin
+        n, m = 20, 15
+        _compare_dense_with_sparse(kkt_system, n, m, Int[], Int[1, 8]) # test with non-trivial equality constraints
     end
     @testset "Fixed variables" begin
         n, m = 10, 5
-        _compare_dense_with_sparse(10, 5, Int[1, 2])
+        _compare_dense_with_sparse(kkt_system, 10, 5, Int[1, 2], Int[])
     end
 end
 

--- a/test/madnlp_dense.jl
+++ b/test/madnlp_dense.jl
@@ -45,7 +45,7 @@ using Random
 
         kkt = ipd.kkt
         @test isa(kkt, MadNLP.DenseKKTSystem)
-        @test size(kkt.jac) == (m, n + ns)
+        @test size(kkt.jac) == (m, n)
         @test ipd.linear_solver.dense === kkt.aug_com
         @test size(kkt.hess) == (n, n)
         @test length(kkt.pr_diag) == n + ns
@@ -79,7 +79,7 @@ function _compare_dense_with_sparse(n, m, ind_fixed)
     @test ips.obj_val ≈ ipd.obj_val atol=1e-10
     @test ips.x ≈ ipd.x atol=1e-10
     @test ips.l ≈ ipd.l atol=1e-10
-    @test ips.kkt.jac_com == ipd.kkt.jac
+    @test ips.kkt.jac_com[:, 1:n] == ipd.kkt.jac
     @test Symmetric(ips.kkt.aug_com, :L) ≈ ipd.kkt.aug_com atol=1e-10
 end
 

--- a/test/madnlp_dense.jl
+++ b/test/madnlp_dense.jl
@@ -102,7 +102,7 @@ end
     end
     @testset "Fixed variables" begin
         n, m = 10, 5
-        _compare_dense_with_sparse(kkt_system, 10, 5, Int[1, 2], Int[])
+        _compare_dense_with_sparse(kkt_system, n, m, Int[1, 2], Int[])
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test, MadNLP, MadNLPTests, MINLPTests
 import MathOptInterface
-import AmplNLReader: AmplModel
+# import AmplNLReader: AmplModel
 import SparseArrays: sparse
 
 @testset "MadNLP test" begin


### PR DESCRIPTION
Add new `DenseCondensedKKTSystem <: AbstractCondensedKKTSystem` abstraction. Works both on CPU and on CUDA GPU. 
The `DenseCondensedKKTSystem` allows to reduce drastically the size of the KKT system if the problem has many inequality constraints.

- `DenseKKTSystem` has been refactorized so the dense Jacobian has a size `(m, n)` (instead of `(m, n+ns)`)
- the option `CONDENSED_KKT_SYSTEM` loads a `DenseCondensedKKTSystem` under the hood (names can be improved, of course, I welcome any suggestion) 
- `MadNLPTests.DenseDummyQP` has been slightly updated to load more challenging QP problem (with inequality constraints activated at the solution). We now can mix both inequalities and equality constraints to test more thoroughly the different `KKTSystem` 
- this PR can be cleaned further once #116  is merged  