### PR TITLE
Define linear solver as a struct instead of as a module

### DIFF
--- a/lib/MadNLPGPU/src/MadNLPGPU.jl
+++ b/lib/MadNLPGPU/src/MadNLPGPU.jl
@@ -11,16 +11,18 @@ import MadNLP
 
 import MadNLP:
     @kwdef, Logger, @debug, @warn, @error,
-    AbstractOptions, AbstractLinearSolver, AbstractNLPModel, set_options!, MadNLPLapackCPU,
+    AbstractOptions, AbstractLinearSolver, AbstractNLPModel, set_options!,
     SymbolicException,FactorizationException,SolveException,InertiaException,
-    introduce, factorize!, solve!, improve!, is_inertia, inertia, tril_to_full!
+    introduce, factorize!, solve!, improve!, is_inertia, inertia, tril_to_full!,
+    LapackOptions, input_type
+
 
 
 include("kernels.jl")
 
 if has_cuda()
     include("lapackgpu.jl")
-    export MadNLPLapackGPU
+    export LapackGPUSolver
 end
 
 end # module

--- a/lib/MadNLPGPU/test/densekkt_gpu.jl
+++ b/lib/MadNLPGPU/test/densekkt_gpu.jl
@@ -5,7 +5,7 @@ using MadNLPTests
 function _compare_gpu_with_cpu(kkt_system, n, m, ind_fixed)
     madnlp_options = Dict{Symbol, Any}(
         :kkt_system=>MadNLP.DENSE_CONDENSED_KKT_SYSTEM,
-        :linear_solver=>MadNLPLapackGPU,
+        :linear_solver=>LapackGPUSolver,
         :print_level=>MadNLP.ERROR,
     )
 

--- a/lib/MadNLPGPU/test/runtests.jl
+++ b/lib/MadNLPGPU/test/runtests.jl
@@ -4,38 +4,34 @@ testset = [
     [
         "LapackGPU-BUNCHKAUFMAN",
         ()->MadNLP.Optimizer(
-            linear_solver=MadNLPLapackGPU,
-            lapackgpu_algorithm=MadNLPLapackGPU.BUNCHKAUFMAN,
+            linear_solver=LapackGPUSolver,
+            lapackgpu_algorithm=MadNLP.BUNCHKAUFMAN,
             print_level=MadNLP.ERROR),
         [],
-        @isdefined(MadNLPLapackGPU)
     ],
     [
         "LapackGPU-LU",
         ()->MadNLP.Optimizer(
-            linear_solver=MadNLPLapackGPU,
-            lapackgpu_algorithm=MadNLPLapackGPU.LU,
+            linear_solver=LapackGPUSolver,
+            lapackgpu_algorithm=MadNLP.LU,
             print_level=MadNLP.ERROR),
         [],
-        @isdefined(MadNLPLapackGPU)
     ],
     [
         "LapackGPU-QR",
         ()->MadNLP.Optimizer(
-            linear_solver=MadNLPLapackGPU,
-            lapackgpu_algorithm=MadNLPLapackGPU.QR,
+            linear_solver=LapackGPUSolver,
+            lapackgpu_algorithm=MadNLP.QR,
             print_level=MadNLP.ERROR),
         [],
-        @isdefined(MadNLPLapackGPU)
     ],
     [
         "LapackGPU-CHOLESKY",
         ()->MadNLP.Optimizer(
-            linear_solver=MadNLPLapackGPU,
-            lapackgpu_algorithm=MadNLPLapackGPU.CHOLESKY,
+            linear_solver=LapackGPUSolver,
+            lapackgpu_algorithm=MadNLP.CHOLESKY,
             print_level=MadNLP.ERROR),
         ["infeasible", "lootsma", "eigmina"],
-        @isdefined(MadNLPLapackGPU)
     ],
 ]
 

--- a/lib/MadNLPHSL/src/MadNLPHSL.jl
+++ b/lib/MadNLPHSL/src/MadNLPHSL.jl
@@ -1,22 +1,23 @@
 module MadNLPHSL
 
 import Libdl: dlopen, RTLD_DEEPBIND
-import MadNLP: @kwdef, Logger, @debug, @warn, @error, 
+import MadNLP: @kwdef, Logger, @debug, @warn, @error,
     AbstractOptions, AbstractLinearSolver, set_options!, SparseMatrixCSC, SubVector, StrideOneVector,
     SymbolicException,FactorizationException,SolveException,InertiaException,
     introduce, factorize!, solve!, improve!, is_inertia, inertia, findIJ, nnz,
-    get_tril_to_full, transfer!
+    get_tril_to_full, transfer!, input_type
 
 include(joinpath("..","deps","deps.jl"))
 
 if @isdefined(libhsl)
+    include("common.jl")
     include("mc68.jl")
     include("ma27.jl")
     include("ma57.jl")
     include("ma77.jl")
     include("ma86.jl")
     include("ma97.jl")
-    export MadNLPMa27, MadNLPMa57, MadNLPMa77, MadNLPMa86, MadNLPMa97
+    export Ma27Solver, Ma57Solver, Ma77Solver, Ma86Solver, Ma97Solver
 end
 
 function __init__()

--- a/lib/MadNLPHSL/src/common.jl
+++ b/lib/MadNLPHSL/src/common.jl
@@ -1,0 +1,14 @@
+
+@enum(
+    Ordering::Int,
+    AMD = 1,
+    METIS = 3,
+)
+
+@enum(
+    Scaling::Int,
+    SCALING_NONE = 0,
+    MC64 = 1,
+    MC77 = 2,
+    MC30 = 4,
+)

--- a/lib/MadNLPHSL/src/ma27.jl
+++ b/lib/MadNLPHSL/src/ma27.jl
@@ -1,20 +1,11 @@
 # MadNLP.jl
 # Created by Sungho Shin (sungho.shin@wisc.edu)
 
-module MadNLPMa27
-
-import ..MadNLPHSL:
-    @kwdef, Logger, @debug, @warn, @error, libhsl,
-    AbstractOptions, AbstractLinearSolver, set_options!, SparseMatrixCSC, SubVector, StrideOneVector,
-    SymbolicException,FactorizationException,SolveException,InertiaException,
-    introduce, factorize!, solve!, improve!, is_inertia, inertia, findIJ, nnz
-
 const ma27_default_icntl = Int32[
     6,6,0,2139062143,1,32639,32639,32639,32639,14,9,8,8,9,10,32639,32639,32639,32689,24,11,9,8,9,10,0,0,0,0,0]
 const ma27_default_cntl  = [.1,1.0,0.,0.,0.]
-const INPUT_MATRIX_TYPE = :csc
 
-@kwdef mutable struct Options <: AbstractOptions
+@kwdef mutable struct Ma27Options <: AbstractOptions
     ma27_pivtol::Float64 = 1e-8
     ma27_pivtolmax::Float64 = 1e-4
     ma27_liw_init_factor::Float64 = 5.
@@ -22,7 +13,7 @@ const INPUT_MATRIX_TYPE = :csc
     ma27_meminc_factor::Float64 =2.
 end
 
-mutable struct Solver <: AbstractLinearSolver
+mutable struct Ma27Solver <: AbstractLinearSolver
     csc::SparseMatrixCSC{Float64,Int32}
     I::Vector{Int32}
     J::Vector{Int32}
@@ -44,7 +35,7 @@ mutable struct Solver <: AbstractLinearSolver
     w::Vector{Float64}
     maxfrt::Vector{Int32}
 
-    opt::Options
+    opt::Ma27Options
     logger::Logger
 end
 
@@ -83,9 +74,9 @@ ma27cd!(n::Cint,a::Vector{Cdouble},la::Cint,iw::Vector{Cint},
              Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint}),
             n,a,la,iw,liw,w,maxfrt,rhs,iw1,nsteps,icntl,info)
 
-function Solver(csc::SparseMatrixCSC;
+function Ma27Solver(csc::SparseMatrixCSC;
                 option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
-                opt=Options(),logger=Logger(),kwargs...)
+                opt=Ma27Options(),logger=Logger(),kwargs...)
 
     set_options!(opt,option_dict,kwargs)
 
