### PR TITLE
[hotfix] Fix detection of upper/lower bounds

### DIFF
--- a/src/nlpmodels.jl
+++ b/src/nlpmodels.jl
@@ -83,8 +83,8 @@ function get_index_constraints(nlp::AbstractNLPModel; fixed_variable_treatment=M
         ind_ub = findall(xu .!= Inf)
     end
 
-    ind_llb = findall((get_lvar(nlp) .== -Inf).*(get_uvar(nlp) .!= Inf))
-    ind_uub = findall((get_lvar(nlp) .!= -Inf).*(get_uvar(nlp) .== Inf))
+    ind_llb = findall((get_lvar(nlp) .!= -Inf).*(get_uvar(nlp) .== Inf))
+    ind_uub = findall((get_lvar(nlp) .== -Inf).*(get_uvar(nlp) .!= Inf))
 
     # Return named tuple
     return (


### PR DESCRIPTION
`get_index_constraints` was not returning the correct numberof variables with only lower/upper bounds.

Fix #209 