### PR TITLE
[Breaking change] Change names to follow JSO conventions

### DIFF
--- a/lib/MadNLPGPU/src/MadNLPGPU.jl
+++ b/lib/MadNLPGPU/src/MadNLPGPU.jl
@@ -14,7 +14,7 @@ import CUDAKernels: CUDADevice
 
 import MadNLP
 import MadNLP:
-    @kwdef, Logger, @debug, @warn, @error,
+    @kwdef, MadNLPLogger, @debug, @warn, @error,
     AbstractOptions, AbstractLinearSolver, AbstractNLPModel, set_options!,
     SymbolicException,FactorizationException,SolveException,InertiaException,
     introduce, factorize!, solve!, improve!, is_inertia, inertia, tril_to_full!,

--- a/lib/MadNLPGPU/src/MadNLPGPU.jl
+++ b/lib/MadNLPGPU/src/MadNLPGPU.jl
@@ -28,6 +28,8 @@ if has_cuda()
     include("lapackgpu.jl")
     export LapackGPUSolver
 end
+export CuMadNLPSolver
+
 include("interface.jl")
 
 end # module

--- a/lib/MadNLPGPU/src/interface.jl
+++ b/lib/MadNLPGPU/src/interface.jl
@@ -1,4 +1,3 @@
-
 function CuMadNLPSolver(nlp::AbstractNLPModel{T}; kwargs...) where T
     opt_ipm, opt_linear_solver, logger = MadNLP.load_options(; linear_solver=LapackGPUSolver, kwargs...)
 

--- a/lib/MadNLPGPU/src/interface.jl
+++ b/lib/MadNLPGPU/src/interface.jl
@@ -1,8 +1,8 @@
 
