### PR TITLE
MadNLPPardisoMKL move to MadNLPPardiso.jl

### DIFF
--- a/lib/MadNLPPardiso/Project.toml
+++ b/lib/MadNLPPardiso/Project.toml
@@ -8,12 +8,14 @@ MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
 
 [compat]
 MadNLP = "~0.4"
 BinaryProvider = "0.5"
 MadNLPTests = "~0.4"
 julia = "1.6"
+MKL_jll = "~2021,2022"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/lib/MadNLPPardiso/src/MadNLPPardiso.jl
+++ b/lib/MadNLPPardiso/src/MadNLPPardiso.jl
@@ -6,17 +6,21 @@ const INPUT_MATRIX_TYPE = :csc
 
 import Libdl: dlopen, RTLD_DEEPBIND
 import MadNLP:
-    @kwdef, Logger, @debug, @warn, @error,
+    MadNLP, @kwdef, Logger, @debug, @warn, @error,
     SubVector, StrideOneVector, SparseMatrixCSC, 
     SymbolicException,FactorizationException,SolveException,InertiaException,
     AbstractOptions, AbstractLinearSolver, set_options!,
     introduce, factorize!, solve!, improve!, is_inertia, inertia
+import MKL_jll: libmkl_rt
 
 @isdefined(libpardiso) && include("pardiso.jl")
+include("pardisomkl.jl")
 
 function __init__()
     check_deps()
     @isdefined(libpardiso) && dlopen(libpardiso,RTLD_DEEPBIND)
 end
+
+export MadNLPPardisoMKL
 
 end # module

--- a/lib/MadNLPPardiso/src/pardisomkl.jl
+++ b/lib/MadNLPPardiso/src/pardisomkl.jl
@@ -1,14 +1,12 @@
-# MadNLP.jl
-# Created by Sungho Shin (sungho.shin@wisc.edu)
-
 module MadNLPPardisoMKL
 
 import ..MadNLP:
     @kwdef, Logger, @debug, @warn, @error,
-    SubVector, StrideOneVector, SparseMatrixCSC, libblas,
+    SubVector, StrideOneVector, SparseMatrixCSC, 
     SymbolicException,FactorizationException,SolveException,InertiaException,
     AbstractOptions, AbstractLinearSolver, set_options!,
     introduce, factorize!, solve!, improve!, is_inertia, inertia, blas_num_threads
+import ..MadNLPPardiso: libmkl_rt
 
 const INPUT_MATRIX_TYPE = :csc
 
@@ -36,7 +34,7 @@ end
 
 pardisomkl_pardisoinit(pt,mtype::Ref{Cint},iparm::Vector{Cint}) =
     ccall(
-        (:pardisoinit,libblas),
+        (:pardisoinit,libmkl_rt),
         Cvoid,
         (Ptr{Cvoid},Ptr{Cint},Ptr{Cint}),
         pt,mtype,iparm)
@@ -45,7 +43,7 @@ pardisomkl_pardiso(pt,maxfct::Ref{Cint},mnum::Ref{Cint},mtype::Ref{Cint},
                    perm::Vector{Cint},nrhs::Ref{Cint},iparm::Vector{Cint},msglvl::Ref{Cint},
                    b::StrideOneVector{Cdouble},x::StrideOneVector{Cdouble},err::Ref{Cint}) =
                        ccall(
-                           (:pardiso,libblas),
+                           (:pardiso,libmkl_rt),
                            Cvoid,
                            (Ptr{Cvoid}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
                             Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
@@ -53,11 +51,11 @@ pardisomkl_pardiso(pt,maxfct::Ref{Cint},mnum::Ref{Cint},mtype::Ref{Cint},
                            pt,maxfct,mnum,mtype,phase,n,a,ia,ja,perm,nrhs,iparm,msglvl,b,x,err)
 
 function pardisomkl_set_num_threads!(n)
-    ccall((:mkl_set_dynamic, libblas),
+    ccall((:mkl_set_dynamic, libmkl_rt),
          Cvoid,
          (Ptr{Cint},),
           Ref{Cint}(0))
-    ccall((:mkl_set_num_threads, libblas),
+    ccall((:mkl_set_num_threads, libmkl_rt),
           Cvoid,
           (Ptr{Cint},),
           Ref{Cint}(n))

--- a/lib/MadNLPPardiso/test/runtests.jl
+++ b/lib/MadNLPPardiso/test/runtests.jl
@@ -9,6 +9,13 @@ testset = [
         [],
         @isdefined(MadNLPPardiso)
     ],
+    [
+        "PardisoMKL",
+        ()->MadNLP.Optimizer(
+            linear_solver=MadNLPPardisoMKL,
+            print_level=MadNLP.ERROR),
+        ["eigmina"]
+    ]
 ]
 
 @testset "MadNLPPardiso test" begin

--- a/src/LinearSolvers/linearsolvers.jl
+++ b/src/LinearSolvers/linearsolvers.jl
@@ -31,4 +31,3 @@ include("lapack.jl")
 
 # direct solvers
 include("umfpack.jl")
-has_mkl() && include("pardisomkl.jl")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -47,17 +47,6 @@ for (name,level,color) in [(:trace,TRACE,7),(:debug,DEBUG,6),(:info,INFO,256),(:
     end
 end
 
-if VERSION >= v"1.7.0"
-    function has_mkl()
-        blasconfig = string(BLAS.get_config())
-        return occursin("mkl", blasconfig)
-    end
-else
-    function has_mkl()
-        return BLAS.vendor() == :mkl
-    end
-end
-
 # BLAS
 const blas_num_threads = Ref{Int}(1)
 function set_blas_num_threads(n::Integer;permanent::Bool=false)

--- a/test/madnlp_test.jl
+++ b/test/madnlp_test.jl
@@ -70,17 +70,6 @@ testset = [
     ],
 ]
 
-@isdefined(MadNLPPardisoMKL) && push!(
-    testset,
-    [
-        "PardisoMKL",
-        ()->MadNLP.Optimizer(
-            linear_solver=MadNLPPardisoMKL,
-            print_level=MadNLP.ERROR),
-        ["eigmina"]
-    ]
-)
-
 for (name,optimizer_constructor,exclude) in testset
     test_madnlp(name,optimizer_constructor,exclude)
 end


### PR DESCRIPTION
With this change, the `MadNLPPardisoMKL` is moved to `MadNLPPardiso.jl` extension pacakge, and now `MadNLPPardiso.jl` relies on `MKL_jll`. This change allows for the self-hosted testing not to require MKL.