### PR TITLE
MadNLPGPU: fix wrong runtime version for CUDA

### DIFF
--- a/lib/MadNLPGPU/src/lapackgpu.jl
+++ b/lib/MadNLPGPU/src/lapackgpu.jl
@@ -85,7 +85,7 @@ end
 improve!(M::Solver) = false
 introduce(M::Solver) = "Lapack-GPU ($(M.opt.lapackgpu_algorithm))"
 
-if CUDA.version() >= v"11.3.1"
+if CUDA.runtime_version() >= v"11.3.1"
 
     is_inertia(M::Solver) = M.opt.lapackgpu_algorithm == CHOLESKY  # TODO: implement inertia(M::Solver) for BUNCHKAUFMAN
 


### PR DESCRIPTION
I made a mistake previously: `CUDA.version` returns the version of the driver being used, instead of the current CUDA's version. We should use `runtime_version` instead.