-function CuInteriorPointSolver(nlp::AbstractNLPModel{T};
+function CuMadNLPSolver(nlp::AbstractNLPModel{T};
     option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(), kwargs...
 ) where T
-    opt = MadNLP.Options(linear_solver=LapackGPUSolver)
+    opt = MadNLP.MadNLPOptions(linear_solver=LapackGPUSolver)
     MadNLP.set_options!(opt,option_dict,kwargs)
     MadNLP.check_option_sanity(opt)
 
@@ -18,5 +18,5 @@ function CuInteriorPointSolver(nlp::AbstractNLPModel{T};
         VT = CuVector{T}
         MadNLP.DenseCondensedKKTSystem{T, VT, MT}
     end
-    return MadNLP.InteriorPointSolver{T,KKTSystem}(nlp, opt; option_linear_solver=option_dict)
+    return MadNLP.MadNLPSolver{T,KKTSystem}(nlp, opt; option_linear_solver=option_dict)
 end

--- a/lib/MadNLPGPU/src/kernels.jl
+++ b/lib/MadNLPGPU/src/kernels.jl
@@ -109,12 +109,12 @@ function MadNLP.jtprod!(y::AbstractVector, kkt::MadNLP.AbstractDenseKKTSystem{T,
     return
 end
 
-function MadNLP.set_aug_diagonal!(kkt::MadNLP.AbstractDenseKKTSystem{T, VT, MT}, ips::MadNLP.InteriorPointSolver) where {T, VT<:CuVector{T}, MT<:CuMatrix{T}}
+function MadNLP.set_aug_diagonal!(kkt::MadNLP.AbstractDenseKKTSystem{T, VT, MT}, solver::MadNLP.MadNLPSolver) where {T, VT<:CuVector{T}, MT<:CuMatrix{T}}
     haskey(kkt.etc, :pr_diag_host) || (kkt.etc[:pr_diag_host] = Vector{T}(undef, length(kkt.pr_diag)))
     pr_diag_h = kkt.etc[:pr_diag_host]::Vector{T}
     # Broadcast is not working as MadNLP array are allocated on the CPU,
     # whereas pr_diag is allocated on the GPU
-    pr_diag_h .= ips.zl./(ips.x.-ips.xl) .+ ips.zu./(ips.xu.-ips.x)
+    pr_diag_h .= solver.zl./(solver.x.-solver.xl) .+ solver.zu./(solver.xu.-solver.x)
     copyto!(kkt.pr_diag, pr_diag_h)
     fill!(kkt.du_diag, 0.0)
 end

--- a/lib/MadNLPGPU/src/lapackgpu.jl
+++ b/lib/MadNLPGPU/src/lapackgpu.jl
@@ -9,14 +9,14 @@ mutable struct LapackGPUSolver{T} <: AbstractLinearSolver{T}
     info::CuVector{Int32}
     etc::Dict{Symbol,Any} # throw some algorithm-specific things here
     opt::LapackOptions
-    logger::Logger
+    logger::MadNLPLogger
 end
 
 
 function LapackGPUSolver(
     dense::MT;
     option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
-    opt=LapackOptions(),logger=Logger(),
+    opt=LapackOptions(),logger=MadNLPLogger(),
     kwargs...) where {T,MT <: AbstractMatrix{T}}
 
     set_options!(opt,option_dict,kwargs...)

--- a/lib/MadNLPGPU/test/densekkt_gpu.jl
+++ b/lib/MadNLPGPU/test/densekkt_gpu.jl
@@ -21,12 +21,12 @@ function _compare_gpu_with_cpu(KKTSystem, n, m, ind_fixed)
         nlp = MadNLPTests.DenseDummyQP{T}(; n=n, m=m, fixed_variables=ind_fixed)
 
         # Solve on CPU
-        h_ips = MadNLP.MadNLPSolver(nlp; madnlp_options...)
-        MadNLP.optimize!(h_ips)
+        h_solver = MadNLP.MadNLPSolver(nlp; madnlp_options...)
+        MadNLP.solve!(h_solver)
 
         # Solve on GPU
-        d_ips = MadNLPGPU.CuMadNLPSolver(nlp; madnlp_options...)
-        MadNLP.optimize!(d_ips)
+        d_solver = MadNLPGPU.CuMadNLPSolver(nlp; madnlp_options...)
+        MadNLP.solve!(d_solver)
 
         @test isa(d_solver.kkt, KKTSystem{T, CuVector{T}, CuMatrix{T}})
         # # Check that both results match exactly

--- a/lib/MadNLPGPU/test/densekkt_gpu.jl
+++ b/lib/MadNLPGPU/test/densekkt_gpu.jl
@@ -21,19 +21,19 @@ function _compare_gpu_with_cpu(KKTSystem, n, m, ind_fixed)
         nlp = MadNLPTests.DenseDummyQP{T}(; n=n, m=m, fixed_variables=ind_fixed)
         
         # Solve on CPU
-        h_ips = MadNLP.InteriorPointSolver(nlp; option_dict=copy(madnlp_options))
-        MadNLP.optimize!(h_ips)
+        h_solver = MadNLP.MadNLPSolver(nlp; option_dict=copy(madnlp_options))
+        MadNLP.solve!(h_solver)
 
         # Solve on GPU
-        d_ips = MadNLPGPU.CuInteriorPointSolver(nlp; option_dict=copy(madnlp_options))
-        MadNLP.optimize!(d_ips)
+        d_solver = MadNLPGPU.CuMadNLPSolver(nlp; option_dict=copy(madnlp_options))
+        MadNLP.solve!(d_solver)
 
-        @test isa(d_ips.kkt, KKTSystem{T, CuVector{T}, CuMatrix{T}})
+        @test isa(d_solver.kkt, KKTSystem{T, CuVector{T}, CuMatrix{T}})
         # # Check that both results match exactly
-        @test h_ips.cnt.k == d_ips.cnt.k
-        @test h_ips.obj_val ≈ d_ips.obj_val atol=atol
-        @test h_ips.x ≈ d_ips.x atol=atol
-        @test h_ips.l ≈ d_ips.l atol=atol
+        @test h_solver.cnt.k == d_solver.cnt.k
+        @test h_solver.obj_val ≈ d_solver.obj_val atol=atol
+        @test h_solver.x ≈ d_solver.x atol=atol
+        @test h_solver.y ≈ d_solver.y atol=atol
     end
 end
 

--- a/lib/MadNLPHSL/src/MadNLPHSL.jl
+++ b/lib/MadNLPHSL/src/MadNLPHSL.jl
@@ -1,7 +1,7 @@
 module MadNLPHSL
 
 import Libdl: dlopen, RTLD_DEEPBIND
-import MadNLP: @kwdef, Logger, @debug, @warn, @error,
+import MadNLP: @kwdef, MadNLPLogger, @debug, @warn, @error,
     AbstractOptions, AbstractLinearSolver, set_options!, SparseMatrixCSC, SubVector,
     SymbolicException,FactorizationException,SolveException,InertiaException,
     introduce, factorize!, solve!, improve!, is_inertia, inertia, findIJ, nnz,

--- a/lib/MadNLPHSL/src/ma27.jl
+++ b/lib/MadNLPHSL/src/ma27.jl
@@ -33,7 +33,7 @@ mutable struct Ma27Solver{T} <: AbstractLinearSolver{T}
     maxfrt::Vector{Int32}
 
     opt::Ma27Options
-    logger::Logger
+    logger::MadNLPLogger
 end
 
 
@@ -90,7 +90,7 @@ end
 
 function Ma27Solver(csc::SparseMatrixCSC{T};
                 option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
-                opt=Ma27Options(),logger=Logger(),kwargs...) where T
+                opt=Ma27Options(),logger=MadNLPLogger(),kwargs...) where T
 
     set_options!(opt,option_dict,kwargs)
 

--- a/lib/MadNLPHSL/src/ma57.jl
+++ b/lib/MadNLPHSL/src/ma57.jl
@@ -38,7 +38,7 @@ mutable struct Ma57Solver{T} <: AbstractLinearSolver{T}
     work::Vector{T}
 
     opt::Ma57Options
-    logger::Logger
+    logger::MadNLPLogger
 end
 
 
@@ -86,7 +86,7 @@ end
 
 function Ma57Solver(csc::SparseMatrixCSC{T};
                 option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
-                opt=Ma57Options(),logger=Logger(),kwargs...) where T
+                opt=Ma57Options(),logger=MadNLPLogger(),kwargs...) where T
 
     set_options!(opt,option_dict,kwargs)
 

--- a/lib/MadNLPHSL/src/ma77.jl
+++ b/lib/MadNLPHSL/src/ma77.jl
@@ -155,7 +155,7 @@ mutable struct Ma77Solver{T} <: AbstractLinearSolver{T}
     keep::Vector{Ptr{Nothing}}
 
     opt::Ma77Options
-    logger::Logger
+    logger::MadNLPLogger
 end
 
 for (fdefault, fanalyse, ffactor, fsolve, ffinalise, fopen, finputv, finputr, typ) in [
@@ -246,7 +246,7 @@ end
 function Ma77Solver(
     csc::SparseMatrixCSC{T,Int32};
     option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
-    opt=Ma77Options(),logger=Logger(),
+    opt=Ma77Options(),logger=MadNLPLogger(),
     kwargs...) where T
 
     set_options!(opt,option_dict,kwargs)

--- a/lib/MadNLPHSL/src/ma86.jl
+++ b/lib/MadNLPHSL/src/ma86.jl
@@ -60,7 +60,7 @@ mutable struct Ma86Solver{T} <: AbstractLinearSolver{T}
     keep::Vector{Ptr{Nothing}}
 
     opt::Ma86Options
-    logger::Logger
+    logger::MadNLPLogger
 end
 
 
@@ -131,7 +131,7 @@ ma86_set_num_threads(n) = ccall((:omp_set_num_threads_,libma86),
 function Ma86Solver(
     csc::SparseMatrixCSC{T,Int32};
     option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
-    opt=Ma86Options(),logger=Logger(),
+    opt=Ma86Options(),logger=MadNLPLogger(),
     kwargs...) where T
 
     set_options!(opt,option_dict,kwargs)

--- a/lib/MadNLPHSL/src/ma97.jl
+++ b/lib/MadNLPHSL/src/ma97.jl
@@ -65,7 +65,7 @@ mutable struct Ma97Solver{T} <:AbstractLinearSolver{T}
     fkeep::Vector{Ptr{Nothing}}
 
     opt::Ma97Options
-    logger::Logger
+    logger::MadNLPLogger
 end
 
 for (fdefault, fanalyse, ffactor, fsolve, ffinalise, typ) in [
@@ -136,7 +136,7 @@ ma97_set_num_threads(n) = ccall((:omp_set_num_threads_,libma97),
 function Ma97Solver(
     csc::SparseMatrixCSC{T,Int32};
     option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
-    opt=Ma97Options(),logger=Logger(),
+    opt=Ma97Options(),logger=MadNLPLogger(),
     kwargs...) where T
 
     set_options!(opt,option_dict,kwargs)

--- a/lib/MadNLPKrylov/src/MadNLPKrylov.jl
+++ b/lib/MadNLPKrylov/src/MadNLPKrylov.jl
@@ -1,7 +1,7 @@
 module MadNLPKrylov
 
 import MadNLP:
-    @kwdef, Logger, @debug, @warn, @error,
+    @kwdef, MadNLPLogger, @debug, @warn, @error,
     AbstractOptions, AbstractIterator, set_options!, @sprintf,
     solve_refine!, mul!, ldiv!, size
 import IterativeSolvers:
@@ -34,11 +34,11 @@ mutable struct KrylovIterator{T} <: AbstractIterator{T}
     g::Union{Nothing,GMRESIterable}
     res::Vector{T}
     opt::KrylovOptions
-    logger::Logger
+    logger::MadNLPLogger
 end
 
 function KrylovIterator(res::Vector{T},_mul!,_ldiv!;
-                opt=KrylovOptions(),logger=Logger(),
+                opt=KrylovOptions(),logger=MadNLPLogger(),
                 option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),kwargs...) where T
     !isempty(kwargs) && (for (key,val) in kwargs; option_dict[key]=val; end)
     set_options!(opt,option_dict)

--- a/lib/MadNLPMumps/src/MadNLPMumps.jl
+++ b/lib/MadNLPMumps/src/MadNLPMumps.jl
@@ -4,7 +4,7 @@ import StaticArrays: SVector, setindex
 import MUMPS_seq_jll
 import MadNLP:
     parsefile, dlopen,
-    @kwdef, Logger, @debug, @warn, @error,
+    @kwdef, MadNLPLogger, @debug, @warn, @error,
     SparseMatrixCSC, SubVector,
     SymbolicException,FactorizationException,SolveException,InertiaException,
     AbstractOptions, AbstractLinearSolver, set_options!, input_type,
@@ -239,7 +239,7 @@ mutable struct MumpsSolver{T} <: AbstractLinearSolver{T}
     mumps_struc::Struc
     is_singular::Bool
     opt::MumpsOptions
-    logger::Logger
+    logger::MadNLPLogger
 end
 
 for (lib,fname,typ) in [(MUMPS_seq_jll.libdmumps,:dmumps_c,Float64), (MUMPS_seq_jll.libsmumps, :smumps_c,Float32)]
@@ -266,7 +266,7 @@ end
 
 function MumpsSolver(csc::SparseMatrixCSC{T,Int32};
                 option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
-                opt=MumpsOptions(),logger=Logger(),
+                opt=MumpsOptions(),logger=MadNLPLogger(),
                 kwargs...) where T
 
     set_options!(opt,option_dict,kwargs)

--- a/lib/MadNLPPardiso/src/MadNLPPardiso.jl
+++ b/lib/MadNLPPardiso/src/MadNLPPardiso.jl
@@ -5,7 +5,7 @@ include(joinpath("..","deps","deps.jl"))
 
 import Libdl: dlopen, RTLD_DEEPBIND
 import MadNLP:
-    MadNLP, @kwdef, Logger, @debug, @warn, @error,
+    MadNLP, @kwdef, MadNLPLogger, @debug, @warn, @error,
     SubVector, SparseMatrixCSC, 
     SymbolicException,FactorizationException,SolveException,InertiaException,
     AbstractOptions, AbstractLinearSolver, set_options!,

--- a/lib/MadNLPPardiso/src/pardiso.jl
+++ b/lib/MadNLPPardiso/src/pardiso.jl
@@ -18,7 +18,7 @@ mutable struct PardisoSolver{T} <: AbstractLinearSolver{T}
     csc::SparseMatrixCSC{T,Int32}
     w::Vector{T}
     opt::PardisoOptions
-    logger::Logger
+    logger::MadNLPLogger
 end
 
 _pardisoinit(
@@ -42,7 +42,7 @@ _pardiso(
             pt,maxfct,mnum,mtype,phase,n,a,ia,ja,perm,nrhs,iparm,msglvl,b,x,err,dparm)
 
 function PardisoSolver(csc::SparseMatrixCSC{T,Int32};
-                opt=PardisoOptions(),logger=Logger(),
+                opt=PardisoOptions(),logger=MadNLPLogger(),
                 option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
                 kwargs...) where T
     !isempty(kwargs) && (for (key,val) in kwargs; option_dict[key]=val; end)

--- a/lib/MadNLPPardiso/src/pardisomkl.jl
+++ b/lib/MadNLPPardiso/src/pardisomkl.jl
@@ -17,7 +17,7 @@ mutable struct PardisoMKLSolver{T} <: AbstractLinearSolver{T}
     csc::SparseMatrixCSC{T,Int32}
     w::Vector{T}
     opt::PardisoMKLOptions
-    logger::Logger
+    logger::MadNLPLogger
 end
 
 pardisomkl_pardisoinit(pt,mtype::Ref{Cint},iparm::Vector{Cint}) where T =
@@ -51,7 +51,7 @@ end
 
 
 function PardisoMKLSolver(csc::SparseMatrixCSC{T};
-                opt=PardisoMKLOptions(),logger=Logger(),
+                opt=PardisoMKLOptions(),logger=MadNLPLogger(),
                 option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
                 kwargs...) where T
     !isempty(kwargs) && (for (key,val) in kwargs; option_dict[key]=val; end)

--- a/src/IPM/IPM.jl
+++ b/src/IPM/IPM.jl
@@ -113,13 +113,13 @@ function MadNLPSolver(nlp::AbstractNLPModel{T}; kwargs...) where T
         MT = Matrix{T}
         DenseCondensedKKTSystem{T, VT, MT}
     end
-    return MadNLPSolverSolver{T,KKTSystem}(nlp, opt_ipm, opt_linear_solver; logger=logger)
+    return MadNLPSolver{T,KKTSystem}(nlp, opt_ipm, opt_linear_solver; logger=logger)
 end
 
 # Inner constructor
-function MadNLPSolverSolver{T,KKTSystem}(
+function MadNLPSolver{T,KKTSystem}(
     nlp::AbstractNLPModel,
-    opt::IPMOptions,
+    opt::MadNLPOptions,
     opt_linear_solver::AbstractOptions;
     logger=MadNLPLogger(),
 ) where {T, KKTSystem<:AbstractKKTSystem{T}}
@@ -195,7 +195,8 @@ function MadNLPSolverSolver{T,KKTSystem}(
     con_jac_scale = ones(T,n_jac)
 
     @trace(logger,"Initializing linear solver.")
-    cnt.linear_solver_time = @elapsed linear_solver = opt.linear_solver(get_kkt(kkt) ; opt=opt_linear_solver, logger=logger)
+    cnt.linear_solver_time =
+        @elapsed linear_solver = opt.linear_solver(get_kkt(kkt) ; opt=opt_linear_solver, logger=logger)
 
     n_kkt = size(kkt, 1)
     buffer_vec = similar(full(d), n_kkt)

--- a/src/IPM/callbacks.jl
+++ b/src/IPM/callbacks.jl
@@ -1,18 +1,18 @@
-function eval_f_wrapper(ips::InteriorPointSolver, x::Vector{T}) where T
-    nlp = ips.nlp
-    cnt = ips.cnt
-    @trace(ips.logger,"Evaluating objective.")
+function eval_f_wrapper(solver::MadNLPSolver, x::Vector{T}) where T
+    nlp = solver.nlp
+    cnt = solver.cnt
+    @trace(solver.logger,"Evaluating objective.")
     x_nlpmodel = _madnlp_unsafe_wrap(x, get_nvar(nlp))
     cnt.eval_function_time += @elapsed obj_val = (get_minimize(nlp) ? 1. : -1.) * obj(nlp,x_nlpmodel)
     cnt.obj_cnt+=1
     cnt.obj_cnt==1 && (is_valid(obj_val) || throw(InvalidNumberException()))
-    return obj_val*ips.obj_scale[]
+    return obj_val*solver.obj_scale[]
 end
 
-function eval_grad_f_wrapper!(ips::InteriorPointSolver, f::Vector{T},x::Vector{T}) where T
-    nlp = ips.nlp
-    cnt = ips.cnt
-    @trace(ips.logger,"Evaluating objective gradient.")
+function eval_grad_f_wrapper!(solver::MadNLPSolver, f::Vector{T},x::Vector{T}) where T
+    nlp = solver.nlp
+    cnt = solver.cnt
+    @trace(solver.logger,"Evaluating objective gradient.")
     x_nlpmodel = _madnlp_unsafe_wrap(x, get_nvar(nlp))
     f_nlpmodel = _madnlp_unsafe_wrap(f, get_nvar(nlp))
     cnt.eval_function_time += @elapsed grad!(
@@ -20,16 +20,16 @@ function eval_grad_f_wrapper!(ips::InteriorPointSolver, f::Vector{T},x::Vector{T
         x_nlpmodel,
         f_nlpmodel
     )
-    f.*=ips.obj_scale[] * (get_minimize(nlp) ? 1. : -1.)
+    f.*=solver.obj_scale[] * (get_minimize(nlp) ? 1. : -1.)
     cnt.obj_grad_cnt+=1
     cnt.obj_grad_cnt==1 && (is_valid(f)  || throw(InvalidNumberException()))
     return f
 end
 
-function eval_cons_wrapper!(ips::InteriorPointSolver, c::Vector{T},x::Vector{T}) where T
-    nlp = ips.nlp
-    cnt = ips.cnt
-    @trace(ips.logger, "Evaluating constraints.")
+function eval_cons_wrapper!(solver::MadNLPSolver, c::Vector{T},x::Vector{T}) where T
+    nlp = solver.nlp
+    cnt = solver.cnt
+    @trace(solver.logger, "Evaluating constraints.")
     x_nlpmodel = _madnlp_unsafe_wrap(x, get_nvar(nlp))
     c_nlpmodel = _madnlp_unsafe_wrap(c, get_ncon(nlp))
     cnt.eval_function_time += @elapsed cons!(
@@ -37,19 +37,19 @@ function eval_cons_wrapper!(ips::InteriorPointSolver, c::Vector{T},x::Vector{T})
         x_nlpmodel,
         c_nlpmodel
     )
-    view(c,ips.ind_ineq).-=view(x,get_nvar(nlp)+1:ips.n)
-    c.-=ips.rhs
-    c.*=ips.con_scale
+    view(c,solver.ind_ineq).-=view(x,get_nvar(nlp)+1:solver.n)
+    c.-=solver.rhs
+    c.*=solver.con_scale
     cnt.con_cnt+=1
     cnt.con_cnt==2 && (is_valid(c) || throw(InvalidNumberException()))
     return c
 end
 
-function eval_jac_wrapper!(ipp::InteriorPointSolver, kkt::AbstractKKTSystem, x::Vector{T}) where T
-    nlp = ipp.nlp
-    cnt = ipp.cnt
-    ns = length(ipp.ind_ineq)
-    @trace(ipp.logger, "Evaluating constraint Jacobian.")
+function eval_jac_wrapper!(solver::MadNLPSolver, kkt::AbstractKKTSystem, x::Vector{T}) where T
+    nlp = solver.nlp
+    cnt = solver.cnt
+    ns = length(solver.ind_ineq)
+    @trace(solver.logger, "Evaluating constraint Jacobian.")
     jac = get_jacobian(kkt)
     x_nlpmodel = _madnlp_unsafe_wrap(x, get_nvar(nlp))
     jac_nlpmodel = _madnlp_unsafe_wrap(jac, get_nnzj(nlp.meta))
@@ -61,24 +61,24 @@ function eval_jac_wrapper!(ipp::InteriorPointSolver, kkt::AbstractKKTSystem, x::
     compress_jacobian!(kkt)
     cnt.con_jac_cnt+=1
     cnt.con_jac_cnt==1 && (is_valid(jac) || throw(InvalidNumberException()))
-    @trace(ipp.logger,"Constraint jacobian evaluation started.")
+    @trace(solver.logger,"Constraint jacobian evaluation started.")
     return jac
 end
 
-function eval_lag_hess_wrapper!(ipp::InteriorPointSolver, kkt::AbstractKKTSystem, x::Vector{T},l::Vector{T};is_resto=false) where T
-    nlp = ipp.nlp
-    cnt = ipp.cnt
-    @trace(ipp.logger,"Evaluating Lagrangian Hessian.")
-    dual(ipp._w1) .= l.*ipp.con_scale
+function eval_lag_hess_wrapper!(solver::MadNLPSolver, kkt::AbstractKKTSystem, x::Vector{T},l::Vector{T};is_resto=false) where T
+    nlp = solver.nlp
+    cnt = solver.cnt
+    @trace(solver.logger,"Evaluating Lagrangian Hessian.")
+    dual(solver._w1) .= l.*solver.con_scale
     hess = get_hessian(kkt)
     x_nlpmodel = _madnlp_unsafe_wrap(x, get_nvar(nlp))
     hess_nlpmodel = _madnlp_unsafe_wrap(hess, get_nnzh(nlp.meta))
     cnt.eval_function_time += @elapsed hess_coord!(
         nlp,
         x_nlpmodel,
-        dual(ipp._w1),
+        dual(solver._w1),
         hess_nlpmodel;
-        obj_weight = (get_minimize(nlp) ? 1. : -1.) * (is_resto ? 0.0 : ipp.obj_scale[])
+        obj_weight = (get_minimize(nlp) ? 1. : -1.) * (is_resto ? 0.0 : solver.obj_scale[])
     )
     compress_hessian!(kkt)
     cnt.lag_hess_cnt+=1
@@ -86,11 +86,11 @@ function eval_lag_hess_wrapper!(ipp::InteriorPointSolver, kkt::AbstractKKTSystem
     return hess
 end
 
-function eval_jac_wrapper!(ipp::InteriorPointSolver, kkt::AbstractDenseKKTSystem, x::Vector{T}) where T
-    nlp = ipp.nlp
-    cnt = ipp.cnt
-    ns = length(ipp.ind_ineq)
-    @trace(ipp.logger, "Evaluating constraint Jacobian.")
+function eval_jac_wrapper!(solver::MadNLPSolver, kkt::AbstractDenseKKTSystem, x::Vector{T}) where T
+    nlp = solver.nlp
+    cnt = solver.cnt
+    ns = length(solver.ind_ineq)
+    @trace(solver.logger, "Evaluating constraint Jacobian.")
     jac = get_jacobian(kkt)
     x_nlpmodel = _madnlp_unsafe_wrap(x, get_nvar(nlp))
     cnt.eval_function_time += @elapsed jac_dense!(
@@ -101,23 +101,23 @@ function eval_jac_wrapper!(ipp::InteriorPointSolver, kkt::AbstractDenseKKTSystem
     compress_jacobian!(kkt)
     cnt.con_jac_cnt+=1
     cnt.con_jac_cnt==1 && (is_valid(jac) || throw(InvalidNumberException()))
-    @trace(ipp.logger,"Constraint jacobian evaluation started.")
+    @trace(solver.logger,"Constraint jacobian evaluation started.")
     return jac
 end
 
-function eval_lag_hess_wrapper!(ipp::InteriorPointSolver, kkt::AbstractDenseKKTSystem, x::Vector{T},l::Vector{T};is_resto=false) where T
-    nlp = ipp.nlp
-    cnt = ipp.cnt
-    @trace(ipp.logger,"Evaluating Lagrangian Hessian.")
-    dual(ipp._w1) .= l.*ipp.con_scale
+function eval_lag_hess_wrapper!(solver::MadNLPSolver, kkt::AbstractDenseKKTSystem, x::Vector{T},l::Vector{T};is_resto=false) where T
+    nlp = solver.nlp
+    cnt = solver.cnt
+    @trace(solver.logger,"Evaluating Lagrangian Hessian.")
+    dual(solver._w1) .= l.*solver.con_scale
     hess = get_hessian(kkt)
     x_nlpmodel = _madnlp_unsafe_wrap(x, get_nvar(nlp))
     cnt.eval_function_time += @elapsed hess_dense!(
         nlp,
         x_nlpmodel,
-        dual(ipp._w1),
+        dual(solver._w1),
         hess;
-        obj_weight = (get_minimize(nlp) ? 1. : -1.) * (is_resto ? 0.0 : ipp.obj_scale[])
+        obj_weight = (get_minimize(nlp) ? 1. : -1.) * (is_resto ? 0.0 : solver.obj_scale[])
     )
     compress_hessian!(kkt)
     cnt.lag_hess_cnt+=1

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -1,90 +1,90 @@
 
 # KKT system updates -------------------------------------------------------
 # Set diagonal
-function set_aug_diagonal!(kkt::AbstractKKTSystem, ips::InteriorPointSolver)
-    kkt.pr_diag .= ips.zl./(ips.x.-ips.xl) .+ ips.zu./(ips.xu.-ips.x)
+function set_aug_diagonal!(kkt::AbstractKKTSystem, solver::MadNLPSolver)
+    kkt.pr_diag .= solver.zl./(solver.x.-solver.xl) .+ solver.zu./(solver.xu.-solver.x)
     fill!(kkt.du_diag, 0.0)
 end
-function set_aug_diagonal!(kkt::SparseUnreducedKKTSystem, ips::InteriorPointSolver)
+function set_aug_diagonal!(kkt::SparseUnreducedKKTSystem, solver::MadNLPSolver)
     kkt.pr_diag .= 0.0
     kkt.du_diag .= 0.0
-    kkt.l_lower .= .-sqrt.(ips.zl_r)
-    kkt.u_lower .= .-sqrt.(ips.zu_r)
-    kkt.l_diag  .= ips.xl_r .- ips.x_lr
-    kkt.u_diag  .= ips.x_ur .- ips.xu_r
+    kkt.l_lower .= .-sqrt.(solver.zl_r)
+    kkt.u_lower .= .-sqrt.(solver.zu_r)
+    kkt.l_diag  .= solver.xl_r .- solver.x_lr
+    kkt.u_diag  .= solver.x_ur .- solver.xu_r
 end
 
 # Robust restoration
-function set_aug_RR!(kkt::AbstractKKTSystem, ips::InteriorPointSolver, RR::RobustRestorer)
-    kkt.pr_diag .= ips.zl./(ips.x.-ips.xl) .+ ips.zu./(ips.xu.-ips.x) .+ RR.zeta.*RR.D_R.^2
+function set_aug_RR!(kkt::AbstractKKTSystem, solver::MadNLPSolver, RR::RobustRestorer)
+    kkt.pr_diag .= solver.zl./(solver.x.-solver.xl) .+ solver.zu./(solver.xu.-solver.x) .+ RR.zeta.*RR.D_R.^2
     kkt.du_diag .= .-RR.pp./RR.zp .- RR.nn./RR.zn
 end
-function set_aug_RR!(kkt::SparseUnreducedKKTSystem, ips::InteriorPointSolver, RR::RobustRestorer)
+function set_aug_RR!(kkt::SparseUnreducedKKTSystem, solver::MadNLPSolver, RR::RobustRestorer)
     kkt.pr_diag.= RR.zeta.*RR.D_R.^2
     kkt.du_diag.= .-RR.pp./RR.zp.-RR.nn./RR.zn
-    kkt.l_lower.=.-sqrt.(ips.zl_r)
-    kkt.u_lower.=.-sqrt.(ips.zu_r)
-    kkt.l_diag .= ips.xl_r .- ips.x_lr
-    kkt.u_diag .= ips.x_ur .- ips.xu_r
+    kkt.l_lower.=.-sqrt.(solver.zl_r)
+    kkt.u_lower.=.-sqrt.(solver.zu_r)
+    kkt.l_diag .= solver.xl_r .- solver.x_lr
+    kkt.u_diag .= solver.x_ur .- solver.xu_r
 end
 
 # Set RHS
-function set_aug_rhs!(ips::InteriorPointSolver, kkt::AbstractKKTSystem, c)
-    primal(ips.p) .= .-ips.f.+ips.mu./(ips.x.-ips.xl).-ips.mu./(ips.xu.-ips.x).-ips.jacl
-    dual(ips.p)   .= .-c
+function set_aug_rhs!(solver::MadNLPSolver, kkt::AbstractKKTSystem, c)
+    primal(solver.p) .= .-solver.f.+solver.mu./(solver.x.-solver.xl).-solver.mu./(solver.xu.-solver.x).-solver.jacl
+    dual(solver.p)   .= .-c
 end
 
-function set_aug_rhs!(ips::InteriorPointSolver, kkt::SparseUnreducedKKTSystem, c)
-    primal(ips.p) .= .-ips.f.+ips.zl.-ips.zu.-ips.jacl
-    dual(ips.p) .= .-c
-    dual_lb(ips.p) .= (ips.xl_r-ips.x_lr).*kkt.l_lower .+ ips.mu./kkt.l_lower
-    dual_ub(ips.p) .= (ips.xu_r-ips.x_ur).*kkt.u_lower .- ips.mu./kkt.u_lower
+function set_aug_rhs!(solver::MadNLPSolver, kkt::SparseUnreducedKKTSystem, c)
+    primal(solver.p) .= .-solver.f.+solver.zl.-solver.zu.-solver.jacl
+    dual(solver.p) .= .-c
+    dual_lb(solver.p) .= (solver.xl_r-solver.x_lr).*kkt.l_lower .+ solver.mu./kkt.l_lower
+    dual_ub(solver.p) .= (solver.xu_r-solver.x_ur).*kkt.u_lower .- solver.mu./kkt.u_lower
 end
 
-function set_aug_rhs_ifr!(ips::InteriorPointSolver, kkt::SparseUnreducedKKTSystem,c)
-    primal(ips._w1) .= 0.0
-    dual(ips._w1) .= .-c
-    dual_lb(ips._w1) .= 0.0
-    dual_ub(ips._w1) .= 0.0
+function set_aug_rhs_ifr!(solver::MadNLPSolver, kkt::SparseUnreducedKKTSystem,c)
+    primal(solver._w1) .= 0.0
+    dual(solver._w1) .= .-c
+    dual_lb(solver._w1) .= 0.0
+    dual_ub(solver._w1) .= 0.0
 end
 
 # Set RHS RR
 function set_aug_rhs_RR!(
-    ips::InteriorPointSolver, kkt::AbstractKKTSystem, RR::RobustRestorer, rho,
+    solver::MadNLPSolver, kkt::AbstractKKTSystem, RR::RobustRestorer, rho,
 )
-    primal(ips.p) .= .-RR.f_R.-ips.jacl.+RR.mu_R./(ips.x.-ips.xl).-RR.mu_R./(ips.xu.-ips.x)
-    dual(ips.p) .= .-ips.c.+RR.pp.-RR.nn.+(RR.mu_R.-(rho.-ips.l).*RR.pp)./RR.zp.-(RR.mu_R.-(rho.+ips.l).*RR.nn)./RR.zn
+    primal(solver.p) .= .-RR.f_R.-solver.jacl.+RR.mu_R./(solver.x.-solver.xl).-RR.mu_R./(solver.xu.-solver.x)
+    dual(solver.p) .= .-solver.c.+RR.pp.-RR.nn.+(RR.mu_R.-(rho.-solver.y).*RR.pp)./RR.zp.-(RR.mu_R.-(rho.+solver.y).*RR.nn)./RR.zn
 end
 
 # Finish
-function finish_aug_solve!(ips::InteriorPointSolver, kkt::AbstractKKTSystem, mu)
-    dual_lb(ips.d) .= (mu.-ips.zl_r.*ips.dx_lr)./(ips.x_lr.-ips.xl_r).-ips.zl_r
-    dual_ub(ips.d) .= (mu.+ips.zu_r.*ips.dx_ur)./(ips.xu_r.-ips.x_ur).-ips.zu_r
+function finish_aug_solve!(solver::MadNLPSolver, kkt::AbstractKKTSystem, mu)
+    dual_lb(solver.d) .= (mu.-solver.zl_r.*solver.dx_lr)./(solver.x_lr.-solver.xl_r).-solver.zl_r
+    dual_ub(solver.d) .= (mu.+solver.zu_r.*solver.dx_ur)./(solver.xu_r.-solver.x_ur).-solver.zu_r
 end
 
-function finish_aug_solve!(ips::InteriorPointSolver, kkt::SparseUnreducedKKTSystem, mu)
-    dual_lb(ips.d) .*= .-kkt.l_lower
-    dual_ub(ips.d) .*= kkt.u_lower
-    dual_lb(ips.d) .= (mu.-ips.zl_r.*ips.dx_lr)./(ips.x_lr.-ips.xl_r).-ips.zl_r
-    dual_ub(ips.d) .= (mu.+ips.zu_r.*ips.dx_ur)./(ips.xu_r.-ips.x_ur).-ips.zu_r
+function finish_aug_solve!(solver::MadNLPSolver, kkt::SparseUnreducedKKTSystem, mu)
+    dual_lb(solver.d) .*= .-kkt.l_lower
+    dual_ub(solver.d) .*= kkt.u_lower
+    dual_lb(solver.d) .= (mu.-solver.zl_r.*solver.dx_lr)./(solver.x_lr.-solver.xl_r).-solver.zl_r
+    dual_ub(solver.d) .= (mu.+solver.zu_r.*solver.dx_ur)./(solver.xu_r.-solver.x_ur).-solver.zu_r
 end
 
 # Initial
-function set_initial_rhs!(ips::InteriorPointSolver, kkt::AbstractKKTSystem)
-    primal(ips.p) .= .-ips.f.+ips.zl.-ips.zu
-    dual(ips.p) .= 0.0
+function set_initial_rhs!(solver::MadNLPSolver, kkt::AbstractKKTSystem)
+    primal(solver.p) .= .-solver.f.+solver.zl.-solver.zu
+    dual(solver.p) .= 0.0
 end
-function set_initial_rhs!(ips::InteriorPointSolver, kkt::SparseUnreducedKKTSystem)
-    primal(ips.p) .= .-ips.f.+ips.zl.-ips.zu
-    dual(ips.p) .= 0.0
-    dual_lb(ips.p) .= 0.0
-    dual_ub(ips.p) .= 0.0
+function set_initial_rhs!(solver::MadNLPSolver, kkt::SparseUnreducedKKTSystem)
+    primal(solver.p) .= .-solver.f.+solver.zl.-solver.zu
+    dual(solver.p) .= 0.0
+    dual_lb(solver.p) .= 0.0
+    dual_ub(solver.p) .= 0.0
 end
 
 # Set ifr
-function set_aug_rhs_ifr!(ips::InteriorPointSolver, kkt::AbstractKKTSystem)
-    primal(ips._w1) .= 0.0
-    dual(ips._w1) .= .-ips.c
+function set_aug_rhs_ifr!(solver::MadNLPSolver, kkt::AbstractKKTSystem)
+    primal(solver._w1) .= 0.0
+    dual(solver._w1) .= .-solver.c
 end
 
 # Finish RR

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -1,682 +1,732 @@
-function initialize!(ips::AbstractInteriorPointSolver)
+function madnlp(model::AbstractNLPModel; kwargs...)
+    solver = MadNLPSolver(model;kwargs...)
+    initialize!(solver.kkt)
+    return solve!(solver)
+end
+
+function solve!(
+    model::AbstractNLPModel,
+    solver::MadNLPSolver,
+    nlp::AbstractNLPModel;
+    x = nlp.meta.x,
+    y = nlp.meta.y,
+    zl= nothing,
+    zu= nothing,
+    kwargs...)
+
+    @assert solver.nlp == nlp
+    
+    solve!(
+        solver;
+        x = x, y = y,
+        zl = zl, zu = zu,
+        kwargs...
+    )
+end
+
+function initialize!(solver::AbstractMadNLPSolver)
     # initializing slack variables
-    @trace(ips.logger,"Initializing slack variables.")
-    cons!(ips.nlp,get_x0(ips.nlp),_madnlp_unsafe_wrap(ips.c,get_ncon(ips.nlp)))
-    ips.cnt.con_cnt += 1
-    ips.x_slk.=ips.c_slk
+    @trace(solver.logger,"Initializing slack variables.")
+    cons!(solver.nlp,get_x0(solver.nlp),_madnlp_unsafe_wrap(solver.c,get_ncon(solver.nlp)))
+    solver.cnt.con_cnt += 1
+    solver.x_slk.=solver.c_slk
 
     # Initialization
-    @trace(ips.logger,"Initializing primal and bound duals.")
-    ips.zl_r.=1.0
-    ips.zu_r.=1.0
-    ips.xl_r.-= max.(1,abs.(ips.xl_r)).*ips.opt.tol
-    ips.xu_r.+= max.(1,abs.(ips.xu_r)).*ips.opt.tol
-    initialize_variables!(ips.x,ips.xl,ips.xu,ips.opt.bound_push,ips.opt.bound_fac)
+    @trace(solver.logger,"Initializing primal and bound duals.")
+    solver.zl_r.=1.0
+    solver.zu_r.=1.0
+    solver.xl_r.-= max.(1,abs.(solver.xl_r)).*solver.opt.tol
+    solver.xu_r.+= max.(1,abs.(solver.xu_r)).*solver.opt.tol
+    initialize_variables!(solver.x,solver.xl,solver.xu,solver.opt.bound_push,solver.opt.bound_fac)
 
     # Automatic scaling (constraints)
-    @trace(ips.logger,"Computing constraint scaling.")
-    eval_jac_wrapper!(ips, ips.kkt, ips.x)
-    compress_jacobian!(ips.kkt)
-    if (ips.m > 0) && ips.opt.nlp_scaling
-        jac = get_raw_jacobian(ips.kkt)
-        scale_constraints!(ips.nlp, ips.con_scale, jac; max_gradient=ips.opt.nlp_scaling_max_gradient)
-        set_jacobian_scaling!(ips.kkt, ips.con_scale)
-        ips.l./=ips.con_scale
+    @trace(solver.logger,"Computing constraint scaling.")
+    eval_jac_wrapper!(solver, solver.kkt, solver.x)
+    compress_jacobian!(solver.kkt)
+    if (solver.m > 0) && solver.opt.nlp_scaling
+        jac = get_raw_jacobian(solver.kkt)
+        scale_constraints!(solver.nlp, solver.con_scale, jac; max_gradient=solver.opt.nlp_scaling_max_gradient)
+        set_jacobian_scaling!(solver.kkt, solver.con_scale)
+        solver.y./=solver.con_scale
     end
-    compress_jacobian!(ips.kkt)
+    compress_jacobian!(solver.kkt)
 
     # Automatic scaling (objective)
-    eval_grad_f_wrapper!(ips, ips.f,ips.x)
-    @trace(ips.logger,"Computing objective scaling.")
-    if ips.opt.nlp_scaling
-        ips.obj_scale[] = scale_objective(ips.nlp, ips.f; max_gradient=ips.opt.nlp_scaling_max_gradient)
-        ips.f.*=ips.obj_scale[]
+    eval_grad_f_wrapper!(solver, solver.f,solver.x)
+    @trace(solver.logger,"Computing objective scaling.")
+    if solver.opt.nlp_scaling
+        solver.obj_scale[] = scale_objective(solver.nlp, solver.f; max_gradient=solver.opt.nlp_scaling_max_gradient)
+        solver.f.*=solver.obj_scale[]
     end
 
     # Initialize dual variables
-    @trace(ips.logger,"Initializing constraint duals.")
-    if !ips.opt.dual_initialized
-        set_initial_rhs!(ips, ips.kkt)
-        initialize!(ips.kkt)
-        factorize_wrapper!(ips)
-        solve_refine_wrapper!(ips,ips.d,ips.p)
-        if norm(dual(ips.d), Inf) > ips.opt.constr_mult_init_max
-            fill!(ips.l, 0.0)
+    @trace(solver.logger,"Initializing constraint duals.")
+    if !solver.opt.dual_initialized
+        set_initial_rhs!(solver, solver.kkt)
+        initialize!(solver.kkt)
+        factorize_wrapper!(solver)
+        solve_refine_wrapper!(solver,solver.d,solver.p)
+        if norm(dual(solver.d), Inf) > solver.opt.constr_mult_init_max
+            fill!(solver.y, 0.0)
         else
-            copyto!(ips.l, dual(ips.d))
+            copyto!(solver.y, dual(solver.d))
         end
     end
 
     # Initializing
-    ips.obj_val = eval_f_wrapper(ips, ips.x)
-    eval_cons_wrapper!(ips, ips.c, ips.x)
-    eval_lag_hess_wrapper!(ips, ips.kkt, ips.x, ips.l)
+    solver.obj_val = eval_f_wrapper(solver, solver.x)
+    eval_cons_wrapper!(solver, solver.c, solver.x)
+    eval_lag_hess_wrapper!(solver, solver.kkt, solver.x, solver.y)
 
-    theta = get_theta(ips.c)
-    ips.theta_max=1e4*max(1,theta)
-    ips.theta_min=1e-4*max(1,theta)
-    ips.mu=ips.opt.mu_init
-    ips.tau=max(ips.opt.tau_min,1-ips.opt.mu_init)
-    ips.filter = [(ips.theta_max,-Inf)]
+    theta = get_theta(solver.c)
+    solver.theta_max=1e4*max(1,theta)
+    solver.theta_min=1e-4*max(1,theta)
+    solver.mu=solver.opt.mu_init
+    solver.tau=max(solver.opt.tau_min,1-solver.opt.mu_init)
+    solver.filter = [(solver.theta_max,-Inf)]
 
     return REGULAR
 end
 
 
-function reinitialize!(ips::AbstractInteriorPointSolver)
-    view(ips.x,1:get_nvar(ips.nlp)) .= get_x0(ips.nlp)
+function reinitialize!(solver::AbstractMadNLPSolver)
+    view(solver.x,1:get_nvar(solver.nlp)) .= get_x0(solver.nlp)
 
-    ips.obj_val = eval_f_wrapper(ips, ips.x)
-    eval_grad_f_wrapper!(ips, ips.f, ips.x)
-    eval_cons_wrapper!(ips, ips.c, ips.x)
-    eval_jac_wrapper!(ips, ips.kkt, ips.x)
-    eval_lag_hess_wrapper!(ips, ips.kkt, ips.x, ips.l)
+    solver.obj_val = eval_f_wrapper(solver, solver.x)
+    eval_grad_f_wrapper!(solver, solver.f, solver.x)
+    eval_cons_wrapper!(solver, solver.c, solver.x)
+    eval_jac_wrapper!(solver, solver.kkt, solver.x)
+    eval_lag_hess_wrapper!(solver, solver.kkt, solver.x, solver.y)
 
-    theta = get_theta(ips.c)
-    ips.theta_max=1e4*max(1,theta)
-    ips.theta_min=1e-4*max(1,theta)
-    ips.mu=ips.opt.mu_init
-    ips.tau=max(ips.opt.tau_min,1-ips.opt.mu_init)
-    ips.filter = [(ips.theta_max,-Inf)]
+    theta = get_theta(solver.c)
+    solver.theta_max=1e4*max(1,theta)
+    solver.theta_min=1e-4*max(1,theta)
+    solver.mu=solver.opt.mu_init
+    solver.tau=max(solver.opt.tau_min,1-solver.opt.mu_init)
+    solver.filter = [(solver.theta_max,-Inf)]
 
     return REGULAR
 end
 
 # major loops ---------------------------------------------------------
-function optimize!(ips::AbstractInteriorPointSolver)
+function solve!(
+    solver::AbstractMadNLPSolver;
+    x = nothing, y = nothing,
+    zl = nothing, zu = nothing,
+    kwargs...)
+
+    if x != nothing
+        solver.x[1:get_nvar(solver.nlp)] .= x
+    end
+    if y != nothing
+        solver.y[1:get_nvar(solver.nlp)] .= y
+    end
+    if zl != nothing
+        solver.zl[1:get_nvar(solver.nlp)] .= zl
+    end
+    if zu != nothing
+        solver.zu[1:get_nvar(solver.nlp)] .= zu
+    end
+
+    if !isempty(kwargs)
+        @warn(solver.logger,"The options set during resolve may not have an effect")
+        set_options!(solver.opt,Dict{Symbol,Any}(),kwargs)
+    end
+    
     try
-        if ips.status == INITIAL
-            @notice(ips.logger,"This is $(introduce()), running with $(introduce(ips.linear_solver))\n")
-            print_init(ips)
-            ips.status = initialize!(ips)
+        if solver.status == INITIAL
+            @notice(solver.logger,"This is $(introduce()), running with $(introduce(solver.linear_solver))\n")
+            print_init(solver)
+            solver.status = initialize!(solver)
         else # resolving the problem
-            ips.status = reinitialize!(ips)
+            solver.status = reinitialize!(solver)
         end
 
-        while ips.status >= REGULAR
-            ips.status == REGULAR && (ips.status = regular!(ips))
-            ips.status == RESTORE && (ips.status = restore!(ips))
-            ips.status == ROBUST && (ips.status = robust!(ips))
+        while solver.status >= REGULAR
+            solver.status == REGULAR && (solver.status = regular!(solver))
+            solver.status == RESTORE && (solver.status = restore!(solver))
+            solver.status == ROBUST && (solver.status = robust!(solver))
         end
     catch e
         if e isa InvalidNumberException
-            ips.status=INVALID_NUMBER_DETECTED
+            solver.status=INVALID_NUMBER_DETECTED
         elseif e isa NotEnoughDegreesOfFreedomException
-            ips.status=NOT_ENOUGH_DEGREES_OF_FREEDOM
+            solver.status=NOT_ENOUGH_DEGREES_OF_FREEDOM
         elseif e isa LinearSolverException
-            ips.status=ERROR_IN_STEP_COMPUTATION;
-            ips.opt.rethrow_error && rethrow(e)
+            solver.status=ERROR_IN_STEP_COMPUTATION;
+            solver.opt.rethrow_error && rethrow(e)
         elseif e isa InterruptException
-            ips.status=USER_REQUESTED_STOP
-            ips.opt.rethrow_error && rethrow(e)
+            solver.status=USER_REQUESTED_STOP
+            solver.opt.rethrow_error && rethrow(e)
         else
-            ips.status=INTERNAL_ERROR
-            ips.opt.rethrow_error && rethrow(e)
+            solver.status=INTERNAL_ERROR
+            solver.opt.rethrow_error && rethrow(e)
         end
     finally
-        ips.cnt.total_time = time() - ips.cnt.start_time
-        !(ips.status < SOLVE_SUCCEEDED) && (print_summary_1(ips);print_summary_2(ips))
+        solver.cnt.total_time = time() - solver.cnt.start_time
+        !(solver.status < SOLVE_SUCCEEDED) && (print_summary_1(solver);print_summary_2(solver))
         # Unscale once the summary has been printed out
-        unscale!(ips)
-        @notice(ips.logger,"EXIT: $(STATUS_OUTPUT_DICT[ips.status])")
-        ips.opt.disable_garbage_collector &&
-            (GC.enable(true); @warn(ips.logger,"Julia garbage collector is turned back on"))
-        finalize(ips.logger)
+        unscale!(solver)
+        @notice(solver.logger,"EXIT: $(STATUS_OUTPUT_DICT[solver.status])")
+        solver.opt.disable_garbage_collector &&
+            (GC.enable(true); @warn(solver.logger,"Julia garbage collector is turned back on"))
+        finalize(solver.logger)
     end
-    return MadNLPExecutionStats(ips)
+    return MadNLPExecutionStats(solver)
 end
 
-function unscale!(ips::AbstractInteriorPointSolver)
-    ips.obj_val/=ips.obj_scale[]
-    ips.c ./= ips.con_scale
-    ips.c .-= ips.rhs
-    ips.c_slk .+= ips.x_slk
+function unscale!(solver::AbstractMadNLPSolver)
+    solver.obj_val/=solver.obj_scale[]
+    solver.c ./= solver.con_scale
+    solver.c .-= solver.rhs
+    solver.c_slk .+= solver.x_slk
 end
 
-function regular!(ips::AbstractInteriorPointSolver)
+function regular!(solver::AbstractMadNLPSolver)
     while true
-        if (ips.cnt.k!=0 && !ips.opt.jacobian_constant)
-            eval_jac_wrapper!(ips, ips.kkt, ips.x)
+        if (solver.cnt.k!=0 && !solver.opt.jacobian_constant)
+            eval_jac_wrapper!(solver, solver.kkt, solver.x)
         end
-        jtprod!(ips.jacl, ips.kkt, ips.l)
-        fixed_variable_treatment_vec!(ips.jacl,ips.ind_fixed)
-        fixed_variable_treatment_z!(ips.zl,ips.zu,ips.f,ips.jacl,ips.ind_fixed)
+        jtprod!(solver.jacl, solver.kkt, solver.y)
+        fixed_variable_treatment_vec!(solver.jacl,solver.ind_fixed)
+        fixed_variable_treatment_z!(solver.zl,solver.zu,solver.f,solver.jacl,solver.ind_fixed)
 
-        sd = get_sd(ips.l,ips.zl_r,ips.zu_r,ips.opt.s_max)
-        sc = get_sc(ips.zl_r,ips.zu_r,ips.opt.s_max)
+        sd = get_sd(solver.y,solver.zl_r,solver.zu_r,solver.opt.s_max)
+        sc = get_sc(solver.zl_r,solver.zu_r,solver.opt.s_max)
 
-        ips.inf_pr = get_inf_pr(ips.c)
-        ips.inf_du = get_inf_du(ips.f,ips.zl,ips.zu,ips.jacl,sd)
-        ips.inf_compl = get_inf_compl(ips.x_lr,ips.xl_r,ips.zl_r,ips.xu_r,ips.x_ur,ips.zu_r,0.,sc)
-        inf_compl_mu = get_inf_compl(ips.x_lr,ips.xl_r,ips.zl_r,ips.xu_r,ips.x_ur,ips.zu_r,ips.mu,sc)
+        solver.inf_pr = get_inf_pr(solver.c)
+        solver.inf_du = get_inf_du(solver.f,solver.zl,solver.zu,solver.jacl,sd)
+        solver.inf_compl = get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,0.,sc)
+        inf_compl_mu = get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,solver.mu,sc)
 
-        print_iter(ips)
+        print_iter(solver)
 
         # evaluate termination criteria
-        @trace(ips.logger,"Evaluating termination criteria.")
-        max(ips.inf_pr,ips.inf_du,ips.inf_compl) <= ips.opt.tol && return SOLVE_SUCCEEDED
-        max(ips.inf_pr,ips.inf_du,ips.inf_compl) <= ips.opt.acceptable_tol ?
-            (ips.cnt.acceptable_cnt < ips.opt.acceptable_iter ?
-            ips.cnt.acceptable_cnt+=1 : return SOLVED_TO_ACCEPTABLE_LEVEL) : (ips.cnt.acceptable_cnt = 0)
-        max(ips.inf_pr,ips.inf_du,ips.inf_compl) >= ips.opt.diverging_iterates_tol && return DIVERGING_ITERATES
-        ips.cnt.k>=ips.opt.max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
-        time()-ips.cnt.start_time>=ips.opt.max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
+        @trace(solver.logger,"Evaluating termination criteria.")
+        max(solver.inf_pr,solver.inf_du,solver.inf_compl) <= solver.opt.tol && return SOLVE_SUCCEEDED
+        max(solver.inf_pr,solver.inf_du,solver.inf_compl) <= solver.opt.acceptable_tol ?
+            (solver.cnt.acceptable_cnt < solver.opt.acceptable_iter ?
+            solver.cnt.acceptable_cnt+=1 : return SOLVED_TO_ACCEPTABLE_LEVEL) : (solver.cnt.acceptable_cnt = 0)
+        max(solver.inf_pr,solver.inf_du,solver.inf_compl) >= solver.opt.diverging_iterates_tol && return DIVERGING_ITERATES
+        solver.cnt.k>=solver.opt.max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
+        time()-solver.cnt.start_time>=solver.opt.max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
 
         # update the barrier parameter
-        @trace(ips.logger,"Updating the barrier parameter.")
-        while ips.mu != max(ips.opt.mu_min,ips.opt.tol/10) &&
-            max(ips.inf_pr,ips.inf_du,inf_compl_mu) <= ips.opt.barrier_tol_factor*ips.mu
-            mu_new = get_mu(ips.mu,ips.opt.mu_min,
-                            ips.opt.mu_linear_decrease_factor,ips.opt.mu_superlinear_decrease_power,ips.opt.tol)
-            inf_compl_mu = get_inf_compl(ips.x_lr,ips.xl_r,ips.zl_r,ips.xu_r,ips.x_ur,ips.zu_r,ips.mu,sc)
-            ips.tau= get_tau(ips.mu,ips.opt.tau_min)
-            ips.mu = mu_new
-            empty!(ips.filter)
-            push!(ips.filter,(ips.theta_max,-Inf))
+        @trace(solver.logger,"Updating the barrier parameter.")
+        while solver.mu != max(solver.opt.mu_min,solver.opt.tol/10) &&
+            max(solver.inf_pr,solver.inf_du,inf_compl_mu) <= solver.opt.barrier_tol_factor*solver.mu
+            mu_new = get_mu(solver.mu,solver.opt.mu_min,
+                            solver.opt.mu_linear_decrease_factor,solver.opt.mu_superlinear_decrease_power,solver.opt.tol)
+            inf_compl_mu = get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,solver.mu,sc)
+            solver.tau= get_tau(solver.mu,solver.opt.tau_min)
+            solver.mu = mu_new
+            empty!(solver.filter)
+            push!(solver.filter,(solver.theta_max,-Inf))
         end
 
         # compute the newton step
-        @trace(ips.logger,"Computing the newton step.")
-        if (ips.cnt.k!=0 && !ips.opt.hessian_constant)
-            eval_lag_hess_wrapper!(ips, ips.kkt, ips.x, ips.l)
+        @trace(solver.logger,"Computing the newton step.")
+        if (solver.cnt.k!=0 && !solver.opt.hessian_constant)
+            eval_lag_hess_wrapper!(solver, solver.kkt, solver.x, solver.y)
         end
 
-        set_aug_diagonal!(ips.kkt,ips)
-        set_aug_rhs!(ips, ips.kkt, ips.c)
-        if ips.opt.inertia_correction_method == INERTIA_FREE
-            set_aug_rhs_ifr!(ips, ips.kkt)
+        set_aug_diagonal!(solver.kkt,solver)
+        set_aug_rhs!(solver, solver.kkt, solver.c)
+        if solver.opt.inertia_correction_method == INERTIA_FREE
+            set_aug_rhs_ifr!(solver, solver.kkt)
         end
-        dual_inf_perturbation!(primal(ips.p),ips.ind_llb,ips.ind_uub,ips.mu,ips.opt.kappa_d)
+        dual_inf_perturbation!(primal(solver.p),solver.ind_llb,solver.ind_uub,solver.mu,solver.opt.kappa_d)
 
         # start inertia conrrection
-        @trace(ips.logger,"Solving primal-dual system.")
-        if ips.opt.inertia_correction_method == INERTIA_FREE
-            inertia_free_reg(ips) || return ROBUST
-        elseif ips.opt.inertia_correction_method == INERTIA_BASED
-            inertia_based_reg(ips) || return ROBUST
+        @trace(solver.logger,"Solving primal-dual system.")
+        if solver.opt.inertia_correction_method == INERTIA_FREE
+            inertia_free_reg(solver) || return ROBUST
+        elseif solver.opt.inertia_correction_method == INERTIA_BASED
+            inertia_based_reg(solver) || return ROBUST
         end
 
-        finish_aug_solve!(ips, ips.kkt, ips.mu)
+        finish_aug_solve!(solver, solver.kkt, solver.mu)
 
         # filter start
-        @trace(ips.logger,"Backtracking line search initiated.")
-        theta = get_theta(ips.c)
-        varphi= get_varphi(ips.obj_val,ips.x_lr,ips.xl_r,ips.xu_r,ips.x_ur,ips.mu)
-        varphi_d = get_varphi_d(ips.f,ips.x,ips.xl,ips.xu,primal(ips.d),ips.mu)
+        @trace(solver.logger,"Backtracking line search initiated.")
+        theta = get_theta(solver.c)
+        varphi= get_varphi(solver.obj_val,solver.x_lr,solver.xl_r,solver.xu_r,solver.x_ur,solver.mu)
+        varphi_d = get_varphi_d(solver.f,solver.x,solver.xl,solver.xu,primal(solver.d),solver.mu)
 
 
-        alpha_max = get_alpha_max(ips.x,ips.xl,ips.xu,primal(ips.d),ips.tau)
-        ips.alpha_z = get_alpha_z(ips.zl_r,ips.zu_r,dual_lb(ips.d),dual_ub(ips.d),ips.tau)
-        alpha_min = get_alpha_min(theta,varphi_d,ips.theta_min,ips.opt.gamma_theta,ips.opt.gamma_phi,
-                                  ips.opt.alpha_min_frac,ips.opt.delta,ips.opt.s_theta,ips.opt.s_phi)
-        ips.cnt.l = 1
-        ips.alpha = alpha_max
+        alpha_max = get_alpha_max(solver.x,solver.xl,solver.xu,primal(solver.d),solver.tau)
+        solver.alpha_z = get_alpha_z(solver.zl_r,solver.zu_r,dual_lb(solver.d),dual_ub(solver.d),solver.tau)
+        alpha_min = get_alpha_min(theta,varphi_d,solver.theta_min,solver.opt.gamma_theta,solver.opt.gamma_phi,
+                                  solver.opt.alpha_min_frac,solver.opt.delta,solver.opt.s_theta,solver.opt.s_phi)
+        solver.cnt.l = 1
+        solver.alpha = alpha_max
         varphi_trial= 0.
             theta_trial = 0.
-            small_search_norm = get_rel_search_norm(ips.x, primal(ips.d)) < 10*eps(eltype(ips.x))
-        switching_condition = is_switching(varphi_d,ips.alpha,ips.opt.s_phi,ips.opt.delta,2.,ips.opt.s_theta)
+            small_search_norm = get_rel_search_norm(solver.x, primal(solver.d)) < 10*eps(eltype(solver.x))
+        switching_condition = is_switching(varphi_d,solver.alpha,solver.opt.s_phi,solver.opt.delta,2.,solver.opt.s_theta)
         armijo_condition = false
         while true
-            copyto!(ips.x_trial, ips.x)
-            axpy!(ips.alpha, primal(ips.d), ips.x_trial)
+            copyto!(solver.x_trial, solver.x)
+            axpy!(solver.alpha, primal(solver.d), solver.x_trial)
 
-            ips.obj_val_trial = eval_f_wrapper(ips, ips.x_trial)
-            eval_cons_wrapper!(ips, ips.c_trial, ips.x_trial)
+            solver.obj_val_trial = eval_f_wrapper(solver, solver.x_trial)
+            eval_cons_wrapper!(solver, solver.c_trial, solver.x_trial)
 
-            theta_trial = get_theta(ips.c_trial)
-            varphi_trial= get_varphi(ips.obj_val_trial,ips.x_trial_lr,ips.xl_r,ips.xu_r,ips.x_trial_ur,ips.mu)
-            armijo_condition = is_armijo(varphi_trial,varphi,ips.opt.eta_phi,ips.alpha,varphi_d)
+            theta_trial = get_theta(solver.c_trial)
+            varphi_trial= get_varphi(solver.obj_val_trial,solver.x_trial_lr,solver.xl_r,solver.xu_r,solver.x_trial_ur,solver.mu)
+            armijo_condition = is_armijo(varphi_trial,varphi,solver.opt.eta_phi,solver.alpha,varphi_d)
 
             small_search_norm && break
 
-            ips.ftype = get_ftype(
-                ips.filter,theta,theta_trial,varphi,varphi_trial,switching_condition,armijo_condition,
-                ips.theta_min,ips.opt.obj_max_inc,ips.opt.gamma_theta,ips.opt.gamma_phi,
-                has_constraints(ips))
-            ips.ftype in ["f","h"] && (@trace(ips.logger,"Step accepted with type $(ips.ftype)"); break)
+            solver.ftype = get_ftype(
+                solver.filter,theta,theta_trial,varphi,varphi_trial,switching_condition,armijo_condition,
+                solver.theta_min,solver.opt.obj_max_inc,solver.opt.gamma_theta,solver.opt.gamma_phi,
+                has_constraints(solver))
+            solver.ftype in ["f","h"] && (@trace(solver.logger,"Step accepted with type $(solver.ftype)"); break)
 
-            ips.cnt.l==1 && theta_trial>=theta && second_order_correction(
-                ips,alpha_max,theta,varphi,theta_trial,varphi_d,switching_condition) && break
+            solver.cnt.l==1 && theta_trial>=theta && second_order_correction(
+                solver,alpha_max,theta,varphi,theta_trial,varphi_d,switching_condition) && break
 
-            ips.alpha /= 2
-            ips.cnt.l += 1
-            if ips.alpha < alpha_min
-                @debug(ips.logger,
-                       "Cannot find an acceptable step at iteration $(ips.cnt.k). Switching to restoration phase.")
-                ips.cnt.k+=1
+            solver.alpha /= 2
+            solver.cnt.l += 1
+            if solver.alpha < alpha_min
+                @debug(solver.logger,
+                       "Cannot find an acceptable step at iteration $(solver.cnt.k). Switching to restoration phase.")
+                solver.cnt.k+=1
                 return RESTORE
             else
-                @trace(ips.logger,"Step rejected; proceed with the next trial step.")
-                ips.alpha * norm(primal(ips.d)) < eps(eltype(ips.x))*10 &&
-                    return ips.cnt.acceptable_cnt >0 ?
+                @trace(solver.logger,"Step rejected; proceed with the next trial step.")
+                solver.alpha * norm(primal(solver.d)) < eps(eltype(solver.x))*10 &&
+                    return solver.cnt.acceptable_cnt >0 ?
                     SOLVED_TO_ACCEPTABLE_LEVEL : SEARCH_DIRECTION_BECOMES_TOO_SMALL
             end
         end
 
-        @trace(ips.logger,"Updating primal-dual variables.")
-        ips.x.=ips.x_trial
-        ips.c.=ips.c_trial
-        ips.obj_val=ips.obj_val_trial
-        adjusted = adjust_boundary!(ips.x_lr,ips.xl_r,ips.x_ur,ips.xu_r,ips.mu)
+        @trace(solver.logger,"Updating primal-dual variables.")
+        solver.x.=solver.x_trial
+        solver.c.=solver.c_trial
+        solver.obj_val=solver.obj_val_trial
+        adjusted = adjust_boundary!(solver.x_lr,solver.xl_r,solver.x_ur,solver.xu_r,solver.mu)
         adjusted > 0 &&
-            @warn(ips.logger,"In iteration $(ips.cnt.k), $adjusted Slack too small, adjusting variable bound")
+            @warn(solver.logger,"In iteration $(solver.cnt.k), $adjusted Slack too small, adjusting variable bound")
 
-        axpy!(ips.alpha,dual(ips.d),ips.l)
-        axpy!(ips.alpha_z, dual_lb(ips.d), ips.zl_r)
-        axpy!(ips.alpha_z, dual_ub(ips.d), ips.zu_r)
-        reset_bound_dual!(ips.zl,ips.x,ips.xl,ips.mu,ips.opt.kappa_sigma)
-        reset_bound_dual!(ips.zu,ips.xu,ips.x,ips.mu,ips.opt.kappa_sigma)
-        eval_grad_f_wrapper!(ips, ips.f,ips.x)
+        axpy!(solver.alpha,dual(solver.d),solver.y)
+        axpy!(solver.alpha_z, dual_lb(solver.d), solver.zl_r)
+        axpy!(solver.alpha_z, dual_ub(solver.d), solver.zu_r)
+        reset_bound_dual!(solver.zl,solver.x,solver.xl,solver.mu,solver.opt.kappa_sigma)
+        reset_bound_dual!(solver.zu,solver.xu,solver.x,solver.mu,solver.opt.kappa_sigma)
+        eval_grad_f_wrapper!(solver, solver.f,solver.x)
 
         if !switching_condition || !armijo_condition
-            @trace(ips.logger,"Augmenting filter.")
-            augment_filter!(ips.filter,theta_trial,varphi_trial,ips.opt.gamma_theta)
+            @trace(solver.logger,"Augmenting filter.")
+            augment_filter!(solver.filter,theta_trial,varphi_trial,solver.opt.gamma_theta)
         end
 
-        ips.cnt.k+=1
-        @trace(ips.logger,"Proceeding to the next interior point iteration.")
+        solver.cnt.k+=1
+        @trace(solver.logger,"Proceeding to the next interior point iteration.")
     end
 end
 
-function restore!(ips::AbstractInteriorPointSolver)
-    ips.del_w=0
-    primal(ips._w1) .= ips.x # backup the previous primal iterate
-    dual(ips._w1) .= ips.l # backup the previous primal iterate
-    dual(ips._w2) .= ips.c # backup the previous primal iterate
+function restore!(solver::AbstractMadNLPSolver)
+    solver.del_w=0
+    primal(solver._w1) .= solver.x # backup the previous primal iterate
+    dual(solver._w1) .= solver.y # backup the previous primal iterate
+    dual(solver._w2) .= solver.c # backup the previous primal iterate
 
-    F = get_F(ips.c,ips.f,ips.zl,ips.zu,ips.jacl,ips.x_lr,ips.xl_r,ips.zl_r,ips.xu_r,ips.x_ur,ips.zu_r,ips.mu)
-    ips.cnt.t = 0
-    ips.alpha_z = 0.
-    ips.ftype = "R"
+    F = get_F(solver.c,solver.f,solver.zl,solver.zu,solver.jacl,solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,solver.mu)
+    solver.cnt.t = 0
+    solver.alpha_z = 0.
+    solver.ftype = "R"
 
     while true
-        ips.alpha = min(get_alpha_max(ips.x,ips.xl,ips.xu,primal(ips.d),ips.tau),
-                        get_alpha_z(ips.zl_r,ips.zu_r,dual_lb(ips.d),dual_ub(ips.d),ips.tau))
+        solver.alpha = min(get_alpha_max(solver.x,solver.xl,solver.xu,primal(solver.d),solver.tau),
+                        get_alpha_z(solver.zl_r,solver.zu_r,dual_lb(solver.d),dual_ub(solver.d),solver.tau))
 
-        ips.x .+= ips.alpha.* primal(ips.d)
-        ips.l .+= ips.alpha.* dual(ips.d)
-        ips.zl_r.+=ips.alpha.* dual_lb(ips.d)
-        ips.zu_r.+=ips.alpha.* dual_ub(ips.d)
+        solver.x .+= solver.alpha.* primal(solver.d)
+        solver.y .+= solver.alpha.* dual(solver.d)
+        solver.zl_r.+=solver.alpha.* dual_lb(solver.d)
+        solver.zu_r.+=solver.alpha.* dual_ub(solver.d)
 
-        eval_cons_wrapper!(ips,ips.c,ips.x)
-        eval_grad_f_wrapper!(ips,ips.f,ips.x)
-        ips.obj_val = eval_f_wrapper(ips,ips.x)
+        eval_cons_wrapper!(solver,solver.c,solver.x)
+        eval_grad_f_wrapper!(solver,solver.f,solver.x)
+        solver.obj_val = eval_f_wrapper(solver,solver.x)
 
-        !ips.opt.jacobian_constant && eval_jac_wrapper!(ips,ips.kkt,ips.x)
-        jtprod!(ips.jacl,ips.kkt,ips.l)
+        !solver.opt.jacobian_constant && eval_jac_wrapper!(solver,solver.kkt,solver.x)
+        jtprod!(solver.jacl,solver.kkt,solver.y)
 
         F_trial = get_F(
-            ips.c,ips.f,ips.zl,ips.zu,ips.jacl,ips.x_lr,ips.xl_r,ips.zl_r,ips.xu_r,ips.x_ur,ips.zu_r,ips.mu)
-        if F_trial > ips.opt.soft_resto_pderror_reduction_factor*F
-            ips.x .= primal(ips._w1)
-            ips.l .= dual(ips._w1)
-            ips.c .= dual(ips._w2) # backup the previous primal iterate
+            solver.c,solver.f,solver.zl,solver.zu,solver.jacl,solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,solver.mu)
+        if F_trial > solver.opt.soft_resto_pderror_reduction_factor*F
+            solver.x .= primal(solver._w1)
+            solver.y .= dual(solver._w1)
+            solver.c .= dual(solver._w2) # backup the previous primal iterate
             return ROBUST
         end
 
-        adjusted = adjust_boundary!(ips.x_lr,ips.xl_r,ips.x_ur,ips.xu_r,ips.mu)
+        adjusted = adjust_boundary!(solver.x_lr,solver.xl_r,solver.x_ur,solver.xu_r,solver.mu)
         adjusted > 0 &&
-            @warn(ips.logger,"In iteration $(ips.cnt.k), $adjusted Slack too small, adjusting variable bound")
+            @warn(solver.logger,"In iteration $(solver.cnt.k), $adjusted Slack too small, adjusting variable bound")
 
 
         F = F_trial
 
-        theta = get_theta(ips.c)
-        varphi= get_varphi(ips.obj_val,ips.x_lr,ips.xl_r,ips.xu_r,ips.x_ur,ips.mu)
+        theta = get_theta(solver.c)
+        varphi= get_varphi(solver.obj_val,solver.x_lr,solver.xl_r,solver.xu_r,solver.x_ur,solver.mu)
 
-        ips.cnt.k+=1
+        solver.cnt.k+=1
 
-        is_filter_acceptable(ips.filter,theta,varphi) ? (return REGULAR) : (ips.cnt.t+=1)
-        ips.cnt.k>=ips.opt.max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
-        time()-ips.cnt.start_time>=ips.opt.max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
+        is_filter_acceptable(solver.filter,theta,varphi) ? (return REGULAR) : (solver.cnt.t+=1)
+        solver.cnt.k>=solver.opt.max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
+        time()-solver.cnt.start_time>=solver.opt.max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
 
 
-        sd = get_sd(ips.l,ips.zl_r,ips.zu_r,ips.opt.s_max)
-        sc = get_sc(ips.zl_r,ips.zu_r,ips.opt.s_max)
-        ips.inf_pr = get_inf_pr(ips.c)
-        ips.inf_du = get_inf_du(ips.f,ips.zl,ips.zu,ips.jacl,sd)
+        sd = get_sd(solver.y,solver.zl_r,solver.zu_r,solver.opt.s_max)
+        sc = get_sc(solver.zl_r,solver.zu_r,solver.opt.s_max)
+        solver.inf_pr = get_inf_pr(solver.c)
+        solver.inf_du = get_inf_du(solver.f,solver.zl,solver.zu,solver.jacl,sd)
 
-        ips.inf_compl = get_inf_compl(ips.x_lr,ips.xl_r,ips.zl_r,ips.xu_r,ips.x_ur,ips.zu_r,0.,sc)
-        inf_compl_mu = get_inf_compl(ips.x_lr,ips.xl_r,ips.zl_r,ips.xu_r,ips.x_ur,ips.zu_r,ips.mu,sc)
-        print_iter(ips)
+        solver.inf_compl = get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,0.,sc)
+        inf_compl_mu = get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,solver.mu,sc)
+        print_iter(solver)
 
-        !ips.opt.hessian_constant && eval_lag_hess_wrapper!(ips,ips.kkt,ips.x,ips.l)
-        set_aug_diagonal!(ips.kkt,ips)
-        set_aug_rhs!(ips, ips.kkt, ips.c)
+        !solver.opt.hessian_constant && eval_lag_hess_wrapper!(solver,solver.kkt,solver.x,solver.y)
+        set_aug_diagonal!(solver.kkt,solver)
+        set_aug_rhs!(solver, solver.kkt, solver.c)
 
-        dual_inf_perturbation!(primal(ips.p),ips.ind_llb,ips.ind_uub,ips.mu,ips.opt.kappa_d)
-        factorize_wrapper!(ips)
-        solve_refine_wrapper!(ips,ips.d,ips.p)
-        finish_aug_solve!(ips, ips.kkt, ips.mu)
+        dual_inf_perturbation!(primal(solver.p),solver.ind_llb,solver.ind_uub,solver.mu,solver.opt.kappa_d)
+        factorize_wrapper!(solver)
+        solve_refine_wrapper!(solver,solver.d,solver.p)
+        finish_aug_solve!(solver, solver.kkt, solver.mu)
 
-        ips.ftype = "f"
+        solver.ftype = "f"
     end
 end
 
-function robust!(ips::InteriorPointSolver)
-    initialize_robust_restorer!(ips)
-    RR = ips.RR
+function robust!(solver::MadNLPSolver)
+    initialize_robust_restorer!(solver)
+    RR = solver.RR
     while true
-        if !ips.opt.jacobian_constant
-            eval_jac_wrapper!(ips, ips.kkt, ips.x)
+        if !solver.opt.jacobian_constant
+            eval_jac_wrapper!(solver, solver.kkt, solver.x)
         end
-        jtprod!(ips.jacl, ips.kkt, ips.l)
-        fixed_variable_treatment_vec!(ips.jacl,ips.ind_fixed)
-        fixed_variable_treatment_z!(ips.zl,ips.zu,ips.f,ips.jacl,ips.ind_fixed)
+        jtprod!(solver.jacl, solver.kkt, solver.y)
+        fixed_variable_treatment_vec!(solver.jacl,solver.ind_fixed)
+        fixed_variable_treatment_z!(solver.zl,solver.zu,solver.f,solver.jacl,solver.ind_fixed)
 
         # evaluate termination criteria
-        @trace(ips.logger,"Evaluating restoration phase termination criteria.")
-        sd = get_sd(ips.l,ips.zl_r,ips.zu_r,ips.opt.s_max)
-        sc = get_sc(ips.zl_r,ips.zu_r,ips.opt.s_max)
-        ips.inf_pr = get_inf_pr(ips.c)
-        ips.inf_du = get_inf_du(ips.f,ips.zl,ips.zu,ips.jacl,sd)
-        ips.inf_compl = get_inf_compl(ips.x_lr,ips.xl_r,ips.zl_r,ips.xu_r,ips.x_ur,ips.zu_r,0.,sc)
+        @trace(solver.logger,"Evaluating restoration phase termination criteria.")
+        sd = get_sd(solver.y,solver.zl_r,solver.zu_r,solver.opt.s_max)
+        sc = get_sc(solver.zl_r,solver.zu_r,solver.opt.s_max)
+        solver.inf_pr = get_inf_pr(solver.c)
+        solver.inf_du = get_inf_du(solver.f,solver.zl,solver.zu,solver.jacl,sd)
+        solver.inf_compl = get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,0.,sc)
 
         # Robust restoration phase error
-        RR.inf_pr_R = get_inf_pr_R(ips.c,RR.pp,RR.nn)
-        RR.inf_du_R = get_inf_du_R(RR.f_R,ips.l,ips.zl,ips.zu,ips.jacl,RR.zp,RR.zn,ips.opt.rho,sd)
+        RR.inf_pr_R = get_inf_pr_R(solver.c,RR.pp,RR.nn)
+        RR.inf_du_R = get_inf_du_R(RR.f_R,solver.y,solver.zl,solver.zu,solver.jacl,RR.zp,RR.zn,solver.opt.rho,sd)
         RR.inf_compl_R = get_inf_compl_R(
-            ips.x_lr,ips.xl_r,ips.zl_r,ips.xu_r,ips.x_ur,ips.zu_r,RR.pp,RR.zp,RR.nn,RR.zn,0.,sc)
+            solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,RR.pp,RR.zp,RR.nn,RR.zn,0.,sc)
         inf_compl_mu_R = get_inf_compl_R(
-            ips.x_lr,ips.xl_r,ips.zl_r,ips.xu_r,ips.x_ur,ips.zu_r,RR.pp,RR.zp,RR.nn,RR.zn,RR.mu_R,sc)
+            solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,RR.pp,RR.zp,RR.nn,RR.zn,RR.mu_R,sc)
 
-        print_iter(ips;is_resto=true)
+        print_iter(solver;is_resto=true)
 
-        max(RR.inf_pr_R,RR.inf_du_R,RR.inf_compl_R) <= ips.opt.tol && return INFEASIBLE_PROBLEM_DETECTED
-        ips.cnt.k>=ips.opt.max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
-        time()-ips.cnt.start_time>=ips.opt.max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
+        max(RR.inf_pr_R,RR.inf_du_R,RR.inf_compl_R) <= solver.opt.tol && return INFEASIBLE_PROBLEM_DETECTED
+        solver.cnt.k>=solver.opt.max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
+        time()-solver.cnt.start_time>=solver.opt.max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
 
 
         # update the barrier parameter
-        @trace(ips.logger,"Updating restoration phase barrier parameter.")
-        while RR.mu_R != ips.opt.mu_min*100 &&
-            max(RR.inf_pr_R,RR.inf_du_R,inf_compl_mu_R) <= ips.opt.barrier_tol_factor*RR.mu_R
-            RR.mu_R = get_mu(RR.mu_R,ips.opt.mu_min,
-                            ips.opt.mu_linear_decrease_factor,ips.opt.mu_superlinear_decrease_power,ips.opt.tol)
+        @trace(solver.logger,"Updating restoration phase barrier parameter.")
+        while RR.mu_R != solver.opt.mu_min*100 &&
+            max(RR.inf_pr_R,RR.inf_du_R,inf_compl_mu_R) <= solver.opt.barrier_tol_factor*RR.mu_R
+            RR.mu_R = get_mu(RR.mu_R,solver.opt.mu_min,
+                            solver.opt.mu_linear_decrease_factor,solver.opt.mu_superlinear_decrease_power,solver.opt.tol)
             inf_compl_mu_R = get_inf_compl_R(
-                ips.x_lr,ips.xl_r,ips.zl_r,ips.xu_r,ips.x_ur,ips.zu_r,RR.pp,RR.zp,RR.nn,RR.zn,RR.mu_R,sc)
-            RR.tau_R= max(ips.opt.tau_min,1-RR.mu_R)
+                solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,RR.pp,RR.zp,RR.nn,RR.zn,RR.mu_R,sc)
+            RR.tau_R= max(solver.opt.tau_min,1-RR.mu_R)
             RR.zeta = sqrt(RR.mu_R)
 
             empty!(RR.filter)
-            push!(RR.filter,(ips.theta_max,-Inf))
+            push!(RR.filter,(solver.theta_max,-Inf))
         end
 
         # compute the newton step
-        if !ips.opt.hessian_constant
-            eval_lag_hess_wrapper!(ips, ips.kkt, ips.x, ips.l; is_resto=true)
+        if !solver.opt.hessian_constant
+            eval_lag_hess_wrapper!(solver, solver.kkt, solver.x, solver.y; is_resto=true)
         end
-        set_aug_RR!(ips.kkt, ips, RR)
-        set_aug_rhs_RR!(ips, ips.kkt, RR, ips.opt.rho)
+        set_aug_RR!(solver.kkt, solver, RR)
+        set_aug_rhs_RR!(solver, solver.kkt, RR, solver.opt.rho)
 
         # without inertia correction,
-        @trace(ips.logger,"Solving restoration phase primal-dual system.")
-        factorize_wrapper!(ips)
-        solve_refine_wrapper!(ips,ips.d,ips.p)
+        @trace(solver.logger,"Solving restoration phase primal-dual system.")
+        factorize_wrapper!(solver)
+        solve_refine_wrapper!(solver,solver.d,solver.p)
 
-        finish_aug_solve!(ips, ips.kkt, RR.mu_R)
-        finish_aug_solve_RR!(RR.dpp,RR.dnn,RR.dzp,RR.dzn,ips.l,dual(ips.d),RR.pp,RR.nn,RR.zp,RR.zn,RR.mu_R,ips.opt.rho)
+        finish_aug_solve!(solver, solver.kkt, RR.mu_R)
+        finish_aug_solve_RR!(RR.dpp,RR.dnn,RR.dzp,RR.dzn,solver.y,dual(solver.d),RR.pp,RR.nn,RR.zp,RR.zn,RR.mu_R,solver.opt.rho)
 
 
-        theta_R = get_theta_R(ips.c,RR.pp,RR.nn)
-        varphi_R = get_varphi_R(RR.obj_val_R,ips.x_lr,ips.xl_r,ips.xu_r,ips.x_ur,RR.pp,RR.nn,RR.mu_R)
-        varphi_d_R = get_varphi_d_R(RR.f_R,ips.x,ips.xl,ips.xu,primal(ips.d),RR.pp,RR.nn,RR.dpp,RR.dnn,RR.mu_R,ips.opt.rho)
+        theta_R = get_theta_R(solver.c,RR.pp,RR.nn)
+        varphi_R = get_varphi_R(RR.obj_val_R,solver.x_lr,solver.xl_r,solver.xu_r,solver.x_ur,RR.pp,RR.nn,RR.mu_R)
+        varphi_d_R = get_varphi_d_R(RR.f_R,solver.x,solver.xl,solver.xu,primal(solver.d),RR.pp,RR.nn,RR.dpp,RR.dnn,RR.mu_R,solver.opt.rho)
 
         # set alpha_min
-        alpha_max = get_alpha_max_R(ips.x,ips.xl,ips.xu,primal(ips.d),RR.pp,RR.dpp,RR.nn,RR.dnn,RR.tau_R)
-        ips.alpha_z = get_alpha_z_R(ips.zl_r,ips.zu_r,dual_lb(ips.d),dual_ub(ips.d),RR.zp,RR.dzp,RR.zn,RR.dzn,RR.tau_R)
-        alpha_min = get_alpha_min(theta_R,varphi_d_R,ips.theta_min,ips.opt.gamma_theta,ips.opt.gamma_phi,
-                                  ips.opt.alpha_min_frac,ips.opt.delta,ips.opt.s_theta,ips.opt.s_phi)
+        alpha_max = get_alpha_max_R(solver.x,solver.xl,solver.xu,primal(solver.d),RR.pp,RR.dpp,RR.nn,RR.dnn,RR.tau_R)
+        solver.alpha_z = get_alpha_z_R(solver.zl_r,solver.zu_r,dual_lb(solver.d),dual_ub(solver.d),RR.zp,RR.dzp,RR.zn,RR.dzn,RR.tau_R)
+        alpha_min = get_alpha_min(theta_R,varphi_d_R,solver.theta_min,solver.opt.gamma_theta,solver.opt.gamma_phi,
+                                  solver.opt.alpha_min_frac,solver.opt.delta,solver.opt.s_theta,solver.opt.s_phi)
 
         # filter start
-        @trace(ips.logger,"Backtracking line search initiated.")
-        ips.alpha = alpha_max
-        ips.cnt.l = 1
+        @trace(solver.logger,"Backtracking line search initiated.")
+        solver.alpha = alpha_max
+        solver.cnt.l = 1
         theta_R_trial = 0.
         varphi_R_trial = 0.
-        small_search_norm = get_rel_search_norm(ips.x, primal(ips.d)) < 10*eps(eltype(ips.x))
-        switching_condition = is_switching(varphi_d_R,ips.alpha,ips.opt.s_phi,ips.opt.delta,theta_R,ips.opt.s_theta)
+        small_search_norm = get_rel_search_norm(solver.x, primal(solver.d)) < 10*eps(eltype(solver.x))
+        switching_condition = is_switching(varphi_d_R,solver.alpha,solver.opt.s_phi,solver.opt.delta,theta_R,solver.opt.s_theta)
         armijo_condition = false
 
         while true
-            copyto!(ips.x_trial,ips.x)
+            copyto!(solver.x_trial,solver.x)
             copyto!(RR.pp_trial,RR.pp)
             copyto!(RR.nn_trial,RR.nn)
-            axpy!(ips.alpha,primal(ips.d),ips.x_trial)
-            axpy!(ips.alpha,RR.dpp,RR.pp_trial)
-            axpy!(ips.alpha,RR.dnn,RR.nn_trial)
+            axpy!(solver.alpha,primal(solver.d),solver.x_trial)
+            axpy!(solver.alpha,RR.dpp,RR.pp_trial)
+            axpy!(solver.alpha,RR.dnn,RR.nn_trial)
 
             RR.obj_val_R_trial = get_obj_val_R(
-                RR.pp_trial,RR.nn_trial,RR.D_R,ips.x_trial,RR.x_ref,ips.opt.rho,RR.zeta)
-            eval_cons_wrapper!(ips, ips.c_trial, ips.x_trial)
-            theta_R_trial  = get_theta_R(ips.c_trial,RR.pp_trial,RR.nn_trial)
+                RR.pp_trial,RR.nn_trial,RR.D_R,solver.x_trial,RR.x_ref,solver.opt.rho,RR.zeta)
+            eval_cons_wrapper!(solver, solver.c_trial, solver.x_trial)
+            theta_R_trial  = get_theta_R(solver.c_trial,RR.pp_trial,RR.nn_trial)
             varphi_R_trial = get_varphi_R(
-                RR.obj_val_R_trial,ips.x_trial_lr,ips.xl_r,ips.xu_r,ips.x_trial_ur,RR.pp_trial,RR.nn_trial,RR.mu_R)
+                RR.obj_val_R_trial,solver.x_trial_lr,solver.xl_r,solver.xu_r,solver.x_trial_ur,RR.pp_trial,RR.nn_trial,RR.mu_R)
 
-            armijo_condition = is_armijo(varphi_R_trial,varphi_R,0.,ips.alpha,varphi_d_R) #####
+            armijo_condition = is_armijo(varphi_R_trial,varphi_R,0.,solver.alpha,varphi_d_R) #####
 
             small_search_norm && break
-            ips.ftype = get_ftype(
+            solver.ftype = get_ftype(
                 RR.filter,theta_R,theta_R_trial,varphi_R,varphi_R_trial,
                 switching_condition,armijo_condition,
-                ips.theta_min,ips.opt.obj_max_inc,ips.opt.gamma_theta,ips.opt.gamma_phi,
-                has_constraints(ips))
-            ips.ftype in ["f","h"] && (@trace(ips.logger,"Step accepted with type $(ips.ftype)"); break)
+                solver.theta_min,solver.opt.obj_max_inc,solver.opt.gamma_theta,solver.opt.gamma_phi,
+                has_constraints(solver))
+            solver.ftype in ["f","h"] && (@trace(solver.logger,"Step accepted with type $(solver.ftype)"); break)
 
-            ips.alpha /= 2
-            ips.cnt.l += 1
-            if ips.alpha < alpha_min
-                @debug(ips.logger,"Restoration phase cannot find an acceptable step at iteration $(ips.cnt.k).")
+            solver.alpha /= 2
+            solver.cnt.l += 1
+            if solver.alpha < alpha_min
+                @debug(solver.logger,"Restoration phase cannot find an acceptable step at iteration $(solver.cnt.k).")
                 return RESTORATION_FAILED
             else
-                @trace(ips.logger,"Step rejected; proceed with the next trial step.")
-                ips.alpha < eps(eltype(ips.x))*10 && return ips.cnt.acceptable_cnt >0 ?
+                @trace(solver.logger,"Step rejected; proceed with the next trial step.")
+                solver.alpha < eps(eltype(solver.x))*10 && return solver.cnt.acceptable_cnt >0 ?
                     SOLVED_TO_ACCEPTABLE_LEVEL : SEARCH_DIRECTION_BECOMES_TOO_SMALL
             end
         end
 
-        @trace(ips.logger,"Updating primal-dual variables.")
-        ips.x.=ips.x_trial
-        ips.c.=ips.c_trial
+        @trace(solver.logger,"Updating primal-dual variables.")
+        solver.x.=solver.x_trial
+        solver.c.=solver.c_trial
         RR.pp.=RR.pp_trial
         RR.nn.=RR.nn_trial
 
         RR.obj_val_R=RR.obj_val_R_trial
-        RR.f_R .= RR.zeta.*RR.D_R.^2 .*(ips.x.-RR.x_ref)
+        RR.f_R .= RR.zeta.*RR.D_R.^2 .*(solver.x.-RR.x_ref)
 
-        axpy!(ips.alpha, dual(ips.d), ips.l)
-        axpy!(ips.alpha_z, dual_lb(ips.d),ips.zl_r)
-        axpy!(ips.alpha_z, dual_ub(ips.d),ips.zu_r)
-        axpy!(ips.alpha_z, RR.dzp,RR.zp)
-        axpy!(ips.alpha_z, RR.dzn,RR.zn)
+        axpy!(solver.alpha, dual(solver.d), solver.y)
+        axpy!(solver.alpha_z, dual_lb(solver.d),solver.zl_r)
+        axpy!(solver.alpha_z, dual_ub(solver.d),solver.zu_r)
+        axpy!(solver.alpha_z, RR.dzp,RR.zp)
+        axpy!(solver.alpha_z, RR.dzn,RR.zn)
 
-        reset_bound_dual!(ips.zl,ips.x,ips.xl,RR.mu_R,ips.opt.kappa_sigma)
-        reset_bound_dual!(ips.zu,ips.xu,ips.x,RR.mu_R,ips.opt.kappa_sigma)
-        reset_bound_dual!(RR.zp,RR.pp,RR.mu_R,ips.opt.kappa_sigma)
-        reset_bound_dual!(RR.zn,RR.nn,RR.mu_R,ips.opt.kappa_sigma)
+        reset_bound_dual!(solver.zl,solver.x,solver.xl,RR.mu_R,solver.opt.kappa_sigma)
+        reset_bound_dual!(solver.zu,solver.xu,solver.x,RR.mu_R,solver.opt.kappa_sigma)
+        reset_bound_dual!(RR.zp,RR.pp,RR.mu_R,solver.opt.kappa_sigma)
+        reset_bound_dual!(RR.zn,RR.nn,RR.mu_R,solver.opt.kappa_sigma)
 
-        adjusted = adjust_boundary!(ips.x_lr,ips.xl_r,ips.x_ur,ips.xu_r,ips.mu)
+        adjusted = adjust_boundary!(solver.x_lr,solver.xl_r,solver.x_ur,solver.xu_r,solver.mu)
         adjusted > 0 &&
-            @warn(ips.logger,"In iteration $(ips.cnt.k), $adjusted Slack too small, adjusting variable bound")
+            @warn(solver.logger,"In iteration $(solver.cnt.k), $adjusted Slack too small, adjusting variable bound")
 
         if !switching_condition || !armijo_condition
-            @trace(ips.logger,"Augmenting restoration phase filter.")
-            augment_filter!(RR.filter,theta_R_trial,varphi_R_trial,ips.opt.gamma_theta)
+            @trace(solver.logger,"Augmenting restoration phase filter.")
+            augment_filter!(RR.filter,theta_R_trial,varphi_R_trial,solver.opt.gamma_theta)
         end
 
         # check if going back to regular phase
-        @trace(ips.logger,"Checking if going back to regular phase.")
-        ips.obj_val = eval_f_wrapper(ips, ips.x)
-        eval_grad_f_wrapper!(ips, ips.f, ips.x)
-        theta = get_theta(ips.c)
-        varphi= get_varphi(ips.obj_val,ips.x_lr,ips.xl_r,ips.xu_r,ips.x_ur,ips.mu)
+        @trace(solver.logger,"Checking if going back to regular phase.")
+        solver.obj_val = eval_f_wrapper(solver, solver.x)
+        eval_grad_f_wrapper!(solver, solver.f, solver.x)
+        theta = get_theta(solver.c)
+        varphi= get_varphi(solver.obj_val,solver.x_lr,solver.xl_r,solver.xu_r,solver.x_ur,solver.mu)
 
-        if is_filter_acceptable(ips.filter,theta,varphi) &&
-            theta <= ips.opt.required_infeasibility_reduction * RR.theta_ref
+        if is_filter_acceptable(solver.filter,theta,varphi) &&
+            theta <= solver.opt.required_infeasibility_reduction * RR.theta_ref
 
-            @trace(ips.logger,"Going back to the regular phase.")
-            ips.zl_r.=1
-            ips.zu_r.=1
+            @trace(solver.logger,"Going back to the regular phase.")
+            solver.zl_r.=1
+            solver.zu_r.=1
 
-            set_initial_rhs!(ips, ips.kkt)
-            initialize!(ips.kkt)
+            set_initial_rhs!(solver, solver.kkt)
+            initialize!(solver.kkt)
 
-            factorize_wrapper!(ips)
-            solve_refine_wrapper!(ips,ips.d,ips.p)
-            if norm(dual(ips.d), Inf)>ips.opt.constr_mult_init_max
-                fill!(ips.l, 0.0)
+            factorize_wrapper!(solver)
+            solve_refine_wrapper!(solver,solver.d,solver.p)
+            if norm(dual(solver.d), Inf)>solver.opt.constr_mult_init_max
+                fill!(solver.y, 0.0)
             else
-                copyto!(ips.l, dual(ips.d))
+                copyto!(solver.y, dual(solver.d))
             end
-            ips.cnt.k+=1
+            solver.cnt.k+=1
 
             return REGULAR
         end
 
-        ips.cnt.k>=ips.opt.max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
-        time()-ips.cnt.start_time>=ips.opt.max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
+        solver.cnt.k>=solver.opt.max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
+        time()-solver.cnt.start_time>=solver.opt.max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
 
-        @trace(ips.logger,"Proceeding to the next restoration phase iteration.")
-        ips.cnt.k+=1
-        ips.cnt.t+=1
+        @trace(solver.logger,"Proceeding to the next restoration phase iteration.")
+        solver.cnt.k+=1
+        solver.cnt.t+=1
     end
 end
 
-function inertia_based_reg(ips::InteriorPointSolver)
-    @trace(ips.logger,"Inertia-based regularization started.")
+function inertia_based_reg(solver::MadNLPSolver)
+    @trace(solver.logger,"Inertia-based regularization started.")
 
-    factorize_wrapper!(ips)
-    num_pos,num_zero,num_neg = inertia(ips.linear_solver)
-    solve_status = num_zero!= 0 ? false : solve_refine_wrapper!(ips,ips.d,ips.p)
+    factorize_wrapper!(solver)
+    num_pos,num_zero,num_neg = inertia(solver.linear_solver)
+    solve_status = num_zero!= 0 ? false : solve_refine_wrapper!(solver,solver.d,solver.p)
 
     n_trial = 0
-    ips.del_w = del_w_prev = 0.0
-    while !is_inertia_correct(ips.kkt, num_pos, num_zero, num_neg) || !solve_status
-        @debug(ips.logger,"Primal-dual perturbed.")
-        if ips.del_w == 0.0
-            ips.del_w = ips.del_w_last==0. ? ips.opt.first_hessian_perturbation :
-                max(ips.opt.min_hessian_perturbation,ips.opt.perturb_dec_fact*ips.del_w_last)
+    solver.del_w = del_w_prev = 0.0
+    while !is_inertia_correct(solver.kkt, num_pos, num_zero, num_neg) || !solve_status
+        @debug(solver.logger,"Primal-dual perturbed.")
+        if solver.del_w == 0.0
+            solver.del_w = solver.del_w_last==0. ? solver.opt.first_hessian_perturbation :
+                max(solver.opt.min_hessian_perturbation,solver.opt.perturb_dec_fact*solver.del_w_last)
         else
-            ips.del_w*= ips.del_w_last==0. ? ips.opt.perturb_inc_fact_first : ips.opt.perturb_inc_fact
-            if ips.del_w>ips.opt.max_hessian_perturbation ips.cnt.k+=1
-                @debug(ips.logger,"Primal regularization is too big. Switching to restoration phase.")
+            solver.del_w*= solver.del_w_last==0. ? solver.opt.perturb_inc_fact_first : solver.opt.perturb_inc_fact
+            if solver.del_w>solver.opt.max_hessian_perturbation solver.cnt.k+=1
+                @debug(solver.logger,"Primal regularization is too big. Switching to restoration phase.")
                 return false
             end
         end
-        ips.del_c = (num_zero == 0 || !solve_status) ?
-            ips.opt.jacobian_regularization_value * ips.mu^(ips.opt.jacobian_regularization_exponent) : 0.
-        regularize_diagonal!(ips.kkt, ips.del_w - del_w_prev, ips.del_c)
-        del_w_prev = ips.del_w
+        solver.del_c = (num_zero == 0 || !solve_status) ?
+            solver.opt.jacobian_regularization_value * solver.mu^(solver.opt.jacobian_regularization_exponent) : 0.
+        regularize_diagonal!(solver.kkt, solver.del_w - del_w_prev, solver.del_c)
+        del_w_prev = solver.del_w
 
-        factorize_wrapper!(ips)
-        num_pos,num_zero,num_neg = inertia(ips.linear_solver)
-        solve_status = num_zero!= 0 ? false : solve_refine_wrapper!(ips,ips.d,ips.p)
+        factorize_wrapper!(solver)
+        num_pos,num_zero,num_neg = inertia(solver.linear_solver)
+        solve_status = num_zero!= 0 ? false : solve_refine_wrapper!(solver,solver.d,solver.p)
         n_trial += 1
     end
-    ips.del_w != 0 && (ips.del_w_last = ips.del_w)
+    solver.del_w != 0 && (solver.del_w_last = solver.del_w)
 
     return true
 end
 
-function inertia_free_reg(ips::InteriorPointSolver)
+function inertia_free_reg(solver::MadNLPSolver)
 
-    @trace(ips.logger,"Inertia-free regularization started.")
-    p0 = ips._w1
-    d0 = ips._w2
-    t = primal(ips._w3)
-    n = primal(ips._w2)
-    wx= primal(ips._w4)
-    fill!(dual(ips._w3), 0)
+    @trace(solver.logger,"Inertia-free regularization started.")
+    p0 = solver._w1
+    d0 = solver._w2
+    t = primal(solver._w3)
+    n = primal(solver._w2)
+    wx= primal(solver._w4)
+    fill!(dual(solver._w3), 0)
 
-    g = ips.x_trial # just to avoid new allocation
-    g .= ips.f.-ips.mu./(ips.x.-ips.xl).+ips.mu./(ips.xu.-ips.x).+ips.jacl
+    g = solver.x_trial # just to avoid new allocation
+    g .= solver.f.-solver.mu./(solver.x.-solver.xl).+solver.mu./(solver.xu.-solver.x).+solver.jacl
 
-    fixed_variable_treatment_vec!(primal(ips._w1), ips.ind_fixed)
-    fixed_variable_treatment_vec!(primal(ips.p),   ips.ind_fixed)
-    fixed_variable_treatment_vec!(g, ips.ind_fixed)
+    fixed_variable_treatment_vec!(primal(solver._w1), solver.ind_fixed)
+    fixed_variable_treatment_vec!(primal(solver.p),   solver.ind_fixed)
+    fixed_variable_treatment_vec!(g, solver.ind_fixed)
 
-    factorize_wrapper!(ips)
-    solve_status = (solve_refine_wrapper!(ips,d0,p0) && solve_refine_wrapper!(ips,ips.d,ips.p))
-    t .= primal(ips.d) .- n
-    mul!(ips._w4, ips.kkt, ips._w3) # prepartation for curv_test
+    factorize_wrapper!(solver)
+    solve_status = (solve_refine_wrapper!(solver,d0,p0) && solve_refine_wrapper!(solver,solver.d,solver.p))
+    t .= primal(solver.d) .- n
+    mul!(solver._w4, solver.kkt, solver._w3) # prepartation for curv_test
     n_trial = 0
-    ips.del_w = del_w_prev = 0.
+    solver.del_w = del_w_prev = 0.
 
-    while !curv_test(t,n,g,wx,ips.opt.inertia_free_tol)  || !solve_status
-        @debug(ips.logger,"Primal-dual perturbed.")
+    while !curv_test(t,n,g,wx,solver.opt.inertia_free_tol)  || !solve_status
+        @debug(solver.logger,"Primal-dual perturbed.")
         if n_trial == 0
-            ips.del_w = ips.del_w_last==.0 ? ips.opt.first_hessian_perturbation :
-                max(ips.opt.min_hessian_perturbation,ips.opt.perturb_dec_fact*ips.del_w_last)
+            solver.del_w = solver.del_w_last==.0 ? solver.opt.first_hessian_perturbation :
+                max(solver.opt.min_hessian_perturbation,solver.opt.perturb_dec_fact*solver.del_w_last)
         else
-            ips.del_w*= ips.del_w_last==.0 ? ips.opt.perturb_inc_fact_first : ips.opt.perturb_inc_fact
-            if ips.del_w>ips.opt.max_hessian_perturbation ips.cnt.k+=1
-                @debug(ips.logger,"Primal regularization is too big. Switching to restoration phase.")
+            solver.del_w*= solver.del_w_last==.0 ? solver.opt.perturb_inc_fact_first : solver.opt.perturb_inc_fact
+            if solver.del_w>solver.opt.max_hessian_perturbation solver.cnt.k+=1
+                @debug(solver.logger,"Primal regularization is too big. Switching to restoration phase.")
                 return false
             end
         end
-        ips.del_c = !solve_status ?
-            ips.opt.jacobian_regularization_value * ips.mu^(ips.opt.jacobian_regularization_exponent) : 0.
-        regularize_diagonal!(ips.kkt, ips.del_w - del_w_prev, ips.del_c)
-        del_w_prev = ips.del_w
+        solver.del_c = !solve_status ?
+            solver.opt.jacobian_regularization_value * solver.mu^(solver.opt.jacobian_regularization_exponent) : 0.
+        regularize_diagonal!(solver.kkt, solver.del_w - del_w_prev, solver.del_c)
+        del_w_prev = solver.del_w
 
-        factorize_wrapper!(ips)
-        solve_status = (solve_refine_wrapper!(ips,d0,p0) && solve_refine_wrapper!(ips,ips.d,ips.p))
-        t .= primal(ips.d) .- n
-        mul!(ips._w4, ips.kkt, ips._w3) # prepartation for curv_test
+        factorize_wrapper!(solver)
+        solve_status = (solve_refine_wrapper!(solver,d0,p0) && solve_refine_wrapper!(solver,solver.d,solver.p))
+        t .= primal(solver.d) .- n
+        mul!(solver._w4, solver.kkt, solver._w3) # prepartation for curv_test
         n_trial += 1
     end
 
-    ips.del_w != 0 && (ips.del_w_last = ips.del_w)
+    solver.del_w != 0 && (solver.del_w_last = solver.del_w)
     return true
 end
 
 curv_test(t,n,g,wx,inertia_free_tol) = dot(wx,t) + max(dot(wx,n)-dot(g,n),0) - inertia_free_tol*dot(t,t) >=0
 
-function second_order_correction(ips::AbstractInteriorPointSolver,alpha_max,theta,varphi,
+function second_order_correction(solver::AbstractMadNLPSolver,alpha_max,theta,varphi,
                                  theta_trial,varphi_d,switching_condition::Bool)
-    @trace(ips.logger,"Second-order correction started.")
+    @trace(solver.logger,"Second-order correction started.")
 
-    dual(ips._w1) .= alpha_max .* ips.c .+ ips.c_trial
+    dual(solver._w1) .= alpha_max .* solver.c .+ solver.c_trial
     theta_soc_old = theta_trial
-    for p=1:ips.opt.max_soc
+    for p=1:solver.opt.max_soc
         # compute second order correction
-        set_aug_rhs!(ips, ips.kkt, dual(ips._w1))
-        dual_inf_perturbation!(primal(ips.p),ips.ind_llb,ips.ind_uub,ips.mu,ips.opt.kappa_d)
-        solve_refine_wrapper!(ips,ips._w1,ips.p)
-        alpha_soc = get_alpha_max(ips.x,ips.xl,ips.xu,primal(ips._w1),ips.tau)
+        set_aug_rhs!(solver, solver.kkt, dual(solver._w1))
+        dual_inf_perturbation!(primal(solver.p),solver.ind_llb,solver.ind_uub,solver.mu,solver.opt.kappa_d)
+        solve_refine_wrapper!(solver,solver._w1,solver.p)
+        alpha_soc = get_alpha_max(solver.x,solver.xl,solver.xu,primal(solver._w1),solver.tau)
 
-        ips.x_trial .= ips.x .+ alpha_soc .* primal(ips._w1)
-        eval_cons_wrapper!(ips, ips.c_trial,ips.x_trial)
-        ips.obj_val_trial = eval_f_wrapper(ips, ips.x_trial)
+        solver.x_trial .= solver.x .+ alpha_soc .* primal(solver._w1)
+        eval_cons_wrapper!(solver, solver.c_trial,solver.x_trial)
+        solver.obj_val_trial = eval_f_wrapper(solver, solver.x_trial)
 
-        theta_soc = get_theta(ips.c_trial)
-        varphi_soc= get_varphi(ips.obj_val_trial,ips.x_trial_lr,ips.xl_r,ips.xu_r,ips.x_trial_ur,ips.mu)
+        theta_soc = get_theta(solver.c_trial)
+        varphi_soc= get_varphi(solver.obj_val_trial,solver.x_trial_lr,solver.xl_r,solver.xu_r,solver.x_trial_ur,solver.mu)
 
-        !is_filter_acceptable(ips.filter,theta_soc,varphi_soc) && break
+        !is_filter_acceptable(solver.filter,theta_soc,varphi_soc) && break
 
-        if theta <=ips.theta_min && switching_condition
+        if theta <=solver.theta_min && switching_condition
             # Case I
-            if is_armijo(varphi_soc,varphi,ips.opt.eta_phi,ips.alpha,varphi_d)
-                @trace(ips.logger,"Step in second order correction accepted by armijo condition.")
-                ips.ftype = "F"
-                ips.alpha=alpha_soc
+            if is_armijo(varphi_soc,varphi,solver.opt.eta_phi,solver.alpha,varphi_d)
+                @trace(solver.logger,"Step in second order correction accepted by armijo condition.")
+                solver.ftype = "F"
+                solver.alpha=alpha_soc
                 return true
             end
         else
             # Case II
-            if is_sufficient_progress(theta_soc,theta,ips.opt.gamma_theta,varphi_soc,varphi,ips.opt.gamma_phi,has_constraints(ips))
-                @trace(ips.logger,"Step in second order correction accepted by sufficient progress.")
-                ips.ftype = "H"
-                ips.alpha=alpha_soc
+            if is_sufficient_progress(theta_soc,theta,solver.opt.gamma_theta,varphi_soc,varphi,solver.opt.gamma_phi,has_constraints(solver))
+                @trace(solver.logger,"Step in second order correction accepted by sufficient progress.")
+                solver.ftype = "H"
+                solver.alpha=alpha_soc
                 return true
             end
         end
 
-        theta_soc>ips.opt.kappa_soc*theta_soc_old && break
+        theta_soc>solver.opt.kappa_soc*theta_soc_old && break
         theta_soc_old = theta_soc
     end
-    @trace(ips.logger,"Second-order correction terminated.")
+    @trace(solver.logger,"Second-order correction terminated.")
 
     return false
 end
+
 

--- a/src/IPM/utils.jl
+++ b/src/IPM/utils.jl
@@ -16,15 +16,15 @@ end
 struct InvalidNumberException <: Exception end
 struct NotEnoughDegreesOfFreedomException <: Exception end
 
-MadNLPExecutionStats(ips::InteriorPointSolver) =MadNLPExecutionStats(
-    ips.status,
-    _madnlp_unsafe_wrap(ips.x, get_nvar(ips.nlp)),
-    ips.obj_val,ips.c,
-    ips.inf_du, ips.inf_pr,
-    ips.l,
-    _madnlp_unsafe_wrap(ips.zl, get_nvar(ips.nlp)),
-    _madnlp_unsafe_wrap(ips.zu, get_nvar(ips.nlp)),
-    ips.cnt.k, get_counters(ips.nlp),ips.cnt.total_time
+MadNLPExecutionStats(solver::MadNLPSolver) =MadNLPExecutionStats(
+    solver.status,
+    _madnlp_unsafe_wrap(solver.x, get_nvar(solver.nlp)),
+    solver.obj_val,solver.c,
+    solver.inf_du, solver.inf_pr,
+    solver.y,
+    _madnlp_unsafe_wrap(solver.zl, get_nvar(solver.nlp)),
+    _madnlp_unsafe_wrap(solver.zu, get_nvar(solver.nlp)),
+    solver.cnt.k, get_counters(solver.nlp),solver.cnt.total_time
 )
 
 get_counters(nlp::NLPModels.AbstractNLPModel) = nlp.counters
@@ -32,82 +32,82 @@ get_counters(nlp::NLPModels.AbstractNLSModel) = nlp.counters.counters
 getStatus(result::MadNLPExecutionStats) = STATUS_OUTPUT_DICT[result.status]
 
 # Utilities
-has_constraints(ips) = ips.m != 0
+has_constraints(solver) = solver.m != 0
 
 # Print functions -----------------------------------------------------------
-function print_init(ips::AbstractInteriorPointSolver)
-    @notice(ips.logger,@sprintf("Number of nonzeros in constraint Jacobian............: %8i",get_nnzj(ips.nlp.meta)))
-    @notice(ips.logger,@sprintf("Number of nonzeros in Lagrangian Hessian.............: %8i\n",get_nnzh(ips.nlp.meta)))
+function print_init(solver::AbstractMadNLPSolver)
+    @notice(solver.logger,@sprintf("Number of nonzeros in constraint Jacobian............: %8i",get_nnzj(solver.nlp.meta)))
+    @notice(solver.logger,@sprintf("Number of nonzeros in Lagrangian Hessian.............: %8i\n",get_nnzh(solver.nlp.meta)))
 
-    num_fixed = length(ips.ind_fixed)
-    num_var = get_nvar(ips.nlp) - num_fixed
-    num_llb_vars = length(ips.ind_llb)
-    num_lu_vars = sum((get_lvar(ips.nlp).!=-Inf).*(get_uvar(ips.nlp).!=Inf)) - num_fixed
-    num_uub_vars = length(ips.ind_uub)
-    num_eq_cons = sum(get_lcon(ips.nlp).==get_ucon(ips.nlp))
-    num_ineq_cons = sum(get_lcon(ips.nlp).!=get_ucon(ips.nlp))
-    num_ue_cons = sum((get_lcon(ips.nlp).!=get_ucon(ips.nlp)).*(get_lcon(ips.nlp).==-Inf).*(get_ucon(ips.nlp).!=Inf))
-    num_le_cons = sum((get_lcon(ips.nlp).!=get_ucon(ips.nlp)).*(get_lcon(ips.nlp).!=-Inf).*(get_ucon(ips.nlp).==Inf))
-    num_lu_cons = sum((get_lcon(ips.nlp).!=get_ucon(ips.nlp)).*(get_lcon(ips.nlp).!=-Inf).*(get_ucon(ips.nlp).!=Inf))
-    get_nvar(ips.nlp) < num_eq_cons && throw(NotEnoughDegreesOfFreedomException())
+    num_fixed = length(solver.ind_fixed)
+    num_var = get_nvar(solver.nlp) - num_fixed
+    num_llb_vars = length(solver.ind_llb)
+    num_lu_vars = sum((get_lvar(solver.nlp).!=-Inf).*(get_uvar(solver.nlp).!=Inf)) - num_fixed
+    num_uub_vars = length(solver.ind_uub)
+    num_eq_cons = sum(get_lcon(solver.nlp).==get_ucon(solver.nlp))
+    num_ineq_cons = sum(get_lcon(solver.nlp).!=get_ucon(solver.nlp))
+    num_ue_cons = sum((get_lcon(solver.nlp).!=get_ucon(solver.nlp)).*(get_lcon(solver.nlp).==-Inf).*(get_ucon(solver.nlp).!=Inf))
+    num_le_cons = sum((get_lcon(solver.nlp).!=get_ucon(solver.nlp)).*(get_lcon(solver.nlp).!=-Inf).*(get_ucon(solver.nlp).==Inf))
+    num_lu_cons = sum((get_lcon(solver.nlp).!=get_ucon(solver.nlp)).*(get_lcon(solver.nlp).!=-Inf).*(get_ucon(solver.nlp).!=Inf))
+    get_nvar(solver.nlp) < num_eq_cons && throw(NotEnoughDegreesOfFreedomException())
 
-    @notice(ips.logger,@sprintf("Total number of variables............................: %8i",num_var))
-    @notice(ips.logger,@sprintf("                     variables with only lower bounds: %8i",num_llb_vars))
-    @notice(ips.logger,@sprintf("                variables with lower and upper bounds: %8i",num_lu_vars))
-    @notice(ips.logger,@sprintf("                     variables with only upper bounds: %8i",num_uub_vars))
-    @notice(ips.logger,@sprintf("Total number of equality constraints.................: %8i",num_eq_cons))
-    @notice(ips.logger,@sprintf("Total number of inequality constraints...............: %8i",num_ineq_cons))
-    @notice(ips.logger,@sprintf("        inequality constraints with only lower bounds: %8i",num_le_cons))
-    @notice(ips.logger,@sprintf("   inequality constraints with lower and upper bounds: %8i",num_lu_cons))
-    @notice(ips.logger,@sprintf("        inequality constraints with only upper bounds: %8i\n",num_ue_cons))
+    @notice(solver.logger,@sprintf("Total number of variables............................: %8i",num_var))
+    @notice(solver.logger,@sprintf("                     variables with only lower bounds: %8i",num_llb_vars))
+    @notice(solver.logger,@sprintf("                variables with lower and upper bounds: %8i",num_lu_vars))
+    @notice(solver.logger,@sprintf("                     variables with only upper bounds: %8i",num_uub_vars))
+    @notice(solver.logger,@sprintf("Total number of equality constraints.................: %8i",num_eq_cons))
+    @notice(solver.logger,@sprintf("Total number of inequality constraints...............: %8i",num_ineq_cons))
+    @notice(solver.logger,@sprintf("        inequality constraints with only lower bounds: %8i",num_le_cons))
+    @notice(solver.logger,@sprintf("   inequality constraints with lower and upper bounds: %8i",num_lu_cons))
+    @notice(solver.logger,@sprintf("        inequality constraints with only upper bounds: %8i\n",num_ue_cons))
     return
 end
 
-function print_iter(ips::AbstractInteriorPointSolver;is_resto=false)
-    mod(ips.cnt.k,10)==0&& @info(ips.logger,@sprintf(
+function print_iter(solver::AbstractMadNLPSolver;is_resto=false)
+    mod(solver.cnt.k,10)==0&& @info(solver.logger,@sprintf(
         "iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls"))
-    @info(ips.logger,@sprintf(
+    @info(solver.logger,@sprintf(
         "%4i%s% 10.7e %6.2e %6.2e %5.1f %6.2e %s %6.2e %6.2e%s  %i",
-        ips.cnt.k,is_resto ? "r" : " ",ips.obj_val/ips.obj_scale[],
-        is_resto ? ips.RR.inf_pr_R : ips.inf_pr,
-        is_resto ? ips.RR.inf_du_R : ips.inf_du,
-        is_resto ? log(10,ips.RR.mu_R) : log(10,ips.mu),
-        ips.cnt.k == 0 ? 0. : norm(primal(ips.d),Inf),
-        ips.del_w == 0 ? "   - " : @sprintf("%5.1f",log(10,ips.del_w)),
-        ips.alpha_z,ips.alpha,ips.ftype,ips.cnt.l))
+        solver.cnt.k,is_resto ? "r" : " ",solver.obj_val/solver.obj_scale[],
+        is_resto ? solver.RR.inf_pr_R : solver.inf_pr,
+        is_resto ? solver.RR.inf_du_R : solver.inf_du,
+        is_resto ? log(10,solver.RR.mu_R) : log(10,solver.mu),
+        solver.cnt.k == 0 ? 0. : norm(primal(solver.d),Inf),
+        solver.del_w == 0 ? "   - " : @sprintf("%5.1f",log(10,solver.del_w)),
+        solver.alpha_z,solver.alpha,solver.ftype,solver.cnt.l))
     return
 end
 
-function print_summary_1(ips::AbstractInteriorPointSolver)
-    @notice(ips.logger,"")
-    @notice(ips.logger,"Number of Iterations....: $(ips.cnt.k)\n")
-    @notice(ips.logger,"                                   (scaled)                 (unscaled)")
-    @notice(ips.logger,@sprintf("Objective...............:  % 1.16e   % 1.16e",ips.obj_val,ips.obj_val/ips.obj_scale[]))
-    @notice(ips.logger,@sprintf("Dual infeasibility......:   %1.16e    %1.16e",ips.inf_du,ips.inf_du/ips.obj_scale[]))
-    @notice(ips.logger,@sprintf("Constraint violation....:   %1.16e    %1.16e",norm(ips.c,Inf),ips.inf_pr))
-    @notice(ips.logger,@sprintf("Complementarity.........:   %1.16e    %1.16e",
-                                ips.inf_compl*ips.obj_scale[],ips.inf_compl))
-    @notice(ips.logger,@sprintf("Overall NLP error.......:   %1.16e    %1.16e\n",
-                                max(ips.inf_du*ips.obj_scale[],norm(ips.c,Inf),ips.inf_compl),
-                                max(ips.inf_du,ips.inf_pr,ips.inf_compl)))
+function print_summary_1(solver::AbstractMadNLPSolver)
+    @notice(solver.logger,"")
+    @notice(solver.logger,"Number of Iterations....: $(solver.cnt.k)\n")
+    @notice(solver.logger,"                                   (scaled)                 (unscaled)")
+    @notice(solver.logger,@sprintf("Objective...............:  % 1.16e   % 1.16e",solver.obj_val,solver.obj_val/solver.obj_scale[]))
+    @notice(solver.logger,@sprintf("Dual infeasibility......:   %1.16e    %1.16e",solver.inf_du,solver.inf_du/solver.obj_scale[]))
+    @notice(solver.logger,@sprintf("Constraint violation....:   %1.16e    %1.16e",norm(solver.c,Inf),solver.inf_pr))
+    @notice(solver.logger,@sprintf("Complementarity.........:   %1.16e    %1.16e",
+                                solver.inf_compl*solver.obj_scale[],solver.inf_compl))
+    @notice(solver.logger,@sprintf("Overall NLP error.......:   %1.16e    %1.16e\n",
+                                max(solver.inf_du*solver.obj_scale[],norm(solver.c,Inf),solver.inf_compl),
+                                max(solver.inf_du,solver.inf_pr,solver.inf_compl)))
     return
 end
 
-function print_summary_2(ips::AbstractInteriorPointSolver)
-    ips.cnt.solver_time = ips.cnt.total_time-ips.cnt.linear_solver_time-ips.cnt.eval_function_time
-    @notice(ips.logger,"Number of objective function evaluations             = $(ips.cnt.obj_cnt)")
-    @notice(ips.logger,"Number of objective gradient evaluations             = $(ips.cnt.obj_grad_cnt)")
-    @notice(ips.logger,"Number of constraint evaluations                     = $(ips.cnt.con_cnt)")
-    @notice(ips.logger,"Number of constraint Jacobian evaluations            = $(ips.cnt.con_jac_cnt)")
-    @notice(ips.logger,"Number of Lagrangian Hessian evaluations             = $(ips.cnt.lag_hess_cnt)")
-    @notice(ips.logger,@sprintf("Total wall-clock secs in solver (w/o fun. eval./lin. alg.)  = %6.3f",
-                                ips.cnt.solver_time))
-    @notice(ips.logger,@sprintf("Total wall-clock secs in linear solver                      = %6.3f",
-                                ips.cnt.linear_solver_time))
-    @notice(ips.logger,@sprintf("Total wall-clock secs in NLP function evaluations           = %6.3f",
-                                ips.cnt.eval_function_time))
-    @notice(ips.logger,@sprintf("Total wall-clock secs                                       = %6.3f\n",
-                                ips.cnt.total_time))
+function print_summary_2(solver::AbstractMadNLPSolver)
+    solver.cnt.solver_time = solver.cnt.total_time-solver.cnt.linear_solver_time-solver.cnt.eval_function_time
+    @notice(solver.logger,"Number of objective function evaluations             = $(solver.cnt.obj_cnt)")
+    @notice(solver.logger,"Number of objective gradient evaluations             = $(solver.cnt.obj_grad_cnt)")
+    @notice(solver.logger,"Number of constraint evaluations                     = $(solver.cnt.con_cnt)")
+    @notice(solver.logger,"Number of constraint Jacobian evaluations            = $(solver.cnt.con_jac_cnt)")
+    @notice(solver.logger,"Number of Lagrangian Hessian evaluations             = $(solver.cnt.lag_hess_cnt)")
+    @notice(solver.logger,@sprintf("Total wall-clock secs in solver (w/o fun. eval./lin. alg.)  = %6.3f",
+                                solver.cnt.solver_time))
+    @notice(solver.logger,@sprintf("Total wall-clock secs in linear solver                      = %6.3f",
+                                solver.cnt.linear_solver_time))
+    @notice(solver.logger,@sprintf("Total wall-clock secs in NLP function evaluations           = %6.3f",
+                                solver.cnt.eval_function_time))
+    @notice(solver.logger,@sprintf("Total wall-clock secs                                       = %6.3f\n",
+                                solver.cnt.total_time))
 end
 
 function print_ignored_options(logger,option_dict)
@@ -116,17 +116,17 @@ function print_ignored_options(logger,option_dict)
         @warn(logger," - "*string(key))
     end
 end
-function string(ips::AbstractInteriorPointSolver)
+function string(solver::AbstractMadNLPSolver)
     """
                 Interior point solver
 
-                number of variables......................: $(get_nvar(ips.nlp))
-                number of constraints....................: $(get_ncon(ips.nlp))
-                number of nonzeros in lagrangian hessian.: $(get_nnzh(ips.nlp.meta))
-                number of nonzeros in constraint jacobian: $(get_nnzj(ips.nlp.meta))
-                status...................................: $(ips.status)
+                number of variables......................: $(get_nvar(solver.nlp))
+                number of constraints....................: $(get_ncon(solver.nlp))
+                number of nonzeros in lagrangian hessian.: $(get_nnzh(solver.nlp.meta))
+                number of nonzeros in constraint jacobian: $(get_nnzj(solver.nlp.meta))
+                status...................................: $(solver.status)
                 """
 end
-print(io::IO,ips::AbstractInteriorPointSolver) = print(io, string(ips))
-show(io::IO,ips::AbstractInteriorPointSolver) = print(io,ips)
+print(io::IO,solver::AbstractMadNLPSolver) = print(io, string(solver))
+show(io::IO,solver::AbstractMadNLPSolver) = print(io,solver)
 

--- a/src/Interfaces/MOI_interface.jl
+++ b/src/Interfaces/MOI_interface.jl
@@ -1164,9 +1164,9 @@ end
 function MOI.optimize!(model::Optimizer)
 
     model.nlp = MOIModel(model)
-    model.solver = ipsSolver(model.nlp; model.option_dict...)
-    model.result = optimize!(model.ips)
-    model.solve_time = model.ips.cnt.total_time
+    model.solver = MadNLPSolver(model.nlp; model.option_dict...)
+    model.result = solve!(model.solver)
+    model.solve_time = model.solver.cnt.total_time
 
     return
 end

--- a/src/Interfaces/interfaces.jl
+++ b/src/Interfaces/interfaces.jl
@@ -1,12 +1,1 @@
-# MadNLP.jl
-# Created by Sungho Shin (sungho.shin@wisc.edu)
-
 include("MOI_interface.jl")
-
-# Thin wrapper for NLPModels.jl
-function madnlp(model::AbstractNLPModel;buffered=true, kwargs...)
-    ips = InteriorPointSolver(model;kwargs...)
-    initialize!(ips.kkt)
-    return optimize!(ips)
-end
-

--- a/src/KKT/KKTsystem.jl
+++ b/src/KKT/KKTsystem.jl
@@ -101,7 +101,7 @@ function get_hessian end
     initialize!(kkt::AbstractKKTSystem)
 
 Initialize KKT system with default values.
-Called when we initialize the `InteriorPointSolver` storing the current KKT system `kkt`.
+Called when we initialize the `MadNLPSolver` storing the current KKT system `kkt`.
 """
 function initialize! end
 

--- a/src/LinearSolvers/backsolve.jl
+++ b/src/LinearSolvers/backsolve.jl
@@ -8,13 +8,13 @@ struct RichardsonIterator{T, VT, KKT, LinSolver <: AbstractLinearSolver{T}} <: A
     max_iter::Int
     tol::T
     acceptable_tol::T
-    logger::Logger
+    logger::MadNLPLogger
 end
 function RichardsonIterator(
     linear_solver::AbstractLinearSolver{T},
     kkt::AbstractKKTSystem,
     res::AbstractVector;
-    max_iter=10, tol=T(1e-10), acceptable_tol=T(1e-5), logger=Logger(),
+    max_iter=10, tol=T(1e-10), acceptable_tol=T(1e-5), logger=MadNLPLogger(),
 ) where T
     return RichardsonIterator(
         linear_solver, kkt, res, max_iter, tol, acceptable_tol, logger,

--- a/src/LinearSolvers/lapack.jl
+++ b/src/LinearSolvers/lapack.jl
@@ -10,7 +10,7 @@ mutable struct LapackCPUSolver{T} <: AbstractLinearSolver{T}
     info::Ref{BlasInt}
     etc::Dict{Symbol,Any}
     opt::LapackOptions
-    logger::Logger
+    logger::MadNLPLogger
 end
 
 
@@ -75,7 +75,7 @@ function LapackCPUSolver(
     dense::Matrix{T};
     option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
     opt=LapackOptions(),
-    logger=Logger(),
+    logger=MadNLPLogger(),
     kwargs...) where T
 
     set_options!(opt,option_dict,kwargs...)

--- a/src/LinearSolvers/umfpack.jl
+++ b/src/LinearSolvers/umfpack.jl
@@ -22,7 +22,7 @@ mutable struct UmfpackSolver{T} <: AbstractLinearSolver{T}
     info::Vector{T}
 
     opt::UmfpackOptions
-    logger::Logger
+    logger::MadNLPLogger
 end
 
 
@@ -58,7 +58,7 @@ end
 function UmfpackSolver(
     csc::SparseMatrixCSC{T};
     option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
-    opt=UmfpackOptions(),logger=Logger(),
+    opt=UmfpackOptions(),logger=MadNLPLogger(),
     kwargs...) where T
 
     set_options!(opt,option_dict,kwargs)

--- a/src/MadNLP.jl
+++ b/src/MadNLP.jl
@@ -18,9 +18,8 @@ import SolverCore: AbstractExecutionStats, getStatus
 
 const MOI = MathOptInterface
 const MOIU = MathOptInterface.Utilities
-const NLPModelsCounters = _Counters
 
-export madnlp, UmfpackSolver, LapackCPUSolver
+export MadNLPSolver, MadNLPOptions, UmfpackSolver, LapackCPUSolver, madnlp, solve!
 
 # Version info
 version() = parsefile(joinpath(@__DIR__,"..","Project.toml"))["version"]
@@ -38,14 +37,7 @@ include(joinpath("Interfaces","interfaces.jl"))
 
 # Initialize
 function __init__()
-    # check_deps()
-    try
-        @isdefined(libpardiso) && dlopen(libpardiso,RTLD_DEEPBIND)
-    catch e
-        println("Pardiso shared library cannot be loaded")
-    end
     set_blas_num_threads(Threads.nthreads(); permanent=true)
 end
 
 end # end module
-

--- a/src/options.jl
+++ b/src/options.jl
@@ -16,7 +16,7 @@ function set_options!(opt::AbstractOptions,option_dict::Dict{Symbol,Any},kwargs)
     set_options!(opt,option_dict)
 end
 
-@kwdef mutable struct Options <: AbstractOptions
+@kwdef mutable struct MadNLPOptions <: AbstractOptions
     # General options
     rethrow_error::Bool = true
     disable_garbage_collector::Bool = false

--- a/src/options.jl
+++ b/src/options.jl
@@ -109,7 +109,7 @@ end
 
 function load_options(; linear_solver=default_linear_solver(), options...)
     # Initiate interior-point options
-    opt_ipm = IPMOptions(linear_solver=linear_solver)
+    opt_ipm = MadNLPOptions(linear_solver=linear_solver)
     linear_solver_options = set_options!(opt_ipm, options)
     check_option_sanity(opt_ipm)
     # Initiate linear-solver options
@@ -117,7 +117,7 @@ function load_options(; linear_solver=default_linear_solver(), options...)
     remaining_options = set_options!(opt_linear_solver, linear_solver_options)
 
     # Initiate logger
-    logger = Logger(
+    logger = MadNLPLogger(
         print_level=opt_ipm.print_level,
         file_print_level=opt_ipm.file_print_level,
         file = opt_ipm.output_file == "" ? nothing : open(opt_ipm.output_file,"w+"),

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -4,17 +4,17 @@ abstract type AbstractOptions end
 default_linear_solver() = UmfpackSolver
 default_dense_solver() = LapackCPUSolver
 
-# Logger
-@kwdef mutable struct Logger
+# MadNLPLogger
+@kwdef mutable struct MadNLPLogger
     print_level::LogLevels = INFO
     file_print_level::LogLevels = INFO
     file::Union{IOStream,Nothing} = nothing
 end
 
-get_level(logger::Logger) = logger.print_level
-get_file_level(logger::Logger) = logger.file_print_level
-get_file(logger::Logger) = logger.file
-finalize(logger::Logger) = logger.file != nothing && close(logger.file)
+get_level(logger::MadNLPLogger) = logger.print_level
+get_file_level(logger::MadNLPLogger) = logger.file_print_level
+get_file(logger::MadNLPLogger) = logger.file
+finalize(logger::MadNLPLogger) = logger.file != nothing && close(logger.file)
 
 for (name,level,color) in [(:trace,TRACE,7),(:debug,DEBUG,6),(:info,INFO,256),(:notice,NOTICE,256),(:warn,WARN,5),(:error,ERROR,9)]
     @eval begin
@@ -64,7 +64,7 @@ end
 # Type definitions for noncontiguous views
 const SubVector{Tv} = SubArray{Tv, 1, Vector{Tv}, Tuple{Vector{Int}}, false}
 
-@kwdef mutable struct Counters
+@kwdef mutable struct MadNLPCounters
     k::Int = 0 # total iteration counter
     l::Int = 0 # backtracking line search counter
     t::Int = 0 # restoration phase counter

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -99,7 +99,7 @@ function timing_callbacks(ips; ntrials=10)
         t_c += @elapsed eval_cons_wrapper!(ips, ips.c, ips.x)
         t_g += @elapsed eval_grad_f_wrapper!(ips, ips.f,ips.x)
         t_j += @elapsed eval_jac_wrapper!(ips, ips.kkt, ips.x)
-        t_h += @elapsed eval_lag_hess_wrapper!(ips, ips.kkt, ips.x, ips.l)
+        t_h += @elapsed eval_lag_hess_wrapper!(ips, ips.kkt, ips.x, ips.y)
     end
     return (
         time_eval_objective   = t_f / ntrials,

--- a/test/madnlp_dense.jl
+++ b/test/madnlp_dense.jl
@@ -30,21 +30,21 @@ function _compare_dense_with_sparse(
 
         nlp = MadNLPTests.DenseDummyQP{T}(; n=n, m=m, fixed_variables=ind_fixed, equality_cons=ind_eq)
 
-        ips = MadNLP.InteriorPointSolver(nlp, option_dict=sparse_options)
-        ipd = MadNLP.InteriorPointSolver(nlp, option_dict=dense_options)
+        solver = MadNLP.MadNLPSolver(nlp, option_dict=sparse_options)
+        solverd = MadNLP.MadNLPSolver(nlp, option_dict=dense_options)
 
-        MadNLP.optimize!(ips)
-        MadNLP.optimize!(ipd)
+        MadNLP.solve!(solver)
+        MadNLP.solve!(solverd)
 
         # Check that dense formulation matches exactly sparse formulation
-        @test ipd.status == MadNLP.SOLVE_SUCCEEDED
-        @test ips.cnt.k == ipd.cnt.k
-        @test ips.obj_val ≈ ipd.obj_val atol=atol
-        @test ips.x ≈ ipd.x atol=atol
-        @test ips.l ≈ ipd.l atol=atol
-        @test ips.kkt.jac_com[:, 1:n] == ipd.kkt.jac
-        if isa(ipd.kkt, MadNLP.AbstractReducedKKTSystem)
-            @test Symmetric(ips.kkt.aug_com, :L) ≈ ipd.kkt.aug_com atol=atol
+        @test solverd.status == MadNLP.SOLVE_SUCCEEDED
+        @test solver.cnt.k == solverd.cnt.k
+        @test solver.obj_val ≈ solverd.obj_val atol=atol
+        @test solver.x ≈ solverd.x atol=atol
+        @test solver.y ≈ solverd.y atol=atol
+        @test solver.kkt.jac_com[:, 1:n] == solverd.kkt.jac
+        if isa(solverd.kkt, MadNLP.AbstractReducedKKTSystem)
+            @test Symmetric(solver.kkt.aug_com, :L) ≈ solverd.kkt.aug_com atol=atol
         end
     end
 end
@@ -62,16 +62,16 @@ end
         )
         m = 0
         nlp = MadNLPTests.DenseDummyQP(; n=n, m=m)
-        ipd = MadNLP.InteriorPointSolver(nlp, option_dict=dense_options)
+        solverd = MadNLP.MadNLPSolver(nlp, option_dict=dense_options)
 
-        kkt = ipd.kkt
+        kkt = solverd.kkt
         @test isa(kkt, kkt_type)
         @test isempty(kkt.jac)
         # Special test for DenseKKTSystem
         if kkt_type <: MadNLP.DenseKKTSystem
             @test kkt.hess === kkt.aug_com
         end
-        @test ipd.linear_solver.dense === kkt.aug_com
+        @test solverd.linear_solver.dense === kkt.aug_com
         @test size(kkt.hess) == (n, n)
         @test length(kkt.pr_diag) == n
         @test length(kkt.du_diag) == m
@@ -81,7 +81,7 @@ end
             :kkt_system=>kkt_options,
             :linear_solver=>MadNLP.UmfpackSolver,
         )
-        @test_throws Exception MadNLP.InteriorPointSolver(nlp, dense_options_error)
+        @test_throws Exception MadNLP.MadNLPSolver(nlp, dense_options_error)
     end
     @testset "Constrained" begin
         dense_options = Dict{Symbol, Any}(
@@ -90,13 +90,13 @@ end
         )
         m = 5
         nlp = MadNLPTests.DenseDummyQP(; n=n, m=m)
-        ipd = MadNLP.InteriorPointSolver(nlp, option_dict=dense_options)
-        ns = length(ipd.ind_ineq)
+        solverd = MadNLP.MadNLPSolver(nlp, option_dict=dense_options)
+        ns = length(solverd.ind_ineq)
 
-        kkt = ipd.kkt
+        kkt = solverd.kkt
         @test isa(kkt, MadNLP.DenseKKTSystem)
         @test size(kkt.jac) == (m, n)
-        @test ipd.linear_solver.dense === kkt.aug_com
+        @test solverd.linear_solver.dense === kkt.aug_com
         @test size(kkt.hess) == (n, n)
         @test length(kkt.pr_diag) == n + ns
         @test length(kkt.du_diag) == m
@@ -130,9 +130,9 @@ end
         :linear_solver=>MadNLP.LapackCPUSolver,
         :print_level=>MadNLP.ERROR,
     )
-    ips = MadNLP.InteriorPointSolver(nlp, option_dict=sparse_options)
-    MadNLP.optimize!(ips)
+    solver = MadNLP.MadNLPSolver(nlp, option_dict=sparse_options)
+    MadNLP.solve!(solver)
     # Restart (should hit MadNLP.reinitialize function)
-    res = MadNLP.optimize!(ips)
-    @test ips.status == MadNLP.SOLVE_SUCCEEDED
+    res = MadNLP.solve!(solver)
+    @test solver.status == MadNLP.SOLVE_SUCCEEDED
 end

--- a/test/madnlp_dense.jl
+++ b/test/madnlp_dense.jl
@@ -30,8 +30,8 @@ function _compare_dense_with_sparse(
 
         nlp = MadNLPTests.DenseDummyQP{T}(; n=n, m=m, fixed_variables=ind_fixed, equality_cons=ind_eq)
 
-        solver = MadNLP.MadNLPSolver(nlp; sparse_options...)
-        solverd = MadNLP.MadNLPSolver(nlp; dense_options...)
+        solver = MadNLPSolver(nlp; sparse_options...)
+        solverd = MadNLPSolver(nlp; dense_options...)
 
         MadNLP.solve!(solver)
         MadNLP.solve!(solverd)
@@ -62,7 +62,7 @@ end
         )
         m = 0
         nlp = MadNLPTests.DenseDummyQP(; n=n, m=m)
-        solverd = MadNLP.MadNLPSolver(nlp; dense_options...)
+        solverd = MadNLPSolver(nlp; dense_options...)
 
         kkt = solverd.kkt
         @test isa(kkt, kkt_type)
@@ -81,7 +81,7 @@ end
             :kkt_system=>kkt_options,
             :linear_solver=>MadNLP.UmfpackSolver,
         )
-        @test_throws Exception MadNLP.MadNLPSolver(nlp; dense_options_error...)
+        @test_throws Exception MadNLPSolver(nlp; dense_options_error...)
     end
     @testset "Constrained" begin
         dense_options = Dict{Symbol, Any}(
@@ -90,7 +90,7 @@ end
         )
         m = 5
         nlp = MadNLPTests.DenseDummyQP(; n=n, m=m)
-        solverd = MadNLP.MadNLPSolver(nlp; dense_options...)
+        solverd = MadNLPSolver(nlp; dense_options...)
         ns = length(solverd.ind_ineq)
 
         kkt = solverd.kkt
@@ -131,8 +131,9 @@ end
         :print_level=>MadNLP.ERROR,
     )
 
-    solver = MadNLP.MadNLPSolver(nlp; sparse_options...)
-    MadNLP.optimize!(solver)
+    solver = MadNLPSolver(nlp; sparse_options...)
+    MadNLP.solve!(solver)
+    
     # Restart (should hit MadNLP.reinitialize function)
     res = MadNLP.solve!(solver)
     @test solver.status == MadNLP.SOLVE_SUCCEEDED

--- a/test/madnlp_test.jl
+++ b/test/madnlp_test.jl
@@ -80,9 +80,9 @@ end
         :print_level=>MadNLP.ERROR,
     )
     nlp = MadNLPTests.HS15Model()
-    ips = MadNLP.InteriorPointSolver(nlp; option_dict=options)
-    MadNLP.optimize!(ips)
-    @test ips.status == MadNLP.SOLVE_SUCCEEDED
+    solver = MadNLP.MadNLPSolver(nlp; option_dict=options)
+    MadNLP.solve!(solver)
+    @test solver.status == MadNLP.SOLVE_SUCCEEDED
 end
 
 
@@ -91,8 +91,8 @@ end
         :print_level=>MadNLP.ERROR,
     )
     nlp = MadNLPTests.NLSModel()
-    ips = MadNLP.InteriorPointSolver(nlp; option_dict=options)
-    MadNLP.optimize!(ips)
-    @test ips.status == MadNLP.SOLVE_SUCCEEDED
+    solver = MadNLP.MadNLPSolver(nlp; option_dict=options)
+    MadNLP.solve!(solver)
+    @test solver.status == MadNLP.SOLVE_SUCCEEDED
 end
 

--- a/test/madnlp_test.jl
+++ b/test/madnlp_test.jl
@@ -78,17 +78,17 @@ end
 @testset "HS15 problem" begin
     nlp = MadNLPTests.HS15Model()
     solver = MadNLP.MadNLPSolver(nlp; print_level=MadNLP.ERROR)
-    MadNLP.optimize!(solver)
+    MadNLP.solve!(solver)
     @test solver.status == MadNLP.SOLVE_SUCCEEDED
 end
 
 
-# @testset "NLS problem" begin
-#     nlp = MadNLPTests.NLSModel()
-#     solver = MadNLPSolver(nlp; print_level=MadNLP.ERROR)
-#     MadNLP.optimize!(solver)
-#     @test solver.status == MadNLP.SOLVE_SUCCEEDED
-# end
+@testset "NLS problem" begin
+    nlp = MadNLPTests.NLSModel()
+    solver = MadNLPSolver(nlp; print_level=MadNLP.ERROR)
+    MadNLP.solve!(solver)
+    @test solver.status == MadNLP.SOLVE_SUCCEEDED
+end
 
 @testset "MadNLP timings" begin
     nlp = MadNLPTests.HS15Model()
@@ -100,6 +100,5 @@ end
     time_madnlp = MadNLP.timing_madnlp(solver)
     @test isa(time_madnlp.time_linear_solver, NamedTuple)
     @test isa(time_madnlp.time_callbacks, NamedTuple)
->>>>>>> master
 end
 


### PR DESCRIPTION
This PR makes several changes in the struct/function/variable names to comply with JSO conventions. These changes include

- `InteriorPointSolver` to `MadNLPSolver`
- `Logger` to `MadNLPLogger`
- `Counters` to `MadNLPCounters`
- `optimize!` to `solve!`
- `ips` to `solver`
- `ips.l` to `ips.y`