### PR TITLE
Add support to KernelAbstractions 0.8

### DIFF
--- a/.ci/ci.jl
+++ b/.ci/ci.jl
@@ -8,10 +8,10 @@ Pkg.activate(@__DIR__)
 
 
 if ARGS[1] == "full"
-    pkgs = ["MadNLPHSL","MadNLPPardiso","MadNLPMumps","MadNLPGPU","MadNLPKrylov"]
+    pkgs = ["MadNLPHSL","MadNLPPardiso","MadNLPMumps","MadNLPKrylov"]
 elseif ARGS[1] == "basic"
     pkgs = ["MadNLPMumps","MadNLPKrylov"]
-elseif ARGS[1] == "gpu"
+elseif ARGS[1] == "cuda"
     pkgs = ["MadNLPGPU"]
 else
     error("proper argument should be given - full or basic")
@@ -22,5 +22,7 @@ Pkg.develop(PackageSpec(path=joinpath(@__DIR__,"..","lib","MadNLPTests")))
 Pkg.develop.([PackageSpec(path=joinpath(@__DIR__,"..","lib",pkg)) for pkg in pkgs])
 Pkg.build()
 
-Pkg.test.("MadNLP", coverage=true)
+if ARGS[1] == "full" || ARGS[1] == "basic"
+    Pkg.test("MadNLP", coverage=true)
+end
 Pkg.test.(pkgs, coverage=true)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,7 @@ jobs:
       - run: julia --color=yes --project=.ci .ci/ci.jl basic
   test-moonshot:
     env:
-      CUDA_VISIBLE_DEVICES: 1
       JULIA_DEPOT_PATH: /scratch/sshin/github-actions/julia_depot_madnlp
-      JULIA_CUDA_USE_BINARYBUILDER: true
     runs-on: self-hosted
     strategy:
       matrix:
@@ -38,7 +36,22 @@ jobs:
       - run: julia --color=yes --project=.ci .ci/ci.jl full
       - uses: julia-actions/julia-processcoverage@v1
         with:
-          directories: src,lib/MadNLPGPU/src,lib/MadNLPHSL/src,lib/MadNLPPardiso/src,lib/MadNLPMumps/src,lib/MadNLPKrylov/src,lib/MadNLPGraph
+          directories: src,lib/MadNLPHSL/src,lib/MadNLPPardiso/src,lib/MadNLPMumps/src,lib/MadNLPKrylov/src,lib/MadNLPGraph
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
+  test-moonshot-cuda:
+    env:
+      CUDA_VISIBLE_DEVICES: 1
+      JULIA_DEPOT_PATH: /scratch/sshin/github-actions/julia_depot_madnlp
+      JULIA_CUDA_USE_BINARYBUILDER: true
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        julia-version: ['^1.7']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+      - run: julia --color=yes --project=.ci .ci/ci.jl cuda

--- a/lib/MadNLPGPU/Project.toml
+++ b/lib/MadNLPGPU/Project.toml
@@ -11,9 +11,9 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
 
 [compat]
-CUDA = "~2,~3"
-CUDAKernels = "0.3.0"
-KernelAbstractions = "0.7"
+CUDA = "~3"
+CUDAKernels = "0.4"
+KernelAbstractions = "0.8"
 MadNLP = "~0.4"
 MadNLPTests = "~0.2"
 julia = "1.6"


### PR DESCRIPTION
KernelAbstractions 0.8 drops support from Julia 1.6, so we have to modify a bit the CI to test MadNLPGPU only with Julia 1.7 (the rest of the packages being tested both by Julia 1.6 and Julia 1.7).