### PR TITLE
fix changed names of meta fields

### DIFF
--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -8,8 +8,8 @@ function solve!(
     model::AbstractNLPModel,
     solver::MadNLPSolver,
     nlp::AbstractNLPModel;
-    x = nlp.meta.x,
-    y = nlp.meta.y,
+    x = get_x0(nlp),
+    y = get_y0(nlp),
     zl= nothing,
     zu= nothing,
     kwargs...)


### PR DESCRIPTION
It appears as if
1. The names have changed to `x0, y0`
2. The getters have been introduced https://github.com/JuliaSmoothOptimizers/NLPModels.jl/pull/371