@@ -115,12 +106,12 @@ function Solver(csc::SparseMatrixCSC;
     resize!(iw,liw)
     maxfrt=Int32[1]
 
-    return Solver(csc,I,J,icntl,cntl,info,a,a_view,la,ikeep,iw,liw,
+    return Ma27Solver(csc,I,J,icntl,cntl,info,a,a_view,la,ikeep,iw,liw,
                   iw1,nsteps,Vector{Float64}(),maxfrt,opt,logger)
 end
 
 
-function factorize!(M::Solver)
+function factorize!(M::Ma27Solver)
     M.a_view.=M.csc.nzval
     while true
         ma27bd!(Int32(M.csc.n),Int32(nnz(M.csc)),M.I,M.J,M.a,M.la,
@@ -143,7 +134,7 @@ function factorize!(M::Solver)
     return M
 end
 
-function solve!(M::Solver,rhs::StrideOneVector{Float64})
+function solve!(M::Ma27Solver,rhs::StrideOneVector{Float64})
     length(M.w)<M.maxfrt[1] && resize!(M.w,M.maxfrt[1])
     length(M.iw1)<M.nsteps[1] && resize!(M.iw1,M.nsteps[1])
     ma27cd!(Int32(M.csc.n),M.a,M.la,M.iw,M.liw,M.w,M.maxfrt,rhs,
@@ -152,13 +143,13 @@ function solve!(M::Solver,rhs::StrideOneVector{Float64})
     return rhs
 end
 
-is_inertia(::Solver) = true
-function inertia(M::Solver)
+is_inertia(::Ma27Solver) = true
+function inertia(M::Ma27Solver)
     rank = M.info[1]==3 ? M.info[2] : rank = M.csc.n
     return (rank-M.info[15],M.csc.n-rank,M.info[15])
 end
 
-function improve!(M::Solver)
+function improve!(M::Ma27Solver)
     if M.cntl[1] == M.opt.ma27_pivtolmax
         @debug(M.logger,"improve quality failed.")
         return false
@@ -168,6 +159,6 @@ function improve!(M::Solver)
     return true
 end
 
-introduce(::Solver)="ma27"
+introduce(::Ma27Solver)="ma27"
+input_type(::Type{Ma27Solver}) = :csc
 
-end # module

--- a/lib/MadNLPHSL/src/ma57.jl
+++ b/lib/MadNLPHSL/src/ma57.jl
@@ -1,19 +1,10 @@
 # MadNLP.jl
 # Created by Sungho Shin (sungho.shin@wisc.edu)
 
-module MadNLPMa57
-
-import ..MadNLPHSL:
-    @kwdef, Logger, @debug, @warn, @error, libhsl,
-    AbstractOptions, set_options!, AbstractLinearSolver, StrideOneVector,
-    SymbolicException,FactorizationException,SolveException,InertiaException,
-    SparseMatrixCSC, introduce, factorize!, solve!, improve!, is_inertia, inertia, findIJ, nnz
-
 const ma57_default_icntl = Int32[0,0,6,1,0,5,1,0,10,0,16,16,10,100,0,0,0,0,0,0]
 const ma57_default_cntl  = Float64[1e-8,1.0e-20,0.5,0.0,0.0]
-const INPUT_MATRIX_TYPE = :csc
 
-@kwdef mutable struct Options <: AbstractOptions
+@kwdef mutable struct Ma57Options <: AbstractOptions
     ma57_pivtol::Float64 = 1e-8
     ma57_pivtolmax::Float64 = 1e-4
     ma57_pre_alloc::Float64 = 1.05
@@ -25,7 +16,7 @@ const INPUT_MATRIX_TYPE = :csc
     ma57_small_pivot_flag::Int = 0
 end
 
-mutable struct Solver <: AbstractLinearSolver
+mutable struct Ma57Solver <: AbstractLinearSolver
     csc::SparseMatrixCSC{Float64,Int32}
     I::Vector{Int32}
     J::Vector{Int32}
@@ -49,7 +40,7 @@ mutable struct Solver <: AbstractLinearSolver
     lwork::Int32
     work::Vector{Float64}
 
-    opt::Options
+    opt::Ma57Options
     logger::Logger
 end
 
@@ -88,9 +79,9 @@ ma57cd!(job::Cint,n::Cint,fact::Vector{Cdouble},lfact::Cint,
              Ptr{Cint},Ptr{Cint}),
             job,n,fact,lfact,ifact,lifact,nrhs,rhs,lrhs,work,lwork,iwork,icntl,info)
 
-function Solver(csc::SparseMatrixCSC;
+function Ma57Solver(csc::SparseMatrixCSC;
                 option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
-                opt=Options(),logger=Logger(),kwargs...)
+                opt=Ma57Options(),logger=Logger(),kwargs...)
 
     set_options!(opt,option_dict,kwargs)
 
@@ -129,10 +120,10 @@ function Solver(csc::SparseMatrixCSC;
     lwork= csc.n
     work = Vector{Float64}(undef,lwork)
 
-    return Solver(csc,I,J,icntl,cntl,info,rinfo,lkeep,keep,lfact,fact,lifact,ifact,iwork,lwork,work,opt,logger)
+    return Ma57Solver(csc,I,J,icntl,cntl,info,rinfo,lkeep,keep,lfact,fact,lifact,ifact,iwork,lwork,work,opt,logger)
 end
 
-function factorize!(M::Solver)
+function factorize!(M::Ma57Solver)
     while true
         ma57bd!(Int32(M.csc.n),Int32(nnz(M.csc)),M.csc.nzval,M.fact,
                 M.lfact,M.ifact,M.lifact,M.lkeep,
@@ -155,18 +146,18 @@ function factorize!(M::Solver)
     return M
 end
 
-function solve!(M::Solver,rhs::StrideOneVector{Float64})
+function solve!(M::Ma57Solver,rhs::StrideOneVector{Float64})
     ma57cd!(one(Int32),Int32(M.csc.n),M.fact,M.lfact,M.ifact,
             M.lifact,one(Int32),rhs,Int32(M.csc.n),M.work,M.lwork,M.iwork,M.icntl,M.info)
     M.info[1]<0 && throw(SolveException())
     return rhs
 end
 
-is_inertia(::Solver) = true
-function inertia(M::Solver)
+is_inertia(::Ma57Solver) = true
+function inertia(M::Ma57Solver)
     return (M.info[25]-M.info[24],Int32(M.csc.n)-M.info[25],M.info[24])
 end
-function improve!(M::Solver)
+function improve!(M::Ma57Solver)
     if M.cntl[1] == M.opt.ma57_pivtolmax
         @debug(M.logger,"improve quality failed.")
         return false
@@ -176,6 +167,5 @@ function improve!(M::Solver)
     return true
 end
 
-introduce(::Solver)="ma57"
-
-end # module
+introduce(::Ma57Solver)="ma57"
+input_type(::Type{Ma57Solver}) = :csc

--- a/lib/MadNLPHSL/src/ma77.jl
+++ b/lib/MadNLPHSL/src/ma77.jl
@@ -1,22 +1,9 @@
 # MadNLP.jl
 # Created by Sungho Shin (sungho.shin@wisc.edu)
 
-module MadNLPMa77
 
-import ..MadNLPHSL:
-    @kwdef, Logger, @debug, @warn, @error, libhsl,
-    SparseMatrixCSC, SparseMatrixCSC, SubVector, StrideOneVector,
-    get_tril_to_full, transfer!,
-    AbstractOptions, AbstractLinearSolver, set_options!,
-    SymbolicException,FactorizationException,SolveException,InertiaException,
-    introduce, factorize!, solve!, improve!, is_inertia, inertia
-import ..MadNLPHSL: Mc68
 
-const INPUT_MATRIX_TYPE = :csc
-
-@enum(Ordering::Int,AMD = 1, METIS = 3)
-
-@kwdef mutable struct Options <: AbstractOptions
+@kwdef mutable struct Ma77Options <: AbstractOptions
     ma77_buffer_lpage::Int = 4096
     ma77_buffer_npage::Int = 1600
     ma77_file_size::Int = 2097152
@@ -30,7 +17,7 @@ const INPUT_MATRIX_TYPE = :csc
     ma77_umax::Float64 = 1e-4
 end
 
-@kwdef mutable struct Control
+@kwdef mutable struct Ma77Control
     f_arrays::Cint = 0
     print_level::Cint = 0
     unit_diagnostics::Cint = 0
@@ -85,7 +72,7 @@ end
     rspare_5::Cdouble = 0.
 end
 
-@kwdef mutable struct Info
+@kwdef mutable struct Ma77Info
     detlog::Cdouble = 0.
     detsign::Cint = 0
     flag::Cint = 0
@@ -158,86 +145,86 @@ end
     rspare_5::Cdouble = 0.
 end
 
-mutable struct Solver <: AbstractLinearSolver
+mutable struct Ma77Solver <: AbstractLinearSolver
     tril::SparseMatrixCSC{Float64,Int32}
     full::SparseMatrixCSC{Float64,Int32}
     tril_to_full_view::SubVector{Float64}
 
-    control::Control
-    info::Info
+    control::Ma77Control
+    info::Ma77Info
 
-    mc68_control::Mc68.Control
-    mc68_info::Mc68.Info
+    mc68_control::Mc68Control
+    mc68_info::Mc68Info
 
     order::Vector{Int32}
     keep::Vector{Ptr{Nothing}}
 
-    opt::Options
+    opt::Ma77Options
     logger::Logger
 end
 
-ma77_default_control_d(control::Control) = ccall(
+ma77_default_control_d(control::Ma77Control) = ccall(
     (:ma77_default_control_d,libhsl),
     Cvoid,
-    (Ref{Control},),
+    (Ref{Ma77Control},),
     control)
 ma77_open_d(n::Cint,fname1::String,fname2::String,fname3::String,fname4::String,
-            keep::Vector{Ptr{Cvoid}},control::Control,info::Info) = ccall(
+            keep::Vector{Ptr{Cvoid}},control::Ma77Control,info::Ma77Info) = ccall(
                 (:ma77_open_d,libhsl),
                 Cvoid,
                 (Cint,Ptr{Cchar},Ptr{Cchar},Ptr{Cchar},Ptr{Cchar},
-                 Ptr{Ptr{Cvoid}},Ref{Control},Ref{Info}),
+                 Ptr{Ptr{Cvoid}},Ref{Ma77Control},Ref{Ma77Info}),
                 n,fname1,fname2,fname3,fname4,keep,control,info)
 ma77_input_vars_d(idx::Cint,nvar::Cint,list::StrideOneVector{Cint},
-                  keep::Vector{Ptr{Cvoid}},control::Control,info::Info) = ccall(
+                  keep::Vector{Ptr{Cvoid}},control::Ma77Control,info::Ma77Info) = ccall(
                       (:ma77_input_vars_d,libhsl),
                       Cvoid,
                       (Cint,Cint,Ptr{Cint},
-                       Ptr{Ptr{Cvoid}},Ref{Control},Ref{Info}),
+                       Ptr{Ptr{Cvoid}},Ref{Ma77Control},Ref{Ma77Info}),
                       idx,nvar,list,keep,control,info)
 ma77_input_reals_d(idx::Cint,length::Cint,reals::StrideOneVector{Cdouble},
-                   keep::Vector{Ptr{Cvoid}},control::Control,info::Info) = ccall(
+                   keep::Vector{Ptr{Cvoid}},control::Ma77Control,info::Ma77Info) = ccall(
                        (:ma77_input_reals_d,libhsl),
                        Cvoid,
                        (Cint,Cint,Ptr{Cdouble},
-                        Ptr{Ptr{Cvoid}},Ref{Control},Ref{Info}),
+                        Ptr{Ptr{Cvoid}},Ref{Ma77Control},Ref{Ma77Info}),
                        idx,length,reals,keep,control,info)
 ma77_analyse_d(order::Vector{Cint},
-               keep::Vector{Ptr{Cvoid}},control::Control,info::Info) = ccall(
+               keep::Vector{Ptr{Cvoid}},control::Ma77Control,info::Ma77Info) = ccall(
                    (:ma77_analyse_d,libhsl),
                    Cvoid,
-                   (Ptr{Cint},Ptr{Ptr{Cvoid}},Ref{Control},Ref{Info}),
+                   (Ptr{Cint},Ptr{Ptr{Cvoid}},Ref{Ma77Control},Ref{Ma77Info}),
                    order,keep,control,info)
-ma77_factor_d(posdef::Cint,keep::Vector{Ptr{Cvoid}},control::Control,info::Info,
+ma77_factor_d(posdef::Cint,keep::Vector{Ptr{Cvoid}},control::Ma77Control,info::Ma77Info,
               scale::Ptr{Nothing}) = ccall(
                   (:ma77_factor_d,libhsl),
                   Cvoid,
-                  (Cint,Ptr{Ptr{Cvoid}},Ref{Control},Ref{Info},Ptr{Nothing}),
+                  (Cint,Ptr{Ptr{Cvoid}},Ref{Ma77Control},Ref{Ma77Info},Ptr{Nothing}),
                   posdef,keep,control,info,scale)
-ma77_factor_solve_d(posdef::Cint,keep::Vector{Ptr{Cvoid}},control::Control,info::Info,
+ma77_factor_solve_d(posdef::Cint,keep::Vector{Ptr{Cvoid}},control::Ma77Control,info::Ma77Info,
                     scale::Vector{Cdouble},nrhs::Cint,lx::Cint,rhs::Vector{Cdouble}) = ccall(
                         (:ma77_factor_solve_d,libhsl),
                         Cvoid,
-                        (Cint,Ptr{Ptr{Cvoid}},Ref{Control},Ref{Info},
+                        (Cint,Ptr{Ptr{Cvoid}},Ref{Ma77Control},Ref{Ma77Info},
                          Ptr{Cdouble},Cint,Cint,Ptr{Cdouble}),
                         posdef,keep,control,info,scale,nrhs,lx,rhs);
 ma77_solve_d(job::Cint,nrhs::Cint,lx::Cint,x::Vector{Cdouble},
-             keep::Vector{Ptr{Cvoid}},control::Control,info::Info,
+             keep::Vector{Ptr{Cvoid}},control::Ma77Control,info::Ma77Info,
              scale::Ptr{Nothing})=ccall(
                  (:ma77_solve_d,libhsl),
                  Cvoid,
                  (Cint,Cint,Cint,Ptr{Float64},
-                  Ptr{Ptr{Cvoid}},Ref{Control},Ref{Info},Ptr{Nothing}),
+                  Ptr{Ptr{Cvoid}},Ref{Ma77Control},Ref{Ma77Info},Ptr{Nothing}),
                  job,nrhs,lx,x,keep,control,info,scale);
-ma77_finalize_d(keep::Vector{Ptr{Cvoid}},control::Control,info::Info) = ccall(
+ma77_finalize_d(keep::Vector{Ptr{Cvoid}},control::Ma77Control,info::Ma77Info) = ccall(
     (:ma77_finalise_d,libhsl),
     Cvoid,
-    (Ptr{Ptr{Cvoid}},Ref{Control},Ref{Info}),
+    (Ptr{Ptr{Cvoid}},Ref{Ma77Control},Ref{Ma77Info}),
     keep,control,info)
 
-function Solver(csc::SparseMatrixCSC{Float64,Int32};
+function Ma77Solver(csc::SparseMatrixCSC{Float64,Int32};
                 option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
-                opt=Options(),logger=Logger(),
+                opt=Ma77Options(),logger=Logger(),
                 kwargs...)
 
     set_options!(opt,option_dict,kwargs)
@@ -245,17 +232,17 @@ function Solver(csc::SparseMatrixCSC{Float64,Int32};
     full,tril_to_full_view = get_tril_to_full(csc)
     order = Vector{Int32}(undef,csc.n)
 
-    mc68_info = Mc68.Info()
-    mc68_control = Mc68.get_mc68_default_control()
+    mc68_info = Mc68Info()
+    mc68_control = get_mc68_default_control()
 
     keep = [C_NULL]
 
     mc68_control.f_array_in=1
     mc68_control.f_array_out=1
-    Mc68.mc68_order_i(Int32(opt.ma77_order),Int32(csc.n),csc.colptr,csc.rowval,order,mc68_control,mc68_info)
+    mc68_order_i(Int32(opt.ma77_order),Int32(csc.n),csc.colptr,csc.rowval,order,mc68_control,mc68_info)
 
-    info=Info()
-    control=Control()
+    info=Ma77Info()
+    control=Ma77Control()
     ma77_default_control_d(control)
     control.f_arrays = 1
     control.bits = 32
@@ -293,13 +280,13 @@ function Solver(csc::SparseMatrixCSC{Float64,Int32};
     ma77_analyse_d(order,keep,control,info)
     info.flag<0 && throw(SymbolicException())
 
-    M = Solver(csc,full,tril_to_full_view,
+    M = Ma77Solver(csc,full,tril_to_full_view,
                control,info,mc68_control,mc68_info,order,keep,opt,logger)
     finalizer(finalize,M)
     return M
 end
 
-function factorize!(M::Solver)
+function factorize!(M::Ma77Solver)
     M.full.nzval.=M.tril_to_full_view
     for i=1:M.full.n
         ma77_input_reals_d(Int32(i),M.full.colptr[i+1]-M.full.colptr[i],
@@ -311,20 +298,20 @@ function factorize!(M::Solver)
     M.info.flag < 0 && throw(FactorizationException())
     return M
 end
-function solve!(M::Solver,rhs::StrideOneVector{Float64})
+function solve!(M::Ma77Solver,rhs::StrideOneVector{Float64})
     ma77_solve_d(Int32(0),Int32(1),Int32(M.full.n),rhs,M.keep,M.control,M.info,C_NULL);
     M.info.flag < 0 && throw(SolveException())
     return rhs
 end
 
-is_inertia(::Solver) = true
-function inertia(M::Solver)
+is_inertia(::Ma77Solver) = true
+function inertia(M::Ma77Solver)
     return (M.info.matrix_rank-M.info.num_neg,M.full.n-M.info.matrix_rank,M.info.num_neg)
 end
 
-finalize(M::Solver) = ma77_finalize_d(M.keep,M.control,M.info)
+finalize(M::Ma77Solver) = ma77_finalize_d(M.keep,M.control,M.info)
 
-function improve!(M::Solver)
+function improve!(M::Ma77Solver)
     if M.control.u == M.opt.ma77_umax
         @debug(M.logger,"improve quality failed.")
         return false
@@ -334,6 +321,5 @@ function improve!(M::Solver)
     return true
 end
 
-introduce(::Solver)="ma77"
-
-end
+introduce(::Ma77Solver)="ma77"
+input_type(::Type{Ma77Solver}) = :csc

--- a/lib/MadNLPHSL/src/ma97.jl
+++ b/lib/MadNLPHSL/src/ma97.jl
@@ -1,21 +1,8 @@
 # MadNLP.jl
 # Created by Sungho Shin (sungho.shin@wisc.edu)
 
-module MadNLPMa97
 
-import ..MadNLPHSL:
-    @kwdef, Logger, @debug, @warn, @error, libhsl,
-    AbstractOptions, AbstractLinearSolver, set_options!, SparseMatrixCSC, SubVector, StrideOneVector,
-    SymbolicException,FactorizationException,SolveException,InertiaException,
-    introduce, factorize!, solve!, improve!, is_inertia, inertia
-import ..MadNLPHSL: Mc68
-
-const INPUT_MATRIX_TYPE = :csc
-
-@enum(Ordering::Int32,AMD = 1, METIS = 3)
-@enum(Scaling::Int32,SCALING_NONE = 0, MC64 = 1, MC77 = 2, MC30 = 4)
-
-@kwdef mutable struct Options <: AbstractOptions
+@kwdef mutable struct Ma97Options <: AbstractOptions
     ma97_num_threads::Int = 1
     ma97_print_level::Int = -1
     ma97_nemin::Int = 8
@@ -26,7 +13,7 @@ const INPUT_MATRIX_TYPE = :csc
     ma97_umax::Float64 = 1e-4
 end
 
-@kwdef mutable struct Control
+@kwdef mutable struct Ma97Control
     f_arrays::Cint = 0
     action::Cint = 0
     nemin::Cint = 0
@@ -48,7 +35,7 @@ end
     rspare::Vector{Cdouble}
 end
 
-@kwdef mutable struct Info
+@kwdef mutable struct Ma97Info
     flag::Cint = 0
     flag68::Cint = 0
     flag77::Cint = 0
@@ -70,51 +57,51 @@ end
     rspare::Vector{Cdouble}
 end
 
-mutable struct Solver <:AbstractLinearSolver
+mutable struct Ma97Solver <:AbstractLinearSolver
     n::Int32
 
     csc::SparseMatrixCSC{Float64,Int32}
 
-    control::Control
-    info::Info
+    control::Ma97Control
+    info::Ma97Info
 
     akeep::Vector{Ptr{Nothing}}
     fkeep::Vector{Ptr{Nothing}}
 
-    opt::Options
+    opt::Ma97Options
     logger::Logger
 end
 
-ma97_default_control_d(control::Control) = ccall(
+ma97_default_control_d(control::Ma97Control) = ccall(
     (:ma97_default_control_d,libhsl),
     Nothing,
-    (Ref{Control},),
+    (Ref{Ma97Control},),
     control)
 
 ma97_analyse_d(check::Cint,n::Cint,ptr::StrideOneVector{Cint},row::StrideOneVector{Cint},
                val::Ptr{Nothing},akeep::Vector{Ptr{Nothing}},
-               control::Control,info::Info,
+               control::Ma97Control,info::Ma97Info,
                order::Ptr{Nothing}) = ccall(
                          (:ma97_analyse_d,libhsl),
                          Nothing,
                          (Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cdouble},
-                          Ptr{Ptr{Nothing}},Ref{Control},Ref{Info},Ptr{Cint}),
+                          Ptr{Ptr{Nothing}},Ref{Ma97Control},Ref{Ma97Info},Ptr{Cint}),
                          check,n,ptr,row,val,akeep,control,info,order)
 ma97_factor_d(matrix_type::Cint,ptr::Ptr{Nothing},row::Ptr{Nothing},
               val::StrideOneVector{Cdouble},akeep::Vector{Ptr{Nothing}},fkeep::Vector{Ptr{Nothing}},
-              control::Control,info::Info,scale::Ptr{Nothing}) = ccall(
+              control::Ma97Control,info::Ma97Info,scale::Ptr{Nothing}) = ccall(
                   (:ma97_factor_d,libhsl),
                   Nothing,
                   (Cint,Ptr{Cint},Ptr{Cint},Ptr{Cdouble},Ptr{Ptr{Nothing}},
-                   Ptr{Ptr{Nothing}},Ref{Control},Ref{Info},Ptr{Cdouble}),
+                   Ptr{Ptr{Nothing}},Ref{Ma97Control},Ref{Ma97Info},Ptr{Cdouble}),
                   matrix_type,ptr,row,val,akeep,fkeep,control,info,scale)
 ma97_solve_d(job::Cint,nrhs::Cint,x::StrideOneVector{Cdouble},ldx::Cint,
              akeep::Vector{Ptr{Nothing}},fkeep::Vector{Ptr{Nothing}},
-             control::Control,info::Info) = ccall(
+             control::Ma97Control,info::Ma97Info) = ccall(
                  (:ma97_solve_d,libhsl),
                  Nothing,
                  (Cint,Cint,Ptr{Cdouble},Cint,Ptr{Ptr{Nothing}},
-                  Ptr{Ptr{Nothing}},Ref{Control},Ref{Info}),
+                  Ptr{Ptr{Nothing}},Ref{Ma97Control},Ref{Ma97Info}),
                  job,nrhs,x,ldx,akeep,fkeep,control,info)
 ma97_finalize_d(akeep::Vector{Ptr{Nothing}},fkeep::Vector{Ptr{Nothing}})=ccall(
     (:ma97_finalise_d,libhsl),
@@ -127,9 +114,9 @@ ma97_set_num_threads(n) = ccall((:omp_set_num_threads_,libhsl),
                                 Cint(n))
 
 
-function Solver(csc::SparseMatrixCSC{Float64,Int32};
+function Ma97Solver(csc::SparseMatrixCSC{Float64,Int32};
                 option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
-                opt=Options(),logger=Logger(),
+                opt=Ma97Options(),logger=Logger(),
                 kwargs...)
 
     set_options!(opt,option_dict,kwargs)
@@ -138,8 +125,8 @@ function Solver(csc::SparseMatrixCSC{Float64,Int32};
 
     n = Int32(csc.n)
 
-    info = Info(ispare=zeros(Int32,5),rspare=zeros(Float64,10))
-    control=Control(ispare=zeros(Int32,5),rspare=zeros(Float64,10))
+    info = Ma97Info(ispare=zeros(Int32,5),rspare=zeros(Float64,10))
+    control=Ma97Control(ispare=zeros(Int32,5),rspare=zeros(Float64,10))
     ma97_default_control_d(control)
 
     control.print_level = opt.ma97_print_level
@@ -155,27 +142,27 @@ function Solver(csc::SparseMatrixCSC{Float64,Int32};
 
     ma97_analyse_d(Int32(1),n,csc.colptr,csc.rowval,C_NULL,akeep,control,info,C_NULL)
     info.flag<0 && throw(SymbolicException())
-    M = Solver(n,csc,control,info,akeep,fkeep,opt,logger)
+    M = Ma97Solver(n,csc,control,info,akeep,fkeep,opt,logger)
     finalizer(finalize,M)
     return M
 end
-function factorize!(M::Solver)
+function factorize!(M::Ma97Solver)
     ma97_factor_d(Int32(4),C_NULL,C_NULL,M.csc.nzval,M.akeep,M.fkeep,M.control,M.info,C_NULL)
     M.info.flag<0 && throw(FactorizationException())
     return M
 end
-function solve!(M::Solver,rhs::StrideOneVector{Float64})
+function solve!(M::Ma97Solver,rhs::StrideOneVector{Float64})
     ma97_solve_d(Int32(0),Int32(1),rhs,M.n,M.akeep,M.fkeep,M.control,M.info)
     M.info.flag<0 && throw(SolveException())
     return rhs
 end
-is_inertia(::Solver)=true
-function inertia(M::Solver)
+is_inertia(::Ma97Solver)=true
+function inertia(M::Ma97Solver)
     return (M.info.matrix_rank-M.info.num_neg,M.n-M.info.matrix_rank,M.info.num_neg)
 end
-finalize(M::Solver) = ma97_finalize_d(M.akeep,M.fkeep)
+finalize(M::Ma97Solver) = ma97_finalize_d(M.akeep,M.fkeep)
 
-function improve!(M::Solver)
+function improve!(M::Ma97Solver)
     if M.control.u == M.opt.ma97_umax
         @debug(M.logger,"improve quality failed.")
         return false
@@ -184,6 +171,6 @@ function improve!(M::Solver)
     @debug(M.logger,"improved quality: pivtol = $(M.control.u)")
     return true
 end
-introduce(::Solver)="ma97"
+introduce(::Ma97Solver)="ma97"
+input_type(::Type{Ma97Solver}) = :csc
 
-end

--- a/lib/MadNLPHSL/src/mc68.jl
+++ b/lib/MadNLPHSL/src/mc68.jl
@@ -1,11 +1,7 @@
 # MadNLP.jl
 # Created by Sungho Shin (sungho.shin@wisc.edu)
 
-module Mc68
-
-import ..MadNLPHSL: @kwdef, libhsl
-
-@kwdef mutable struct Control
+@kwdef mutable struct Mc68Control
     f_array_in::Cint = 0
     f_array_out::Cint = 0
     min_l_workspace::Clong = 0
@@ -18,7 +14,7 @@ import ..MadNLPHSL: @kwdef, libhsl
     row_search::Cint = 0
 end
 
-@kwdef mutable struct Info
+@kwdef mutable struct Mc68Info
     flag::Cint = 0
     iostat::Cint = 0
     stat::Cint = 0
@@ -32,21 +28,20 @@ end
 end
 
 function get_mc68_default_control()
-    control = Control(0,0,0,0,0,0,0,0,0,0)
+    control = Mc68Control(0,0,0,0,0,0,0,0,0,0)
     mc68_default_control_i(control)
     return control
 end
 
-mc68_default_control_i(control::Control) = ccall((:mc68_default_control_i,libhsl),
+mc68_default_control_i(control::Mc68Control) = ccall((:mc68_default_control_i,libhsl),
                                                  Nothing,
-                                                 (Ref{Control},),
+                                                 (Ref{Mc68Control},),
                                                  control)
 
 mc68_order_i(ord::Int32,n::Int32,ptr::Array{Int32,1},row::Array{Int32,1},
-             perm::Array{Int32,1},control::Control,info::Info) = ccall(
+             perm::Array{Int32,1},control::Mc68Control,info::Mc68Info) = ccall(
                  (:mc68_order_i,libhsl),
                  Nothing,
-                 (Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ref{Control},Ref{Info}),
+                 (Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ref{Mc68Control},Ref{Mc68Info}),
                  ord,n,ptr,row,perm,control,info)
 
-end #module

--- a/lib/MadNLPHSL/test/runtests.jl
+++ b/lib/MadNLPHSL/test/runtests.jl
@@ -4,41 +4,44 @@ testset = [
     [
         "HSL-Ma27",
         ()->MadNLP.Optimizer(
-            linear_solver=MadNLPMa27,
+            linear_solver=Ma27Solver,
             print_level=MadNLP.ERROR),
         []
     ],
     [
         "HSL-Ma57",
         ()->MadNLP.Optimizer(
-            linear_solver=MadNLPMa57,
+            linear_solver=Ma57Solver,
             print_level=MadNLP.ERROR),
         []
     ],
     [
         "HSL-Ma77",
         ()->MadNLP.Optimizer(
-            linear_solver=MadNLPMa77,
+            linear_solver=Ma77Solver,
             print_level=MadNLP.ERROR),
         ["unbounded"]
     ],
     [
         "HSL-Ma86",
         ()->MadNLP.Optimizer(
-            linear_solver=MadNLPMa86,
+            linear_solver=Ma86Solver,
             print_level=MadNLP.ERROR),
         []
     ],
     [
         "HSL-Ma97",
         ()->MadNLP.Optimizer(
-            linear_solver=MadNLPMa97,
+            linear_solver=Ma97Solver,
             print_level=MadNLP.ERROR),
         []
     ],
 ]
 
 @testset "MadNLPHSL test" begin
+    for hsl_solver in [Ma27Solver, Ma57Solver, Ma77Solver, Ma86Solver, Ma97Solver]
+        MadNLPTests.test_linear_solver(hsl_solver)
+    end
     for (name,optimizer_constructor,exclude) in testset
         test_madnlp(name,optimizer_constructor,exclude)
     end

--- a/lib/MadNLPKrylov/src/MadNLPKrylov.jl
+++ b/lib/MadNLPKrylov/src/MadNLPKrylov.jl
@@ -9,7 +9,8 @@ import IterativeSolvers:
     orthogonalize_and_normalize!, update_residual!, gmres_iterable!, GMRESIterable, converged,
     ModifiedGramSchmidt
 
-@kwdef mutable struct Options <: AbstractOptions
+
+@kwdef mutable struct KrylovOptions <: AbstractOptions
     krylov_restart::Int = 5
     krylov_max_iter::Int = 10
     krylov_tol::Float64 = 1e-10
@@ -29,15 +30,15 @@ struct VirtualPreconditioner
 end
 ldiv!(Pl::VirtualPreconditioner,x::StrideOneVector{Float64}) = Pl.ldiv!(x)
 
-mutable struct Solver <: AbstractIterator
+mutable struct KrylovSolver <: AbstractIterator
     g::Union{Nothing,GMRESIterable}
     res::Vector{Float64}
-    opt::Options
+    opt::KrylovOptions
     logger::Logger
 end
 
-function Solver(res::Vector{Float64},_mul!,_ldiv!;
-                opt=Options(),logger=Logger(),
+function KrylovSolver(res::Vector{Float64},_mul!,_ldiv!;
+                opt=KrylovOptions(),logger=Logger(),
                 option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),kwargs...)
     !isempty(kwargs) && (for (key,val) in kwargs; option_dict[key]=val; end)
     set_options!(opt,option_dict)
@@ -50,11 +51,11 @@ function Solver(res::Vector{Float64},_mul!,_ldiv!;
                       opt.krylov_max_iter,opt.krylov_tol,0.,
                       ModifiedGramSchmidt())
 
-    return Solver(g,res,opt,logger)
+    return KrylovSolver(g,res,opt,logger)
 end
 
 function solve_refine!(x::StridedVector{Float64},
-                       is::Solver,
+                       is::KrylovSolver,
                        b::AbstractVector{Float64})
     @debug(is.logger,"Iterator initiated")
     is.res.=0

--- a/lib/MadNLPKrylov/src/MadNLPKrylov.jl
+++ b/lib/MadNLPKrylov/src/MadNLPKrylov.jl
@@ -30,14 +30,14 @@ struct VirtualPreconditioner
 end
 ldiv!(Pl::VirtualPreconditioner,x::StrideOneVector{Float64}) = Pl.ldiv!(x)
 
-mutable struct KrylovSolver <: AbstractIterator
+mutable struct KrylovIterator <: AbstractIterator
     g::Union{Nothing,GMRESIterable}
     res::Vector{Float64}
     opt::KrylovOptions
     logger::Logger
 end
 
-function KrylovSolver(res::Vector{Float64},_mul!,_ldiv!;
+function KrylovIterator(res::Vector{Float64},_mul!,_ldiv!;
                 opt=KrylovOptions(),logger=Logger(),
                 option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),kwargs...)
     !isempty(kwargs) && (for (key,val) in kwargs; option_dict[key]=val; end)
@@ -51,11 +51,11 @@ function KrylovSolver(res::Vector{Float64},_mul!,_ldiv!;
                       opt.krylov_max_iter,opt.krylov_tol,0.,
                       ModifiedGramSchmidt())
 
-    return KrylovSolver(g,res,opt,logger)
+    return KrylovIterator(g,res,opt,logger)
 end
 
 function solve_refine!(x::StridedVector{Float64},
-                       is::KrylovSolver,
+                       is::KrylovIterator,
                        b::AbstractVector{Float64})
     @debug(is.logger,"Iterator initiated")
     is.res.=0

--- a/lib/MadNLPKrylov/test/runtests.jl
+++ b/lib/MadNLPKrylov/test/runtests.jl
@@ -4,7 +4,7 @@ testset = [
     [
         "Iterative",
         ()->MadNLP.Optimizer(
-            iterative_solver=MadNLPKrylov,
+            iterative_solver=MadNLPKrylov.KrylovSolver,
             print_level=MadNLP.ERROR),
         []
     ],

--- a/lib/MadNLPKrylov/test/runtests.jl
+++ b/lib/MadNLPKrylov/test/runtests.jl
@@ -4,7 +4,7 @@ testset = [
     [
         "Iterative",
         ()->MadNLP.Optimizer(
-            iterative_solver=MadNLPKrylov.KrylovSolver,
+            iterative_solver=MadNLPKrylov.KrylovIterator,
             print_level=MadNLP.ERROR),
         []
     ],

--- a/lib/MadNLPMumps/test/runtests.jl
+++ b/lib/MadNLPMumps/test/runtests.jl
@@ -4,13 +4,14 @@ testset = [
     [
         "Mumps",
         ()->MadNLP.Optimizer(
-            linear_solver=MadNLPMumps,
+            linear_solver=MadNLPMumps.MumpsSolver,
             print_level=MadNLP.ERROR),
         []
     ],
 ]
 
 @testset "MadNLPMumps test" begin
+    MadNLPTests.test_linear_solver(MadNLPMumps.MumpsSolver)
     for (name,optimizer_constructor,exclude) in testset
         test_madnlp(name,optimizer_constructor,exclude)
     end

--- a/lib/MadNLPPardiso/src/MadNLPPardiso.jl
+++ b/lib/MadNLPPardiso/src/MadNLPPardiso.jl
@@ -2,15 +2,15 @@ module MadNLPPardiso
 
 include(joinpath("..","deps","deps.jl"))
 
-const INPUT_MATRIX_TYPE = :csc
 
 import Libdl: dlopen, RTLD_DEEPBIND
 import MadNLP:
     MadNLP, @kwdef, Logger, @debug, @warn, @error,
-    SubVector, StrideOneVector, SparseMatrixCSC, 
+    SubVector, StrideOneVector, SparseMatrixCSC,
     SymbolicException,FactorizationException,SolveException,InertiaException,
     AbstractOptions, AbstractLinearSolver, set_options!,
-    introduce, factorize!, solve!, improve!, is_inertia, inertia
+    introduce, factorize!, solve!, improve!, is_inertia, inertia, input_type,
+    blas_num_threads
 import MKL_jll: libmkl_rt
 
 @isdefined(libpardiso) && include("pardiso.jl")
@@ -21,6 +21,6 @@ function __init__()
     @isdefined(libpardiso) && dlopen(libpardiso,RTLD_DEEPBIND)
 end
 
-export MadNLPPardisoMKL
+export PardisoSolver, PardisoMKLSolver
 
 end # module

--- a/lib/MadNLPPardiso/src/pardiso.jl
+++ b/lib/MadNLPPardiso/src/pardiso.jl
@@ -17,7 +17,7 @@ mutable struct PardisoSolver <: AbstractLinearSolver
     err::Ref{Int32}
     csc::SparseMatrixCSC{Float64,Int32}
     w::Vector{Float64}
-    opt::Options
+    opt::PardisoOptions
     logger::Logger
 end
 
@@ -121,5 +121,5 @@ function improve!(M::PardisoSolver)
     return false
 end
 
-introduce(::Solver)="pardiso"
+introduce(::PardisoSolver)="pardiso"
 input_type(::Type{PardisoSolver}) = :csc

--- a/lib/MadNLPPardiso/src/pardisomkl.jl
+++ b/lib/MadNLPPardiso/src/pardisomkl.jl
@@ -1,18 +1,8 @@
-module MadNLPPardisoMKL
 
-import ..MadNLP:
-    @kwdef, Logger, @debug, @warn, @error,
-    SubVector, StrideOneVector, SparseMatrixCSC, 
-    SymbolicException,FactorizationException,SolveException,InertiaException,
-    AbstractOptions, AbstractLinearSolver, set_options!,
-    introduce, factorize!, solve!, improve!, is_inertia, inertia, blas_num_threads
-import ..MadNLPPardiso: libmkl_rt
-
-const INPUT_MATRIX_TYPE = :csc
 
 @enum(MatchingStrategy::Int,COMPLETE=1,COMPLETE2x2=2,CONSTRAINTS=3)
 
-@kwdef mutable struct Options <: AbstractOptions
+@kwdef mutable struct PardisoMKLOptions <: AbstractOptions
     pardisomkl_num_threads::Int = 1
     pardiso_matching_strategy::MatchingStrategy = COMPLETE2x2
     pardisomkl_max_iterative_refinement_steps::Int = 1
@@ -20,7 +10,7 @@ const INPUT_MATRIX_TYPE = :csc
     pardisomkl_order::Int = 2
 end
 
-mutable struct Solver <: AbstractLinearSolver
+mutable struct PardisoMKLSolver <: AbstractLinearSolver
     pt::Vector{Ptr{Cvoid}}
     iparm::Vector{Int32}
     perm::Vector{Int32}
@@ -28,7 +18,7 @@ mutable struct Solver <: AbstractLinearSolver
     err::Ref{Int32}
     csc::SparseMatrixCSC{Float64,Int32}
     w::Vector{Float64}
-    opt::Options
+    opt::PardisoMKLOptions
     logger::Logger
 end
 
@@ -62,8 +52,8 @@ function pardisomkl_set_num_threads!(n)
 end
 
 
-function Solver(csc::SparseMatrixCSC;
-                opt=Options(),logger=Logger(),
+function PardisoMKLSolver(csc::SparseMatrixCSC;
+                opt=PardisoMKLOptions(),logger=Logger(),
                 option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
                 kwargs...)
     !isempty(kwargs) && (for (key,val) in kwargs; option_dict[key]=val; end)
@@ -103,13 +93,13 @@ function Solver(csc::SparseMatrixCSC;
 
     err.x < 0  && throw(SymbolicException())
 
-    M = Solver(pt,iparm,perm,msglvl,err,csc,w,opt,logger)
+    M = PardisoMKLSolver(pt,iparm,perm,msglvl,err,csc,w,opt,logger)
 
     finalizer(finalize,M)
 
     return M
 end
-function factorize!(M::Solver)
+function factorize!(M::PardisoMKLSolver)
     pardisomkl_set_num_threads!(M.opt.pardisomkl_num_threads)
     pardisomkl_pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),Ref{Int32}(-2),Ref{Int32}(22),
                      Ref{Int32}(M.csc.n),M.csc.nzval,M.csc.colptr,M.csc.rowval,M.perm,
@@ -126,7 +116,7 @@ function factorize!(M::Solver)
     M.err.x < 0  && throw(FactorizationException())
     return M
 end
-function solve!(M::Solver,rhs::StrideOneVector{Float64})
+function solve!(M::PardisoMKLSolver,rhs::StrideOneVector{Float64})
     pardisomkl_set_num_threads!(M.opt.pardisomkl_num_threads)
     pardisomkl_pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),Ref{Int32}(-2),Ref{Int32}(33),
                      Ref{Int32}(M.csc.n),M.csc.nzval,M.csc.colptr,M.csc.rowval,M.perm,
@@ -136,22 +126,22 @@ function solve!(M::Solver,rhs::StrideOneVector{Float64})
     return rhs
 end
 
-function finalize(M::Solver)
+function finalize(M::PardisoMKLSolver)
     pardisomkl_pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),Ref{Int32}(-2),Ref{Int32}(-1),
                      Ref{Int32}(M.csc.n),M.csc.nzval,M.csc.colptr,M.csc.rowval,M.perm,
                      Ref{Int32}(1),M.iparm,M.msglvl,Float64[],M.w,M.err)
 end
-is_inertia(::Solver)=true
-function inertia(M::Solver)
+is_inertia(::PardisoMKLSolver)=true
+function inertia(M::PardisoMKLSolver)
     pos = M.iparm[22]
     neg = M.iparm[23]
     return (pos,M.csc.n-pos-neg,neg)
 end
 
-function improve!(M::Solver)
+function improve!(M::PardisoMKLSolver)
     @debug(M.logger,"improve quality failed.")
     return false
 end
-introduce(::Solver)="pardiso-mkl"
+introduce(::PardisoMKLSolver)="pardiso-mkl"
 
-end # module
+input_type(::Type{PardisoMKLSolver}) = :csc

--- a/lib/MadNLPPardiso/test/runtests.jl
+++ b/lib/MadNLPPardiso/test/runtests.jl
@@ -13,7 +13,7 @@ testset = [
     [
         "PardisoMKL",
         ()->MadNLP.Optimizer(
-            linear_solver=MadNLPPardisoMKL,
+            linear_solver=PardisoMKLSolver,
             print_level=MadNLP.ERROR),
         ["eigmina"]
     ]

--- a/lib/MadNLPTests/Project.toml
+++ b/lib/MadNLPTests/Project.toml
@@ -4,11 +4,12 @@ authors = ["Sungho Shin <sungho.shin.ss@gmail.com>"]
 version = "0.2.1"
 
 [deps]
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/src/IPM/IPM.jl
+++ b/src/IPM/IPM.jl
@@ -103,10 +103,10 @@ function InteriorPointSolver(nlp::AbstractNLPModel;
     check_option_sanity(opt)
 
     KKTSystem = if opt.kkt_system == SPARSE_KKT_SYSTEM
-        MT = (opt.linear_solver.INPUT_MATRIX_TYPE == :csc) ? SparseMatrixCSC{Float64, Int32} : Matrix{Float64}
+        MT = (input_type(opt.linear_solver) == :csc) ? SparseMatrixCSC{Float64, Int32} : Matrix{Float64}
         SparseKKTSystem{Float64, MT}
     elseif opt.kkt_system == SPARSE_UNREDUCED_KKT_SYSTEM
-        MT = (opt.linear_solver.INPUT_MATRIX_TYPE == :csc) ? SparseMatrixCSC{Float64, Int32} : Matrix{Float64}
+        MT = (input_type(opt.linear_solver) == :csc) ? SparseMatrixCSC{Float64, Int32} : Matrix{Float64}
         SparseUnreducedKKTSystem{Float64, MT}
     elseif opt.kkt_system == DENSE_KKT_SYSTEM
         MT = Matrix{Float64}
@@ -196,7 +196,7 @@ function InteriorPointSolver{KKTSystem}(nlp::AbstractNLPModel, opt::Options;
 
     @trace(logger,"Initializing linear solver.")
     cnt.linear_solver_time =
-        @elapsed linear_solver = opt.linear_solver.Solver(get_kkt(kkt) ; option_dict=option_linear_solver,logger=logger)
+        @elapsed linear_solver = opt.linear_solver(get_kkt(kkt) ; option_dict=option_linear_solver,logger=logger)
 
     n_kkt = size(kkt, 1)
     buffer_vec = similar(full(d), n_kkt)

--- a/src/LinearSolvers/lapack.jl
+++ b/src/LinearSolvers/lapack.jl
@@ -1,27 +1,16 @@
-module MadNLPLapackCPU
 
-import ..MadNLP:
-    @kwdef, Logger, @debug, @warn, @error,
-    AbstractOptions, AbstractLinearSolver, StrideOneVector, set_options!, tril_to_full!,
-    libblas, BlasInt, @blasfunc,
-    SymbolicException,FactorizationException,SolveException,InertiaException,
-    introduce, factorize!, solve!, improve!, is_inertia, inertia
-
-const INPUT_MATRIX_TYPE = :dense
-
-@enum(Algorithms::Int, BUNCHKAUFMAN = 1, LU = 2, QR =3, CHOLESKY=4)
-@kwdef mutable struct Options <: AbstractOptions
-    lapackcpu_algorithm::Algorithms = BUNCHKAUFMAN
+@kwdef mutable struct LapackOptions <: AbstractOptions
+    lapack_algorithm::LinearFactorization = BUNCHKAUFMAN
 end
 
-mutable struct Solver <: AbstractLinearSolver
+mutable struct LapackCPUSolver <: AbstractLinearSolver
     dense::Matrix{Float64}
     fact::Matrix{Float64}
     work::Vector{Float64}
     lwork::BlasInt
     info::Ref{BlasInt}
     etc::Dict{Symbol,Any}
-    opt::Options
+    opt::LapackOptions
     logger::Logger
 end
 
@@ -71,9 +60,9 @@ potrs(uplo,n,nrhs,a,lda,b,ldb,info)=ccall(
     (Ref{Cchar},Ref{BlasInt},Ref{BlasInt},Ptr{Cdouble},Ref{BlasInt},Ptr{Cdouble},Ref{BlasInt},Ptr{BlasInt}),
     uplo,n,nrhs,a,lda,b,ldb,info)
 
-function Solver(dense::Matrix{Float64};
+function LapackCPUSolver(dense::Matrix{Float64};
                 option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
-                opt=Options(),logger=Logger(),
+                opt=LapackOptions(),logger=Logger(),
                 kwargs...)
 
     set_options!(opt,option_dict,kwargs...)
@@ -83,37 +72,37 @@ function Solver(dense::Matrix{Float64};
     work = Vector{Float64}(undef, 1)
     info=0
 
-    return Solver(dense,fact,work,-1,info,etc,opt,logger)
+    return LapackCPUSolver(dense,fact,work,-1,info,etc,opt,logger)
 end
 
-function factorize!(M::Solver)
-    if M.opt.lapackcpu_algorithm == BUNCHKAUFMAN
+function factorize!(M::LapackCPUSolver)
+    if M.opt.lapack_algorithm == BUNCHKAUFMAN
         factorize_bunchkaufman!(M)
-    elseif M.opt.lapackcpu_algorithm == LU
+    elseif M.opt.lapack_algorithm == LU
         factorize_lu!(M)
-    elseif M.opt.lapackcpu_algorithm == QR
+    elseif M.opt.lapack_algorithm == QR
         factorize_qr!(M)
-    elseif M.opt.lapackcpu_algorithm == CHOLESKY
+    elseif M.opt.lapack_algorithm == CHOLESKY
         factorize_cholesky!(M)
     else
-        error(LOGGER,"Invalid lapackcpu_algorithm")
+        error(LOGGER,"Invalid lapack_algorithm")
     end
 end
-function solve!(M::Solver, x::StrideOneVector{Float64})
-    if M.opt.lapackcpu_algorithm == BUNCHKAUFMAN
+function solve!(M::LapackCPUSolver, x::StrideOneVector{Float64})
+    if M.opt.lapack_algorithm == BUNCHKAUFMAN
         solve_bunchkaufman!(M,x)
-    elseif M.opt.lapackcpu_algorithm == LU
+    elseif M.opt.lapack_algorithm == LU
         solve_lu!(M,x)
-    elseif M.opt.lapackcpu_algorithm == QR
+    elseif M.opt.lapack_algorithm == QR
         solve_qr!(M,x)
-    elseif M.opt.lapackcpu_algorithm == CHOLESKY
+    elseif M.opt.lapack_algorithm == CHOLESKY
         solve_cholesky!(M,x)
     else
-        error(LOGGER,"Invalid lapackcpu_algorithm")
+        error(LOGGER,"Invalid lapack_algorithm")
     end
 end
 
-function factorize_bunchkaufman!(M::Solver)
+function factorize_bunchkaufman!(M::LapackCPUSolver)
     size(M.fact,1) == 0 && return M
     haskey(M.etc,:ipiv) || (M.etc[:ipiv] = Vector{BlasInt}(undef,size(M.dense,1)))
     M.lwork = -1
@@ -124,13 +113,13 @@ function factorize_bunchkaufman!(M::Solver)
     sytrf('L',size(M.fact,1),M.fact,size(M.fact,2),M.etc[:ipiv],M.work,M.lwork,M.info)
     return M
 end
-function solve_bunchkaufman!(M::Solver,x)
+function solve_bunchkaufman!(M::LapackCPUSolver,x)
     size(M.fact,1) == 0 && return M
     sytrs('L',size(M.fact,1),1,M.fact,size(M.fact,2),M.etc[:ipiv],x,length(x),M.info)
     return x
 end
 
-function factorize_lu!(M::Solver)
+function factorize_lu!(M::LapackCPUSolver)
     size(M.fact,1) == 0 && return M
     haskey(M.etc,:ipiv) || (M.etc[:ipiv] = Vector{BlasInt}(undef,size(M.dense,1)))
     tril_to_full!(M.dense)
@@ -138,14 +127,14 @@ function factorize_lu!(M::Solver)
     getrf(size(M.fact,1),size(M.fact,2),M.fact,size(M.fact,2),M.etc[:ipiv],M.info)
     return M
 end
-function solve_lu!(M::Solver,x)
+function solve_lu!(M::LapackCPUSolver,x)
     size(M.fact,1) == 0 && return M
     getrs('N',size(M.fact,1),1,M.fact,size(M.fact,2),
           M.etc[:ipiv],x,length(x),M.info)
     return x
 end
 
-function factorize_qr!(M::Solver)
+function factorize_qr!(M::LapackCPUSolver)
     size(M.fact,1) == 0 && return M
     haskey(M.etc,:tau) || (M.etc[:tau] = Vector{Float64}(undef,size(M.dense,1)))
     tril_to_full!(M.dense)
@@ -158,7 +147,7 @@ function factorize_qr!(M::Solver)
     return M
 end
 
-function solve_qr!(M::Solver,x)
+function solve_qr!(M::LapackCPUSolver,x)
     size(M.fact,1) == 0 && return M
     M.lwork = -1
     ormqr('L','T',size(M.fact,1),1,length(M.etc[:tau]),M.fact,size(M.fact,2),M.etc[:tau],x,length(x),M.work,M.lwork,M.info)
@@ -169,28 +158,28 @@ function solve_qr!(M::Solver,x)
     return x
 end
 
-function factorize_cholesky!(M::Solver)
+function factorize_cholesky!(M::LapackCPUSolver)
     size(M.fact,1) == 0 && return M
     M.lwork = -1
     M.fact .= M.dense
     potrf('L',size(M.fact,1),M.fact,size(M.fact,2),M.info)
     return M
 end
-function solve_cholesky!(M::Solver,x)
+function solve_cholesky!(M::LapackCPUSolver,x)
     size(M.fact,1) == 0 && return M
     potrs('L',size(M.fact,1),1,M.fact,size(M.fact,2),x,length(x),M.info)
     return x
 end
 
-is_inertia(M::Solver) =
-    M.opt.lapackcpu_algorithm == BUNCHKAUFMAN || M.opt.lapackcpu_algorithm == CHOLESKY
-function inertia(M::Solver)
-    if M.opt.lapackcpu_algorithm == BUNCHKAUFMAN
+is_inertia(M::LapackCPUSolver) =
+    M.opt.lapack_algorithm == BUNCHKAUFMAN || M.opt.lapack_algorithm == CHOLESKY
+function inertia(M::LapackCPUSolver)
+    if M.opt.lapack_algorithm == BUNCHKAUFMAN
         inertia(M.fact,M.etc[:ipiv],M.info[])
-    elseif M.opt.lapackcpu_algorithm == CHOLESKY
+    elseif M.opt.lapack_algorithm == CHOLESKY
         M.info[] == 0 ? (size(M.fact,1),0,0) : (0,size(M.fact,1),0) # later we need to change inertia() to is_inertia_correct() and is_full_rank()
     else
-        error(LOGGER,"Invalid lapackcpu_algorithm")
+        error(LOGGER,"Invalid lapack_algorithm")
     end
 end
 
@@ -201,9 +190,11 @@ function inertia(fact,ipiv,info)
     return (numpos,numzero,numneg)
 end
 
-improve!(M::Solver) = false
+improve!(M::LapackCPUSolver) = false
 
-introduce(M::Solver) = "Lapack-CPU ($(M.opt.lapackcpu_algorithm))"
+introduce(M::LapackCPUSolver) = "Lapack-CPU ($(M.opt.lapack_algorithm))"
+
+input_type(::Type{LapackCPUSolver}) = :dense
 
 function num_neg_ev(n,D,ipiv)
     numneg = 0
@@ -228,4 +219,3 @@ function num_neg_ev(n,D,ipiv)
     return numneg
 end
 
-end # module

--- a/src/LinearSolvers/linearsolvers.jl
+++ b/src/LinearSolvers/linearsolvers.jl
@@ -94,6 +94,14 @@ struct SolveException <: Exception end
 struct InertiaException <: Exception end
 LinearSolverException=Union{SymbolicException,FactorizationException,SolveException,InertiaException}
 
+@enum(
+    LinearFactorization::Int,
+    BUNCHKAUFMAN = 1,
+    LU = 2,
+    QR =3,
+    CHOLESKY=4,
+)
+
 # iterative solvers
 include("backsolve.jl")
 

--- a/src/LinearSolvers/umfpack.jl
+++ b/src/LinearSolvers/umfpack.jl
@@ -1,21 +1,8 @@
-# MadNLP.jl
-# Created by Sungho Shin (sungho.shin@wisc.edu)
-
-module MadNLPUmfpack
-
-import ..MadNLP:
-    @kwdef, Logger, @debug, @warn, @error,
-    SubVector, StrideOneVector, SparseMatrixCSC, get_tril_to_full,
-    SymbolicException,FactorizationException,SolveException,InertiaException,
-    AbstractOptions, AbstractLinearSolver, set_options!, UMFPACK,
-    introduce, factorize!, solve!, mul!, improve!, is_inertia, inertia
-
-const INPUT_MATRIX_TYPE = :csc
 
 const umfpack_default_ctrl = copy(UMFPACK.umf_ctrl)
 const umfpack_default_info = copy(UMFPACK.umf_info)
 
-@kwdef mutable struct Options <: AbstractOptions
+@kwdef mutable struct UmfpackOptions <: AbstractOptions
     umfpack_pivtol::Float64 = 1e-4
     umfpack_pivtolmax::Float64 = 1e-1
     umfpack_sym_pivtol::Float64 = 1e-3
@@ -23,7 +10,7 @@ const umfpack_default_info = copy(UMFPACK.umf_info)
     umfpack_strategy::Float64 = 2.
 end
 
-mutable struct Solver <: AbstractLinearSolver
+mutable struct UmfpackSolver <: AbstractLinearSolver
     inner::UMFPACK.UmfpackLU
     tril::SparseMatrixCSC{Float64}
     full::SparseMatrixCSC{Float64}
@@ -35,7 +22,7 @@ mutable struct Solver <: AbstractLinearSolver
     ctrl::Vector{Float64}
     info::Vector{Float64}
 
-    opt::Options
+    opt::UmfpackOptions
     logger::Logger
 end
 
@@ -57,10 +44,10 @@ umfpack_di_solve(typ,colptr,rowval,nzval,x,b,numeric,ctrl,info) = ccall(
 
 
 
-function Solver(csc::SparseMatrixCSC;
-                option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
-                opt=Options(),logger=Logger(),
-                kwargs...)
+function UmfpackSolver(csc::SparseMatrixCSC;
+    option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
+    opt=UmfpackOptions(),logger=Logger(),
+    kwargs...)
 
     set_options!(opt,option_dict,kwargs)
 
@@ -78,13 +65,13 @@ function Solver(csc::SparseMatrixCSC;
     ctrl[12]=opt.umfpack_sym_pivtol
     ctrl[5]=opt.umfpack_block_size
     ctrl[6]=opt.umfpack_strategy
-    
+
     tmp = Vector{Ptr{Cvoid}}(undef, 1)
 
-    return Solver(inner,csc,full,tril_to_full_view,p,tmp,ctrl,info,opt,logger)
+    return UmfpackSolver(inner,csc,full,tril_to_full_view,p,tmp,ctrl,info,opt,logger)
 end
 
-function factorize!(M::Solver)
+function factorize!(M::UmfpackSolver)
     UMFPACK.umfpack_free_numeric(M.inner)
     M.full.nzval.=M.tril_to_full_view
     status = umfpack_di_numeric(M.inner.colptr,M.inner.rowval,M.inner.nzval,M.inner.symbolic,M.tmp,M.ctrl,M.info)
@@ -93,15 +80,16 @@ function factorize!(M::Solver)
     M.inner.status = status
     return M
 end
-function solve!(M::Solver,rhs::StrideOneVector{Float64})
+function solve!(M::UmfpackSolver,rhs::StrideOneVector{Float64})
     status = umfpack_di_solve(1,M.inner.colptr,M.inner.rowval,M.inner.nzval,M.p,rhs,M.inner.numeric,M.ctrl,M.info)
     rhs .= M.p
     return rhs
 end
-is_inertia(::Solver) = false
-inertia(M::Solver) = throw(InertiaException())
+is_inertia(::UmfpackSolver) = false
+inertia(M::UmfpackSolver) = throw(InertiaException())
+input_type(::Type{UmfpackSolver}) = :csc
 
-function improve!(M::Solver)
+function improve!(M::UmfpackSolver)
     if M.ctrl[4] == M.opt.umfpack_pivtolmax
         @debug(M.logger,"improve quality failed.")
         return false
@@ -112,6 +100,5 @@ function improve!(M::Solver)
 
     return false
 end
-introduce(::Solver)="umfpack"
+introduce(::UmfpackSolver)="umfpack"
 
-end # module

--- a/src/MadNLP.jl
+++ b/src/MadNLP.jl
@@ -19,7 +19,7 @@ const MOI = MathOptInterface
 const MOIU = MathOptInterface.Utilities
 const NLPModelsCounters = _Counters
 
-export MadNLPUmfpack, MadNLPLapackCPU, MadNLPPardisoMKL, madnlp
+export madnlp
 
 # Version info
 version() = parsefile(joinpath(@__DIR__,"..","Project.toml"))["version"]
@@ -27,11 +27,11 @@ introduce() = "MadNLP version v$(version())"
 
 include("enums.jl")
 include("utils.jl")
-include("options.jl")
 include("matrixtools.jl")
 include("nlpmodels.jl")
 include(joinpath("KKT", "KKTsystem.jl"))
 include(joinpath("LinearSolvers","linearsolvers.jl"))
+include("options.jl")
 include(joinpath("IPM", "IPM.jl"))
 include(joinpath("Interfaces","interfaces.jl"))
 

--- a/src/options.jl
+++ b/src/options.jl
@@ -1,5 +1,4 @@
 # Options
-abstract type AbstractOptions end
 
 parse_option(::Type{Module},str::String) = eval(Symbol(str))
 
@@ -22,7 +21,7 @@ end
     rethrow_error::Bool = true
     disable_garbage_collector::Bool = false
     blas_num_threads::Int = 1
-    linear_solver::Module
+    linear_solver::Type = LapackCPUSolver
     iterator::Type = RichardsonIterator
 
     # Output options
@@ -95,9 +94,9 @@ end
 end
 
 function check_option_sanity(options)
-    if options.linear_solver.INPUT_MATRIX_TYPE == :csc && options.kkt_system == DENSE_KKT_SYSTEM
-        error("[options] Sparse Linear solver is not supported in dense mode.\n"*
-              "Please use a dense linear solver or change `kkt_system` ")
-    end
+    # if options.linear_solver.INPUT_MATRIX_TYPE == :csc && options.kkt_system == DENSE_KKT_SYSTEM
+    #     error("[options] Sparse Linear solver is not supported in dense mode.\n"*
+    #           "Please use a dense linear solver or change `kkt_system` ")
+    # end
 end
 

--- a/src/options.jl
+++ b/src/options.jl
@@ -94,9 +94,9 @@ end
 end
 
 function check_option_sanity(options)
-    # if options.linear_solver.INPUT_MATRIX_TYPE == :csc && options.kkt_system == DENSE_KKT_SYSTEM
-    #     error("[options] Sparse Linear solver is not supported in dense mode.\n"*
-    #           "Please use a dense linear solver or change `kkt_system` ")
-    # end
+    if input_type(options.linear_solver) == :csc && options.kkt_system == DENSE_KKT_SYSTEM
+        error("[options] Sparse Linear solver is not supported in dense mode.\n"*
+              "Please use a dense linear solver or change `kkt_system` ")
+    end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,13 +1,11 @@
 # MadNLP.jl.
 # Created by Sungho Shin (sungho.shin@wisc.edu)
+abstract type AbstractOptions end
 
 # Build info
-default_linear_solver() = MadNLPUmfpack
-default_dense_solver() = MadNLPLapackCPU
+default_linear_solver() = UmfpackSolver
+default_dense_solver() = LapackCPUSolver
 
-
-# Dummy module
-module DummyModule end
 
 # Logger
 @kwdef mutable struct Logger

--- a/test/madnlp_dense.jl
+++ b/test/madnlp_dense.jl
@@ -9,12 +9,12 @@ using Random
 function _compare_dense_with_sparse(kkt_system, n, m, ind_fixed, ind_eq)
     sparse_options = Dict{Symbol, Any}(
         :kkt_system=>MadNLP.SPARSE_KKT_SYSTEM,
-        :linear_solver=>MadNLPLapackCPU,
+        :linear_solver=>MadNLP.LapackCPUSolver,
         :print_level=>MadNLP.ERROR,
     )
     dense_options = Dict{Symbol, Any}(
         :kkt_system=>kkt_system,
-        :linear_solver=>MadNLPLapackCPU,
+        :linear_solver=>MadNLP.LapackCPUSolver,
         :print_level=>MadNLP.ERROR,
     )
 
@@ -46,7 +46,7 @@ end
     @testset "Unconstrained" begin
         dense_options = Dict{Symbol, Any}(
             :kkt_system=>kkt_options,
-            :linear_solver=>MadNLPLapackCPU,
+            :linear_solver=>MadNLP.LapackCPUSolver,
         )
         m = 0
         nlp = MadNLPTests.DenseDummyQP(; n=n, m=m)
@@ -67,14 +67,14 @@ end
         # Test that using a sparse solver is forbidden in dense mode
         dense_options_error = Dict{Symbol, Any}(
             :kkt_system=>kkt_options,
-            :linear_solver=>MadNLPUmfpack,
+            :linear_solver=>MadNLP.UmfpackSolver,
         )
         @test_throws Exception MadNLP.InteriorPointSolver(nlp, dense_options_error)
     end
     @testset "Constrained" begin
         dense_options = Dict{Symbol, Any}(
             :kkt_system=>MadNLP.DENSE_KKT_SYSTEM,
-            :linear_solver=>MadNLPLapackCPU,
+            :linear_solver=>MadNLP.LapackCPUSolver,
         )
         m = 5
         nlp = MadNLPTests.DenseDummyQP(; n=n, m=m)
@@ -111,7 +111,7 @@ end
     nlp = MadNLPTests.DenseDummyQP(; n=n, m=m)
     sparse_options = Dict{Symbol, Any}(
         :kkt_system=>MadNLP.SPARSE_KKT_SYSTEM,
-        :linear_solver=>MadNLPLapackCPU,
+        :linear_solver=>MadNLP.LapackCPUSolver,
         :print_level=>MadNLP.ERROR,
     )
     ips = MadNLP.InteriorPointSolver(nlp, option_dict=sparse_options)

--- a/test/madnlp_test.jl
+++ b/test/madnlp_test.jl
@@ -2,39 +2,39 @@ testset = [
     [
         "Umfpack",
         ()->MadNLP.Optimizer(
-            linear_solver=MadNLPUmfpack,
+            linear_solver=MadNLP.UmfpackSolver,
             print_level=MadNLP.ERROR),
         []
     ],
     [
         "LapackCPU-BUNCHKAUFMAN",
         ()->MadNLP.Optimizer(
-            linear_solver=MadNLPLapackCPU,
-            lapackcpu_algorithm=MadNLPLapackCPU.BUNCHKAUFMAN,
+            linear_solver=MadNLP.LapackCPUSolver,
+            lapackcpu_algorithm=MadNLP.BUNCHKAUFMAN,
             print_level=MadNLP.ERROR),
         []
     ],
     [
         "LapackCPU-LU",
         ()->MadNLP.Optimizer(
-            linear_solver=MadNLPLapackCPU,
-            lapackcpu_algorithm=MadNLPLapackCPU.LU,
+            linear_solver=MadNLP.LapackCPUSolver,
+            lapackcpu_algorithm=MadNLP.LU,
             print_level=MadNLP.ERROR),
         []
     ],
     [
         "LapackCPU-QR",
         ()->MadNLP.Optimizer(
-            linear_solver=MadNLPLapackCPU,
-            lapackcpu_algorithm=MadNLPLapackCPU.QR,
+            linear_solver=MadNLP.LapackCPUSolver,
+            lapackcpu_algorithm=MadNLP.QR,
             print_level=MadNLP.ERROR),
         []
     ],
     [
         "LapackCPU-CHOLESKY",
         ()->MadNLP.Optimizer(
-            linear_solver=MadNLPLapackCPU,
-            lapackcpu_algorithm=MadNLPLapackCPU.CHOLESKY,
+            linear_solver=MadNLP.LapackCPUSolver,
+            lapackcpu_algorithm=MadNLP.CHOLESKY,
             print_level=MadNLP.ERROR),
         ["infeasible", "lootsma", "eigmina"]
     ],

--- a/test/matrix_test.jl
+++ b/test/matrix_test.jl
@@ -20,7 +20,7 @@ end
 
 @testset "LAPACK" begin
     sol= [0.8542713567839195, 1.4572864321608041]
-    M = MadNLPLapackCPU.Solver(dense)
+    M = MadNLP.LapackCPUSolver(dense)
     MadNLP.introduce(M)
     MadNLP.improve!(M)
     MadNLP.factorize!(M)
@@ -29,30 +29,15 @@ end
     @test solcmp(x,sol)
 end
 
-macro test_linear_solver(name)
-    str=string(name)
-    quote
-        if isdefined(MadNLP,Symbol($str))
-            @testset $str begin
-                sol= [0.8542713567839195, 1.4572864321608041]
-                M = MadNLP.$name.Solver(csc)
-                MadNLP.introduce(M)
-                MadNLP.improve!(M)
-                MadNLP.factorize!(M)
-                MadNLP.is_inertia(M) && (MadNLP.inertia(M) = (2,0,0))
-                x = MadNLP.solve!(M,copy(b))
-                @test solcmp(x,sol)
-            end
-        end
-    end
-end
 
-@test_linear_solver ma27
-@test_linear_solver ma57
-@test_linear_solver ma77
-@test_linear_solver ma86
-@test_linear_solver ma97
-@test_linear_solver pardiso
-@test_linear_solver pardisomkl
-@test_linear_solver umfpack
-@test_linear_solver mumps
+MadNLPTests.test_linear_solver(MadNLP.LapackCPUSolver)
+MadNLPTests.test_linear_solver(MadNLP.UmfpackSolver)
+# @test_linear_solver ma27
+# @test_linear_solver ma57
+# @test_linear_solver ma77
+# @test_linear_solver ma86
+# @test_linear_solver ma97
+# @test_linear_solver pardiso
+# @test_linear_solver pardisomkl
+# @test_linear_solver umfpack
+# @test_linear_solver mumps

--- a/test/minlp_test.jl
+++ b/test/minlp_test.jl
@@ -1,5 +1,5 @@
 const OPTIMIZER = ()->MadNLP.Optimizer(
-    linear_solver=MadNLPLapackCPU,
+    linear_solver=MadNLP.LapackCPUSolver,
     print_level=MadNLP.ERROR
 )
 


### PR DESCRIPTION
This PR defines the linear solver as proper Julia's struct, instead of a module. This allows to homogenize the code with the previous refactoring of the iterative refinement algorithm in #167 . 

### Summary 

In short, instead of defining a new MadNLP instance by passing a reference to the `MadNLPLapackCPU` module:
```julia
MadNLP.Optimizer(
    linear_solver=MadNLPLapackCPU,
)
```
this PR allows to instantiate MadNLP directly with the constructor of the linear solver:
```julia
MadNLP.Optimizer(
     linear_solver=LapackCPUSolver,
)
```

### To discuss

I am not sure about the naming of the different linear solvers (as previously they were all called `Solver`). Right now, I suggest:
- `MadNLPLapackCPU` -> `LapackCPUSolver`
- `MadNLPLapackGPU` -> `LapackGPUSolver`
- `MadNLPMumps` -> `MumpsSolver` 
-  `MadNLPMaXX` -> `MaXXSolver` 

But I welcome any feedback on this first suggestion!

