### PR TITLE
[TTFS] clean interior-point kernels to improve inference 

### DIFF
--- a/src/IPM/callbacks.jl
+++ b/src/IPM/callbacks.jl
@@ -21,7 +21,7 @@ function eval_grad_f_wrapper!(solver::MadNLPSolver, f::Vector{T},x::Vector{T}) w
         x_nlpmodel,
         f_nlpmodel
     )
-    scal!(obj_scaling, f)
+    BLAS.scal!(obj_scaling, f)
     cnt.obj_grad_cnt+=1
     cnt.obj_grad_cnt==1 && (is_valid(f)  || throw(InvalidNumberException(:grad)))
     return f

--- a/src/IPM/callbacks.jl
+++ b/src/IPM/callbacks.jl
@@ -21,7 +21,7 @@ function eval_grad_f_wrapper!(solver::MadNLPSolver, f::Vector{T},x::Vector{T}) w
         x_nlpmodel,
         f_nlpmodel
     )
-    BLAS.scal!(obj_scaling, f)
+    _scal!(obj_scaling, f)
     cnt.obj_grad_cnt+=1
     cnt.obj_grad_cnt==1 && (is_valid(f)  || throw(InvalidNumberException(:grad)))
     return f

--- a/src/IPM/factorization.jl
+++ b/src/IPM/factorization.jl
@@ -72,7 +72,7 @@ function solve_refine_wrapper!(
     xy = view(full(x), kkt.ind_eq_shifted)
     xz = view(full(x), kkt.ind_ineq_shifted)
 
-    v_c .= 0.0
+    fill!(v_c, zero(T))
     v_c[kkt.ind_ineq] .= (Σs .* bz .+ α .* bs) ./ α.^2
     jtprod!(jv_t, kkt, v_c)
     # init right-hand-side

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -1,51 +1,57 @@
 
 # KKT system updates -------------------------------------------------------
 # Set diagonal
-function set_aug_diagonal!(kkt::AbstractKKTSystem, solver::MadNLPSolver)
+function set_aug_diagonal!(kkt::AbstractKKTSystem, solver::MadNLPSolver{T}) where T
     kkt.pr_diag .= solver.zl./(solver.x.-solver.xl) .+ solver.zu./(solver.xu.-solver.x)
-    fill!(kkt.du_diag, 0.0)
+    fill!(kkt.du_diag, zero(T))
+    return
 end
-function set_aug_diagonal!(kkt::SparseUnreducedKKTSystem, solver::MadNLPSolver)
-    kkt.pr_diag .= 0.0
-    kkt.du_diag .= 0.0
+function set_aug_diagonal!(kkt::SparseUnreducedKKTSystem, solver::MadNLPSolver{T}) where T
+    fill!(kkt.pr_diag, zero(T))
+    fill!(kkt.du_diag, zero(T))
     kkt.l_lower .= .-sqrt.(solver.zl_r)
     kkt.u_lower .= .-sqrt.(solver.zu_r)
     kkt.l_diag  .= solver.xl_r .- solver.x_lr
     kkt.u_diag  .= solver.x_ur .- solver.xu_r
+    return
 end
 
 # Robust restoration
 function set_aug_RR!(kkt::AbstractKKTSystem, solver::MadNLPSolver, RR::RobustRestorer)
     kkt.pr_diag .= solver.zl./(solver.x.-solver.xl) .+ solver.zu./(solver.xu.-solver.x) .+ RR.zeta.*RR.D_R.^2
     kkt.du_diag .= .-RR.pp./RR.zp .- RR.nn./RR.zn
+    return
 end
 function set_aug_RR!(kkt::SparseUnreducedKKTSystem, solver::MadNLPSolver, RR::RobustRestorer)
-    kkt.pr_diag.= RR.zeta.*RR.D_R.^2
-    kkt.du_diag.= .-RR.pp./RR.zp.-RR.nn./RR.zn
-    kkt.l_lower.=.-sqrt.(solver.zl_r)
-    kkt.u_lower.=.-sqrt.(solver.zu_r)
-    kkt.l_diag .= solver.xl_r .- solver.x_lr
-    kkt.u_diag .= solver.x_ur .- solver.xu_r
+    kkt.pr_diag .= RR.zeta.*RR.D_R.^2
+    kkt.du_diag .= .-RR.pp./RR.zp.-RR.nn./RR.zn
+    kkt.l_lower .=.-sqrt.(solver.zl_r)
+    kkt.u_lower .=.-sqrt.(solver.zu_r)
+    kkt.l_diag  .= solver.xl_r .- solver.x_lr
+    kkt.u_diag  .= solver.x_ur .- solver.xu_r
+    return
 end
 
 # Set RHS
 function set_aug_rhs!(solver::MadNLPSolver, kkt::AbstractKKTSystem, c)
-    primal(solver.p) .= .-solver.f.+solver.mu./(solver.x.-solver.xl).-solver.mu./(solver.xu.-solver.x).-solver.jacl
+    primal(solver.p) .= .-solver.f .+ solver.mu ./ (solver.x.-solver.xl) .- solver.mu ./ (solver.xu.-solver.x) .-solver.jacl
     dual(solver.p)   .= .-c
+    return
 end
-
 function set_aug_rhs!(solver::MadNLPSolver, kkt::SparseUnreducedKKTSystem, c)
-    primal(solver.p) .= .-solver.f.+solver.zl.-solver.zu.-solver.jacl
+    primal(solver.p) .= .-solver.f .+ solver.zl .- solver.zu .- solver.jacl
     dual(solver.p) .= .-c
-    dual_lb(solver.p) .= (solver.xl_r-solver.x_lr).*kkt.l_lower .+ solver.mu./kkt.l_lower
-    dual_ub(solver.p) .= (solver.xu_r-solver.x_ur).*kkt.u_lower .- solver.mu./kkt.u_lower
+    dual_lb(solver.p) .= (solver.xl_r-solver.x_lr) .* kkt.l_lower .+ solver.mu ./ kkt.l_lower
+    dual_ub(solver.p) .= (solver.xu_r-solver.x_ur) .* kkt.u_lower .- solver.mu ./ kkt.u_lower
+    return
 end
 
-function set_aug_rhs_ifr!(solver::MadNLPSolver, kkt::SparseUnreducedKKTSystem,c)
-    primal(solver._w1) .= 0.0
+function set_aug_rhs_ifr!(solver::MadNLPSolver{T}, kkt::SparseUnreducedKKTSystem,c) where T
+    fill!(primal(solver._w1), zero(T))
+    fill!(dual_lb(solver._w1), zero(T))
+    fill!(dual_ub(solver._w1), zero(T))
     dual(solver._w1) .= .-c
-    dual_lb(solver._w1) .= 0.0
-    dual_ub(solver._w1) .= 0.0
+    return
 end
 
 # Set RHS RR
@@ -54,45 +60,51 @@ function set_aug_rhs_RR!(
 )
     primal(solver.p) .= .-RR.f_R.-solver.jacl.+RR.mu_R./(solver.x.-solver.xl).-RR.mu_R./(solver.xu.-solver.x)
     dual(solver.p) .= .-solver.c.+RR.pp.-RR.nn.+(RR.mu_R.-(rho.-solver.y).*RR.pp)./RR.zp.-(RR.mu_R.-(rho.+solver.y).*RR.nn)./RR.zn
+    return
 end
 
 # Finish
 function finish_aug_solve!(solver::MadNLPSolver, kkt::AbstractKKTSystem, mu)
     dual_lb(solver.d) .= (mu.-solver.zl_r.*solver.dx_lr)./(solver.x_lr.-solver.xl_r).-solver.zl_r
     dual_ub(solver.d) .= (mu.+solver.zu_r.*solver.dx_ur)./(solver.xu_r.-solver.x_ur).-solver.zu_r
+    return
 end
-
 function finish_aug_solve!(solver::MadNLPSolver, kkt::SparseUnreducedKKTSystem, mu)
     dual_lb(solver.d) .*= .-kkt.l_lower
-    dual_ub(solver.d) .*= kkt.u_lower
-    dual_lb(solver.d) .= (mu.-solver.zl_r.*solver.dx_lr)./(solver.x_lr.-solver.xl_r).-solver.zl_r
-    dual_ub(solver.d) .= (mu.+solver.zu_r.*solver.dx_ur)./(solver.xu_r.-solver.x_ur).-solver.zu_r
+    dual_ub(solver.d) .*=   kkt.u_lower
+    dual_lb(solver.d) .= (mu.-solver.zl_r.*solver.dx_lr) ./ (solver.x_lr.-solver.xl_r) .- solver.zl_r
+    dual_ub(solver.d) .= (mu.+solver.zu_r.*solver.dx_ur) ./ (solver.xu_r.-solver.x_ur) .- solver.zu_r
+    return
 end
 
 # Initial
-function set_initial_rhs!(solver::MadNLPSolver, kkt::AbstractKKTSystem)
-    primal(solver.p) .= .-solver.f.+solver.zl.-solver.zu
-    dual(solver.p) .= 0.0
+function set_initial_rhs!(solver::MadNLPSolver{T}, kkt::AbstractKKTSystem) where T
+    primal(solver.p) .= .-solver.f .+ solver.zl .- solver.zu
+    fill!(dual(solver.p), zero(T))
+    return
 end
-function set_initial_rhs!(solver::MadNLPSolver, kkt::SparseUnreducedKKTSystem)
+function set_initial_rhs!(solver::MadNLPSolver{T}, kkt::SparseUnreducedKKTSystem) where T
     primal(solver.p) .= .-solver.f.+solver.zl.-solver.zu
-    dual(solver.p) .= 0.0
-    dual_lb(solver.p) .= 0.0
-    dual_ub(solver.p) .= 0.0
+    fill!(dual(solver.p), zero(T))
+    fill!(dual_lb(solver.p), zero(T))
+    fill!(dual_ub(solver.p), zero(T))
+    return
 end
 
 # Set ifr
-function set_aug_rhs_ifr!(solver::MadNLPSolver, kkt::AbstractKKTSystem)
-    primal(solver._w1) .= 0.0
+function set_aug_rhs_ifr!(solver::MadNLPSolver{T}, kkt::AbstractKKTSystem) where T
+    fill!(primal(solver._w1), zero(T))
     dual(solver._w1) .= .-solver.c
+    return
 end
 
 # Finish RR
-function finish_aug_solve_RR!(dpp,dnn,dzp,dzn,l,dl,pp,nn,zp,zn,mu_R,rho)
+function finish_aug_solve_RR!(dpp, dnn, dzp, dzn, l, dl, pp, nn, zp, zn, mu_R, rho)
     dpp .= (mu_R.+pp.*dl.-(rho.-l).*pp)./zp
     dnn .= (mu_R.-nn.*dl.-(rho.+l).*nn)./zn
     dzp .= (mu_R.-zp.*dpp)./pp.-zp
     dzn .= (mu_R.-zn.*dnn)./nn.-zn
+    return
 end
 
 # Kernel functions ---------------------------------------------------------
@@ -105,261 +117,322 @@ function is_valid(vec::AbstractArray)
 end
 is_valid(args...) = all(is_valid(arg) for arg in args)
 
-function get_varphi(obj_val,x_lr,xl_r,xu_r,x_ur,mu)
+function get_varphi(obj_val, x_lr, xl_r, xu_r, x_ur, mu)
     varphi = obj_val
-    @simd for i=1:length(x_lr)
-        @inbounds xll = x_lr[i]-xl_r[i]
+    @inbounds @simd for i=1:length(x_lr)
+        xll = x_lr[i]-xl_r[i]
         xll < 0 && return Inf
         varphi -= mu*log(xll)
     end
-    @simd for i=1:length(x_ur)
-        @inbounds xuu = xu_r[i]-x_ur[i]
+    @inbounds @simd for i=1:length(x_ur)
+        xuu = xu_r[i]-x_ur[i]
         xuu < 0 && return Inf
         varphi -= mu*log(xuu)
     end
     return varphi
 end
-get_inf_pr(c) = norm(c,Inf)
-function get_inf_du(f,zl,zu,jacl,sd)
-    inf_du = 0.
-    @simd for i=1:length(f)
-        @inbounds inf_du = max(inf_du,abs(f[i]-zl[i]+zu[i]+jacl[i]))
+
+@inline get_inf_pr(c) = norm(c, Inf)
+
+function get_inf_du(f, zl, zu, jacl, sd)
+    inf_du = 0.0
+    @inbounds @simd for i=1:length(f)
+        inf_du = max(inf_du,abs(f[i]-zl[i]+zu[i]+jacl[i]))
     end
     return inf_du/sd
 end
-function get_inf_compl(x_lr,xl_r,zl_r,xu_r,x_ur,zu_r,mu,sc)
-    inf_compl = 0.
-    @simd for i=1:length(x_lr)
-        @inbounds inf_compl = max(inf_compl,abs((x_lr[i]-xl_r[i])*zl_r[i]-mu))
+
+function get_inf_compl(x_lr, xl_r, zl_r, xu_r, x_ur, zu_r, mu, sc)
+    inf_compl = 0.0
+    @inbounds @simd for i=1:length(x_lr)
+        inf_compl = max(inf_compl,abs((x_lr[i]-xl_r[i])*zl_r[i]-mu))
     end
-    @simd for i=1:length(x_ur)
-        @inbounds inf_compl = max(inf_compl,abs((xu_r[i]-x_ur[i])*zu_r[i]-mu))
+    @inbounds @simd for i=1:length(x_ur)
+        inf_compl = max(inf_compl,abs((xu_r[i]-x_ur[i])*zu_r[i]-mu))
     end
     return inf_compl/sc
 end
-function get_varphi_d(f,x,xl,xu,dx,mu)
-    varphi_d = 0.
-    @simd for i=1:length(f)
-        @inbounds varphi_d += (f[i] - mu/(x[i]-xl[i]) + mu/(xu[i]-x[i])) *dx[i]
+
+function get_varphi_d(f, x, xl, xu, dx, mu)
+    varphi_d = 0.0
+    @inbounds @simd for i=1:length(f)
+        varphi_d += (f[i] - mu/(x[i]-xl[i]) + mu/(xu[i]-x[i])) *dx[i]
     end
     return varphi_d
 end
-function get_alpha_max(x,xl,xu,dx,tau)
-    alpha_max = 1.
-    @simd for i=1:length(x)
-        @inbounds dx[i]<0 && (alpha_max=min(alpha_max,(-x[i]+xl[i])*tau/dx[i]))
-        @inbounds dx[i]>0 && (alpha_max=min(alpha_max,(-x[i]+xu[i])*tau/dx[i]))
+
+function get_alpha_max(x, xl, xu, dx, tau)
+    alpha_max = 1.0
+    @inbounds @simd for i=1:length(x)
+        dx[i]<0 && (alpha_max=min(alpha_max,(-x[i]+xl[i])*tau/dx[i]))
+        dx[i]>0 && (alpha_max=min(alpha_max,(-x[i]+xu[i])*tau/dx[i]))
     end
     return alpha_max
 end
-function get_alpha_z(zl_r,zu_r,dzl,dzu,tau)
-    alpha_z = 1.
-    @simd for i=1:length(zl_r)
-        @inbounds dzl[i]<0 && (alpha_z=min(alpha_z,-zl_r[i]*tau/dzl[i]))
+
+function get_alpha_z(zl_r, zu_r, dzl, dzu, tau)
+    alpha_z = 1.0
+    @inbounds @simd for i=1:length(zl_r)
+        dzl[i] < 0 && (alpha_z=min(alpha_z,-zl_r[i]*tau/dzl[i]))
      end
-    @simd for i=1:length(zu_r)
-        @inbounds dzu[i]<0 && (alpha_z=min(alpha_z,-zu_r[i]*tau/dzu[i]))
+    @inbounds @simd for i=1:length(zu_r)
+        dzu[i] < 0 && (alpha_z=min(alpha_z,-zu_r[i]*tau/dzu[i]))
     end
     return alpha_z
 end
-function get_obj_val_R(p,n,D_R,x,x_ref,rho,zeta)
+
+function get_obj_val_R(p, n, D_R, x, x_ref, rho, zeta)
     obj_val_R = 0.
-    @simd for i=1:length(p)
-        @inbounds obj_val_R += rho*(p[i]+n[i]) .+ zeta/2*D_R[i]^2*(x[i]-x_ref[i])^2
+    @inbounds @simd for i=1:length(p)
+        obj_val_R += rho*(p[i]+n[i]) .+ zeta/2*D_R[i]^2*(x[i]-x_ref[i])^2
     end
     return obj_val_R
 end
-get_theta(c) = norm(c,1)
-function get_theta_R(c,p,n)
-    theta_R = 0.
-    @simd for i=1:length(c)
-        @inbounds theta_R += abs(c[i]-p[i]+n[i])
+
+@inline get_theta(c) = norm(c, 1)
+
+function get_theta_R(c, p, n)
+    theta_R = 0.0
+    @inbounds @simd for i=1:length(c)
+        theta_R += abs(c[i]-p[i]+n[i])
     end
     return theta_R
 end
-function get_inf_pr_R(c,p,n)
-    inf_pr_R = 0.
-    @simd for i=1:length(c)
-        @inbounds inf_pr_R = max(inf_pr_R,abs(c[i]-p[i]+n[i]))
+
+function get_inf_pr_R(c, p, n)
+    inf_pr_R = 0.0
+    @inbounds @simd for i=1:length(c)
+        inf_pr_R = max(inf_pr_R,abs(c[i]-p[i]+n[i]))
     end
     return inf_pr_R
 end
-function get_inf_du_R(f_R,l,zl,zu,jacl,zp,zn,rho,sd)
-    inf_du_R = 0.
-    @simd for i=1:length(zl)
-        @inbounds inf_du_R = max(inf_du_R,abs(f_R[i]-zl[i]+zu[i]+jacl[i]))
+
+function get_inf_du_R(f_R, l, zl, zu, jacl, zp, zn, rho, sd)
+    inf_du_R = 0.0
+    @inbounds @simd for i=1:length(zl)
+        inf_du_R = max(inf_du_R,abs(f_R[i]-zl[i]+zu[i]+jacl[i]))
     end
-    @simd for i=1:length(zp)
-        @inbounds inf_du_R = max(inf_du_R,abs(rho-l[i]-zp[i]))
+    @inbounds @simd for i=1:length(zp)
+        inf_du_R = max(inf_du_R,abs(rho-l[i]-zp[i]))
     end
-    @simd for i=1:length(zn)
-        @inbounds inf_du_R = max(inf_du_R,abs(rho+l[i]-zn[i]))
+    @inbounds @simd for i=1:length(zn)
+        inf_du_R = max(inf_du_R,abs(rho+l[i]-zn[i]))
     end
-    return inf_du_R/sd
+    return inf_du_R / sd
 end
-function get_inf_compl_R(x_lr,xl_r,zl_r,xu_r,x_ur,zu_r,pp,zp,nn,zn,mu_R,sc)
-    inf_compl_R = 0.
-    @simd for i=1:length(x_lr)
-        @inbounds inf_compl_R = max(inf_compl_R,abs((x_lr[i]-xl_r[i])*zl_r[i]-mu_R))
+
+function get_inf_compl_R(x_lr, xl_r, zl_r, xu_r, x_ur, zu_r, pp, zp, nn, zn, mu_R, sc)
+    inf_compl_R = 0.0
+    @inbounds @simd for i=1:length(x_lr)
+        inf_compl_R = max(inf_compl_R,abs((x_lr[i]-xl_r[i])*zl_r[i]-mu_R))
     end
-    @simd for i=1:length(xu_r)
-        @inbounds inf_compl_R = max(inf_compl_R,abs((xu_r[i]-x_ur[i])*zu_r[i]-mu_R))
+    @inbounds @simd for i=1:length(xu_r)
+        inf_compl_R = max(inf_compl_R,abs((xu_r[i]-x_ur[i])*zu_r[i]-mu_R))
     end
-    @simd for i=1:length(pp)
-        @inbounds inf_compl_R = max(inf_compl_R,abs(pp[i]*zp[i]-mu_R))
+    @inbounds @simd for i=1:length(pp)
+        inf_compl_R = max(inf_compl_R,abs(pp[i]*zp[i]-mu_R))
     end
-    @simd for i=1:length(nn)
-        @inbounds inf_compl_R = max(inf_compl_R,abs(nn[i]*zn[i]-mu_R))
+    @inbounds @simd for i=1:length(nn)
+        inf_compl_R = max(inf_compl_R,abs(nn[i]*zn[i]-mu_R))
     end
-    return inf_compl_R/sc
+    return inf_compl_R / sc
 end
-function get_alpha_max_R(x,xl,xu,dx,pp,dpp,nn,dnn,tau_R)
-    alpha_max_R = 1.
-    @simd for i=1:length(x)
-        @inbounds dx[i]<0 && (alpha_max_R=min(alpha_max_R,(-x[i]+xl[i])*tau_R/dx[i]))
-        @inbounds dx[i]>0 && (alpha_max_R=min(alpha_max_R,(-x[i]+xu[i])*tau_R/dx[i]))
+
+function get_alpha_max_R(x, xl, xu, dx, pp, dpp, nn, dnn, tau_R)
+    alpha_max_R = 1.0
+    @inbounds @simd for i=1:length(x)
+        dx[i]<0 && (alpha_max_R=min(alpha_max_R,(-x[i]+xl[i])*tau_R/dx[i]))
+        dx[i]>0 && (alpha_max_R=min(alpha_max_R,(-x[i]+xu[i])*tau_R/dx[i]))
     end
-    @simd for i=1:length(pp)
-        @inbounds dpp[i]<0 && (alpha_max_R=min(alpha_max_R,-pp[i]*tau_R/dpp[i]))
+    @inbounds @simd for i=1:length(pp)
+        dpp[i]<0 && (alpha_max_R=min(alpha_max_R,-pp[i]*tau_R/dpp[i]))
     end
-    @simd for i=1:length(nn)
-        @inbounds dnn[i]<0 && (alpha_max_R=min(alpha_max_R,-nn[i]*tau_R/dnn[i]))
+    @inbounds @simd for i=1:length(nn)
+        dnn[i]<0 && (alpha_max_R=min(alpha_max_R,-nn[i]*tau_R/dnn[i]))
     end
     return alpha_max_R
 end
-function get_alpha_z_R(zl_r,zu_r,dzl,dzu,zp,dzp,zn,dzn,tau_R)
-    alpha_z_R = 1.
-    @simd for i=1:length(zl_r)
-        @inbounds dzl[i]<0 && (alpha_z_R=min(alpha_z_R,-zl_r[i]*tau_R/dzl[i]))
+
+function get_alpha_z_R(zl_r, zu_r, dzl, dzu, zp, dzp, zn, dzn, tau_R)
+    alpha_z_R = 1.0
+    @inbounds @simd for i=1:length(zl_r)
+        dzl[i]<0 && (alpha_z_R=min(alpha_z_R,-zl_r[i]*tau_R/dzl[i]))
     end
-    @simd for i=1:length(zu_r)
-        @inbounds dzu[i]<0 && (alpha_z_R=min(alpha_z_R,-zu_r[i]*tau_R/dzu[i]))
+    @inbounds @simd for i=1:length(zu_r)
+        dzu[i]<0 && (alpha_z_R=min(alpha_z_R,-zu_r[i]*tau_R/dzu[i]))
     end
-    @simd for i=1:length(zp)
-        @inbounds dzp[i]<0 && (alpha_z_R=min(alpha_z_R,-zp[i]*tau_R/dzp[i]))
+    @inbounds @simd for i=1:length(zp)
+        dzp[i]<0 && (alpha_z_R=min(alpha_z_R,-zp[i]*tau_R/dzp[i]))
     end
-    @simd for i=1:length(zn)
-        @inbounds dzn[i]<0 && (alpha_z_R=min(alpha_z_R,-zn[i]*tau_R/dzn[i]))
+    @inbounds @simd for i=1:length(zn)
+        dzn[i]<0 && (alpha_z_R=min(alpha_z_R,-zn[i]*tau_R/dzn[i]))
     end
     return alpha_z_R
 end
-function get_varphi_R(obj_val,x_lr,xl_r,xu_r,x_ur,pp,nn,mu_R)
+
+function get_varphi_R(obj_val, x_lr, xl_r, xu_r, x_ur, pp, nn, mu_R)
     varphi_R = obj_val
-    @simd for i=1:length(x_lr)
-        @inbounds xll = x_lr[i]-xl_r[i]
+    @inbounds @simd for i=1:length(x_lr)
+        xll = x_lr[i]-xl_r[i]
         xll < 0 && return Inf
         varphi_R -= mu_R*log(xll)
     end
-    @simd for i=1:length(x_ur)
-        @inbounds xuu = xu_r[i]-x_ur[i]
+    @inbounds @simd for i=1:length(x_ur)
+        xuu = xu_r[i]-x_ur[i]
         xuu < 0 && return Inf
         varphi_R -= mu_R*log(xuu)
     end
-    @simd for i=1:length(pp)
-        @inbounds pp[i] < 0 && return Inf
-        @inbounds varphi_R -= mu_R*log(pp[i])
+    @inbounds @simd for i=1:length(pp)
+        pp[i] < 0 && return Inf
+        varphi_R -= mu_R*log(pp[i])
     end
-    @simd for i=1:length(pp)
-        @inbounds nn[i] < 0 && return Inf
-        @inbounds varphi_R -= mu_R*log(nn[i])
+    @inbounds @simd for i=1:length(pp)
+        nn[i] < 0 && return Inf
+        varphi_R -= mu_R*log(nn[i])
     end
     return varphi_R
 end
-function get_F(c,f,zl,zu,jacl,x_lr,xl_r,zl_r,xu_r,x_ur,zu_r,mu)
-    F = 0.
-    for i=1:length(c)
-        @inbounds F = max(F,c[i])
+
+function get_F(c, f, zl, zu, jacl, x_lr, xl_r, zl_r, xu_r, x_ur, zu_r, mu)
+    F = 0.0
+    @inbounds for i=1:length(c)
+        F = max(F, c[i])
     end
-    for i=1:length(f)
-        @inbounds F = max(F,f[i]-zl[i]+zu[i]+jacl[i])
+    @inbounds for i=1:length(f)
+        F = max(F, f[i]-zl[i]+zu[i]+jacl[i])
     end
-    for i=1:length(x_lr)
+    @inbounds for i=1:length(x_lr)
         x_lr[i] >= xl_r[i] || return Inf
         zl_r[i] >= 0       || return Inf
-        @inbounds F = max(F,(x_lr[i]-xl_r[i])*zl_r[i]-mu)
+        F = max(F, (x_lr[i]-xl_r[i])*zl_r[i]-mu)
     end
-    for i=1:length(x_ur)
+    @inbounds for i=1:length(x_ur)
         xu_r[i] >= x_ur[i] || return Inf
         zu_r[i] >= 0       || return Inf
-        @inbounds F = max(F,(xu_r[i]-xu_r[i])*zu_r[i]-mu)
+        F = max(F, (xu_r[i]-xu_r[i])*zu_r[i]-mu)
     end
     return F
 end
-function get_varphi_d_R(f_R,x,xl,xu,dx,pp,nn,dpp,dnn,mu_R,rho)
-    varphi_d = 0.
-    @simd for i=1:length(x)
-        @inbounds varphi_d += (f_R[i] - mu_R/(x[i]-xl[i]) + mu_R/(xu[i]-x[i])) *dx[i]
+
+function get_varphi_d_R(f_R, x, xl, xu, dx, pp, nn, dpp, dnn, mu_R, rho)
+    varphi_d = 0.0
+    @inbounds @simd for i=1:length(x)
+        varphi_d += (f_R[i] - mu_R/(x[i]-xl[i]) + mu_R/(xu[i]-x[i])) * dx[i]
     end
-    @simd for i=1:length(pp)
-        @inbounds varphi_d += (rho - mu_R/pp[i]) *dpp[i]
+    @inbounds @simd for i=1:length(pp)
+        varphi_d += (rho - mu_R/pp[i]) * dpp[i]
     end
-    @simd for i=1:length(nn)
-        @inbounds varphi_d += (rho - mu_R/nn[i]) *dnn[i]
+    @inbounds @simd for i=1:length(nn)
+        varphi_d += (rho - mu_R/nn[i]) * dnn[i]
     end
     return varphi_d
 end
-function initialize_variables!(x,xl,xu,bound_push,bound_fac)
+
+function initialize_variables!(x, xl, xu, bound_push, bound_fac)
     @inbounds @simd for i=1:length(x)
         if xl[i]!=-Inf && xu[i]!=Inf
-            x[i]=min(xu[i]-min(bound_push*max(1,abs(xu[i])),bound_fac*(xu[i]-xl[i])),
-                     max(xl[i]+min(bound_push*max(1,abs(xl[i])),bound_fac*(xu[i]-xl[i])),x[i]))
+            x[i] = min(
+                xu[i]-min(bound_push*max(1,abs(xu[i])), bound_fac*(xu[i]-xl[i])),
+                max(xl[i]+min(bound_push*max(1,abs(xl[i])),bound_fac*(xu[i]-xl[i])),x[i]),
+            )
         elseif xl[i]!=-Inf && xu[i]==Inf
-            x[i]=max(xl[i]+bound_push*max(1,abs(xl[i])),x[i])
+            x[i] = max(xl[i]+bound_push*max(1,abs(xl[i])), x[i])
         elseif xl[i]==-Inf && xu[i]!=Inf
-            x[i]=min(xu[i]-bound_push*max(1,abs(xu[i])),x[i])
+            x[i] = min(xu[i]-bound_push*max(1,abs(xu[i])), x[i])
         end
     end
 end
 
-function adjust_boundary!(x_lr::VT,xl_r,x_ur,xu_r,mu) where {T, VT <: AbstractVector{T}}
+function adjust_boundary!(x_lr::VT, xl_r, x_ur, xu_r, mu) where {T, VT <: AbstractVector{T}}
     adjusted = 0
     c1 = eps(T)*mu
     c2= eps(T)^(3/4)
-    @simd for i=1:length(xl_r)
-        @inbounds x_lr[i]-xl_r[i] < c1 && (xl_r[i] -= c2*max(1,abs(x_lr[i]));adjusted+=1)
+    @inbounds @simd for i=1:length(xl_r)
+        if x_lr[i]-xl_r[i] < c1
+            xl_r[i] -= c2*max(1,abs(x_lr[i]))
+            adjusted += 1
+        end
     end
-    @simd for i=1:length(xu_r)
-        @inbounds xu_r[i]-x_ur[i] < c1 && (xu_r[i] += c2*max(1,abs(x_ur[i]));adjusted+=1)
+    @inbounds @simd for i=1:length(xu_r)
+        if xu_r[i]-x_ur[i] < c1
+            xu_r[i] += c2*max(1, abs(x_ur[i]))
+            adjusted += 1
+        end
     end
     return adjusted
 end
-function get_rel_search_norm(x,dx)
-    rel_search_norm = 0.
-    @simd for i=1:length(x)
-        @inbounds rel_search_norm = max(rel_search_norm,abs(dx[i])/(1. +abs(x[i])))
+
+function get_rel_search_norm(x, dx)
+    rel_search_norm = 0.0
+    @inbounds @simd for i=1:length(x)
+        rel_search_norm = max(
+            rel_search_norm,
+            abs(dx[i]) / (1.0 + abs(x[i])),
+        )
     end
     return rel_search_norm
 end
 
 # Utility functions
-get_sd(l,zl_r,zu_r,s_max) =
-    max(s_max,(norm(l,1)+norm(zl_r,1)+norm(zu_r,1)) / max(1,(length(l)+length(zl_r)+length(zu_r))))/s_max
-get_sc(zl_r,zu_r,s_max) =
-    max(s_max,(norm(zl_r,1)+norm(zu_r,1)) / max(1,length(zl_r)+length(zu_r)))/s_max
-get_mu(mu,mu_min,mu_linear_decrease_factor,mu_superlinear_decrease_power,tol) =
-    max(mu_min, max(tol/10,min(mu_linear_decrease_factor*mu,mu^mu_superlinear_decrease_power)))
-get_tau(mu,tau_min)=max(tau_min,1-mu)
-function get_alpha_min(theta,varphi_d,theta_min,gamma_theta,gamma_phi,alpha_min_frac,del,s_theta,s_phi)
+function get_sd(l, zl_r, zu_r, s_max)
+    return max(
+        s_max,
+        (norm(l, 1)+norm(zl_r, 1)+norm(zu_r, 1)) / max(1, (length(l)+length(zl_r)+length(zu_r))),
+    ) / s_max
+end
+
+function get_sc(zl_r, zu_r, s_max)
+    return max(
+        s_max,
+        (norm(zl_r,1)+norm(zu_r,1)) / max(1,length(zl_r)+length(zu_r)),
+    ) / s_max
+end
+
+function get_mu(mu, mu_min, mu_linear_decrease_factor, mu_superlinear_decrease_power, tol)
+    return max(
+        mu_min,
+        tol/10,
+        min(mu_linear_decrease_factor*mu, mu^mu_superlinear_decrease_power),
+    )
+end
+
+@inline get_tau(mu, tau_min) = max(tau_min, 1-mu)
+
+function get_alpha_min(theta, varphi_d, theta_min, gamma_theta, gamma_phi, alpha_min_frac, del, s_theta, s_phi)
     if varphi_d<0
         if theta<=theta_min
             return alpha_min_frac*min(
                 gamma_theta,gamma_phi*theta/(-varphi_d),
-                del*theta^s_theta/(-varphi_d)^s_phi)
+                del*theta^s_theta/(-varphi_d)^s_phi,
+            )
         else
             return alpha_min_frac*min(
-                gamma_theta,gamma_phi*theta/(-varphi_d))
+                gamma_theta,
+                -gamma_phi*theta/varphi_d,
+            )
         end
     else
         return alpha_min_frac*gamma_theta
     end
 end
-is_switching(varphi_d,alpha,s_phi,del,theta,s_theta) = varphi_d < 0 && alpha*(-varphi_d)^s_phi > del*theta^s_theta
-is_armijo(varphi_trial,varphi,eta_phi,alpha,varphi_d) = varphi_trial <= varphi + eta_phi*alpha*varphi_d
-is_sufficient_progress(theta_trial::T,theta,gamma_theta,varphi_trial,varphi,gamma_phi,has_constraints) where T =
-    (has_constraints && ((theta_trial<=(1-gamma_theta)*theta+10*eps(T)*abs(theta))) ||
-    ((varphi_trial<=varphi-gamma_phi*theta +10*eps(T)*abs(varphi))))
-augment_filter!(filter,theta,varphi,gamma_theta) = push!(filter,((1-gamma_theta)*theta,varphi-gamma_theta*theta))
-function is_filter_acceptable(filter,theta,varphi)
+
+function is_switching(varphi_d, alpha, s_phi, del, theta, s_theta)
+    return (varphi_d < 0) && (alpha*(-varphi_d)^s_phi > del*theta^s_theta)
+end
+
+function is_armijo(varphi_trial, varphi, eta_phi, alpha, varphi_d)
+    return (varphi_trial <= varphi + eta_phi*alpha*varphi_d)
+end
+
+function is_sufficient_progress(theta_trial::T, theta, gamma_theta, varphi_trial, varphi, gamma_phi, has_constraints) where T
+    (has_constraints && ((theta_trial<=(1-gamma_theta)*theta+10*eps(T)*abs(theta))) || ((varphi_trial<=varphi-gamma_phi*theta +10*eps(T)*abs(varphi))))
+end
+
+function augment_filter!(filter, theta, varphi, gamma_theta)
+    push!(filter, ((1-gamma_theta)*theta, varphi-gamma_theta*theta))
+end
+
+function is_filter_acceptable(filter, theta, varphi)
     !isnan(theta) || return false
     !isinf(theta) || return false
     !isnan(varphi) || return false
@@ -370,10 +443,20 @@ function is_filter_acceptable(filter,theta,varphi)
     end
     return true
 end
-is_barr_obj_rapid_increase(varphi,varphi_trial,obj_max_inc) =
-    varphi_trial >= varphi && log(10,varphi_trial-varphi) > obj_max_inc + max(1.,log(10,abs(varphi)))
-reset_bound_dual!(z,x,mu,kappa_sigma) = (z.=max.(min.(z,kappa_sigma.*mu./x),mu/kappa_sigma./x))
-reset_bound_dual!(z,x1,x2,mu,kappa_sigma) = (z.=max.(min.(z,(kappa_sigma*mu)./(x1.-x2)),(mu/kappa_sigma)./(x1.-x2)))
+
+function is_barr_obj_rapid_increase(varphi, varphi_trial, obj_max_inc)
+    return (varphi_trial >= varphi) && (log10(varphi_trial-varphi) > obj_max_inc + max(1.0, log10(abs(varphi))))
+end
+
+function reset_bound_dual!(z, x, mu, kappa_sigma)
+    z .= max.(min.(z, (kappa_sigma*mu)./x), (mu/kappa_sigma)./x)
+    return
+end
+function reset_bound_dual!(z, x1, x2, mu, kappa_sigma)
+    z .= max.(min.(z, (kappa_sigma*mu)./(x1.-x2)), (mu/kappa_sigma)./(x1.-x2))
+    return
+end
+
 function get_ftype(filter,theta,theta_trial,varphi,varphi_trial,switching_condition,armijo_condition,
                    theta_min,obj_max_inc,gamma_theta,gamma_phi,has_constraints)
     is_filter_acceptable(filter,theta_trial,varphi_trial) || return " "
@@ -391,8 +474,8 @@ end
 
 # fixed variable treatment ----------------------------------------------------
 function _get_fixed_variable_index(
-    mat::SparseMatrixCSC{Tv,Ti1}, ind_fixed::Vector{Ti2}) where {Tv,Ti1,Ti2}
-
+    mat::SparseMatrixCSC{Tv,Ti1}, ind_fixed::Vector{Ti2}
+) where {Tv,Ti1,Ti2}
     fixed_aug_index = Int[]
     for i in ind_fixed
         append!(fixed_aug_index,append!(collect(mat.colptr[i]+1:mat.colptr[i+1]-1)))
@@ -401,19 +484,32 @@ function _get_fixed_variable_index(
 
     return fixed_aug_index
 end
-fixed_variable_treatment_vec!(vec,ind_fixed) = (vec[ind_fixed] .= 0.)
-function fixed_variable_treatment_z!(zl,zu,f,jacl,ind_fixed)
-    @simd for i in ind_fixed
-        z = f[i]+jacl[i]
-        z >=0 ? (zl[i] = z; zu[i] = 0.) : (zl[i] = 0.; zu[i] = -z)
+
+function fixed_variable_treatment_vec!(vec, ind_fixed)
+    @inbounds for i in ind_fixed
+        vec[i] = 0.0
     end
 end
 
-function dual_inf_perturbation!(px,ind_llb,ind_uub,mu,kappa_d)
-    @simd for i in ind_llb
-        @inbounds px[i] -= mu*kappa_d
-    end
-    @simd for i in ind_uub
-        @inbounds px[i] += mu*kappa_d
+function fixed_variable_treatment_z!(zl, zu, f, jacl, ind_fixed)
+    @inbounds @simd for i in ind_fixed
+        z = f[i]+jacl[i]
+        if z >= 0.0
+            zl[i] = z
+            zu[i] = 0.0
+        else
+            zl[i] = 0.0
+            zu[i] = -z
+        end
     end
 end
+
+function dual_inf_perturbation!(px, ind_llb, ind_uub, mu, kappa_d)
+    @inbounds @simd for i in ind_llb
+        px[i] -= mu*kappa_d
+    end
+    @inbounds @simd for i in ind_uub
+        px[i] += mu*kappa_d
+    end
+end
+

--- a/src/IPM/restoration.jl
+++ b/src/IPM/restoration.jl
@@ -1,4 +1,4 @@
-mutable struct RobustRestorer{T} 
+mutable struct RobustRestorer{T}
     obj_val_R::T
     f_R::Vector{T}
     x_ref::Vector{T}
@@ -61,16 +61,16 @@ function RobustRestorer(solver::AbstractMadNLPSolver{T}) where T
     )
 end
 
-function initialize_robust_restorer!(solver::AbstractMadNLPSolver)
+function initialize_robust_restorer!(solver::AbstractMadNLPSolver{T}) where T
     @trace(solver.logger,"Initializing restoration phase variables.")
     solver.RR == nothing && (solver.RR = RobustRestorer(solver))
     RR = solver.RR
 
-    RR.x_ref .= solver.x
+    copyto!(RR.x_ref, solver.x)
     RR.theta_ref = get_theta(solver.c)
-    RR.D_R   .= min.(1,1 ./abs.(RR.x_ref))
+    RR.D_R .= min.(one(T), one(T) ./abs.(RR.x_ref))
 
-    RR.mu_R = max(solver.mu,norm(solver.c,Inf))
+    RR.mu_R = max(solver.mu, norm(solver.c, Inf))
     RR.tau_R= max(solver.opt.tau_min,1-RR.mu_R)
     RR.zeta = sqrt(RR.mu_R)
 
@@ -81,16 +81,16 @@ function initialize_robust_restorer!(solver::AbstractMadNLPSolver)
     RR.zn .= RR.mu_R./RR.nn
 
     RR.obj_val_R = get_obj_val_R(RR.pp,RR.nn,RR.D_R,solver.x,RR.x_ref,solver.opt.rho,RR.zeta)
-    RR.f_R.=0
+    fill!(RR.f_R, zero(T))
     empty!(RR.filter)
-    push!(RR.filter,(solver.theta_max,-Inf))
+    push!(RR.filter, (solver.theta_max,-Inf))
 
-    solver.y .= 0.
-    solver.zl_r .= min.(solver.opt.rho,solver.zl_r)
-    solver.zu_r .= min.(solver.opt.rho,solver.zu_r)
+    fill!(solver.y, zero(T))
+    solver.zl_r .= min.(solver.opt.rho, solver.zl_r)
+    solver.zu_r .= min.(solver.opt.rho, solver.zu_r)
     solver.cnt.t = 0
 
     # misc
-    solver.del_w = 0
+    solver.del_w = zero(T)
 end
 

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -56,7 +56,7 @@ function initialize!(solver::AbstractMadNLPSolver{T}) where T
     @trace(solver.logger,"Computing objective scaling.")
     if solver.opt.nlp_scaling
         solver.obj_scale[] = scale_objective(solver.nlp, solver.f; max_gradient=solver.opt.nlp_scaling_max_gradient)
-        scal!(solver.obj_scale[], solver.f)
+        BLAS.scal!(solver.obj_scale[], solver.f)
     end
 
     # Initialize dual variables

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -56,7 +56,7 @@ function initialize!(solver::AbstractMadNLPSolver{T}) where T
     @trace(solver.logger,"Computing objective scaling.")
     if solver.opt.nlp_scaling
         solver.obj_scale[] = scale_objective(solver.nlp, solver.f; max_gradient=solver.opt.nlp_scaling_max_gradient)
-        BLAS.scal!(solver.obj_scale[], solver.f)
+        _scal!(solver.obj_scale[], solver.f)
     end
 
     # Initialize dual variables

--- a/src/IPM/utils.jl
+++ b/src/IPM/utils.jl
@@ -36,15 +36,9 @@ getStatus(result::MadNLPExecutionStats) = STATUS_OUTPUT_DICT[result.status]
 # Utilities
 has_constraints(solver) = solver.m != 0
 
-# Print functions -----------------------------------------------------------
-function print_init(solver::AbstractMadNLPSolver)
-    @notice(solver.logger,@sprintf("Number of nonzeros in constraint Jacobian............: %8i", get_nnzj(solver.nlp.meta)))
-    @notice(solver.logger,@sprintf("Number of nonzeros in Lagrangian Hessian.............: %8i\n", get_nnzh(solver.nlp.meta)))
-
+function get_vars_info(solver)
     x_lb = get_lvar(solver.nlp)
     x_ub = get_uvar(solver.nlp)
-    g_lb = get_lcon(solver.nlp)
-    g_ub = get_ucon(solver.nlp)
     num_fixed = length(solver.ind_fixed)
     num_var = get_nvar(solver.nlp) - num_fixed
     num_llb_vars = length(solver.ind_llb)
@@ -56,6 +50,18 @@ function print_init(solver::AbstractMadNLPSolver)
         end
     end
     num_uub_vars = length(solver.ind_uub)
+    return (
+        n_free=num_var,
+        n_fixed=num_fixed,
+        n_only_lb=num_llb_vars,
+        n_only_ub=num_uub_vars,
+        n_bounded=num_lu_vars,
+    )
+end
+
+function get_cons_info(solver)
+    g_lb = get_lcon(solver.nlp)
+    g_ub = get_ucon(solver.nlp)
     # Classify constraints
     num_eq_cons, num_ineq_cons = 0, 0
     num_ue_cons, num_le_cons, num_lu_cons = 0, 0, 0
@@ -74,20 +80,35 @@ function print_init(solver::AbstractMadNLPSolver)
             end
         end
     end
+    return (
+        n_eq=num_eq_cons,
+        n_ineq=num_ineq_cons,
+        n_only_lb=num_le_cons,
+        n_only_ub=num_ue_cons,
+        n_bounded=num_lu_cons,
+    )
+end
 
-    if get_nvar(solver.nlp) < num_eq_cons
+# Print functions -----------------------------------------------------------
+function print_init(solver::AbstractMadNLPSolver)
+    @notice(solver.logger,@sprintf("Number of nonzeros in constraint Jacobian............: %8i", get_nnzj(solver.nlp.meta)))
+    @notice(solver.logger,@sprintf("Number of nonzeros in Lagrangian Hessian.............: %8i\n", get_nnzh(solver.nlp.meta)))
+    var_info = get_vars_info(solver)
+    con_info = get_cons_info(solver)
+
+    if get_nvar(solver.nlp) < con_info.n_eq
         throw(NotEnoughDegreesOfFreedomException())
     end
 
-    @notice(solver.logger,@sprintf("Total number of variables............................: %8i",num_var))
-    @notice(solver.logger,@sprintf("                     variables with only lower bounds: %8i",num_llb_vars))
-    @notice(solver.logger,@sprintf("                variables with lower and upper bounds: %8i",num_lu_vars))
-    @notice(solver.logger,@sprintf("                     variables with only upper bounds: %8i",num_uub_vars))
-    @notice(solver.logger,@sprintf("Total number of equality constraints.................: %8i",num_eq_cons))
-    @notice(solver.logger,@sprintf("Total number of inequality constraints...............: %8i",num_ineq_cons))
-    @notice(solver.logger,@sprintf("        inequality constraints with only lower bounds: %8i",num_le_cons))
-    @notice(solver.logger,@sprintf("   inequality constraints with lower and upper bounds: %8i",num_lu_cons))
-    @notice(solver.logger,@sprintf("        inequality constraints with only upper bounds: %8i\n",num_ue_cons))
+    @notice(solver.logger,@sprintf("Total number of variables............................: %8i",var_info.n_free))
+    @notice(solver.logger,@sprintf("                     variables with only lower bounds: %8i",var_info.n_only_lb))
+    @notice(solver.logger,@sprintf("                variables with lower and upper bounds: %8i",var_info.n_bounded))
+    @notice(solver.logger,@sprintf("                     variables with only upper bounds: %8i",var_info.n_only_ub))
+    @notice(solver.logger,@sprintf("Total number of equality constraints.................: %8i",con_info.n_eq))
+    @notice(solver.logger,@sprintf("Total number of inequality constraints...............: %8i",con_info.n_ineq))
+    @notice(solver.logger,@sprintf("        inequality constraints with only lower bounds: %8i",con_info.n_only_lb))
+    @notice(solver.logger,@sprintf("   inequality constraints with lower and upper bounds: %8i",con_info.n_bounded))
+    @notice(solver.logger,@sprintf("        inequality constraints with only upper bounds: %8i\n",con_info.n_only_ub))
     return
 end
 

--- a/src/LinearSolvers/linearsolvers.jl
+++ b/src/LinearSolvers/linearsolvers.jl
@@ -114,12 +114,11 @@ struct SolveException <: Exception end
 struct InertiaException <: Exception end
 LinearSolverException=Union{SymbolicException,FactorizationException,SolveException,InertiaException}
 
-@enum(
-    LinearFactorization::Int,
+@enum(LinearFactorization::Int,
     BUNCHKAUFMAN = 1,
     LU = 2,
-    QR =3,
-    CHOLESKY=4,
+    QR = 3,
+    CHOLESKY = 4,
 )
 
 # iterative solvers

--- a/src/MadNLP.jl
+++ b/src/MadNLP.jl
@@ -7,8 +7,8 @@ import Pkg.TOML: parsefile
 import MathOptInterface
 import Libdl: dlopen, dlext, RTLD_DEEPBIND, RTLD_GLOBAL
 import Printf: @sprintf
-import LinearAlgebra: BLAS, Adjoint, Symmetric, mul!, ldiv!, norm, dot
-import LinearAlgebra.BLAS: axpy!, symv!, libblas, liblapack, BlasInt, @blasfunc
+import LinearAlgebra: BLAS, Adjoint, Symmetric, mul!, ldiv!, norm, dot, normInf
+import LinearAlgebra.BLAS: axpy!, scal!, symv!, libblas, liblapack, BlasInt, @blasfunc
 import SparseArrays: AbstractSparseMatrix, SparseMatrixCSC, sparse, getcolptr, rowvals, nnz
 import Base: string, show, print, size, getindex, copyto!, @kwdef
 import SuiteSparse: UMFPACK

--- a/src/MadNLP.jl
+++ b/src/MadNLP.jl
@@ -8,7 +8,7 @@ import MathOptInterface
 import Libdl: dlopen, dlext, RTLD_DEEPBIND, RTLD_GLOBAL
 import Printf: @sprintf
 import LinearAlgebra: BLAS, Adjoint, Symmetric, mul!, ldiv!, norm, dot, normInf
-import LinearAlgebra.BLAS: axpy!, scal!, symv!, libblas, liblapack, BlasInt, @blasfunc
+import LinearAlgebra.BLAS: axpy!, symv!, libblas, liblapack, BlasInt, @blasfunc
 import SparseArrays: AbstractSparseMatrix, SparseMatrixCSC, sparse, getcolptr, rowvals, nnz
 import Base: string, show, print, size, getindex, copyto!, @kwdef
 import SuiteSparse: UMFPACK

--- a/src/nlpmodels.jl
+++ b/src/nlpmodels.jl
@@ -33,14 +33,14 @@ before calling this function.
 
 """
 function scale_constraints!(
-    nlp::AbstractNLPModel,
+    nlp::AbstractNLPModel{T},
     con_scale::AbstractVector,
     jac::AbstractMatrix;
     max_gradient=1e-8,
-)
-    fill!(con_scale, 0.0)
+) where T
+    fill!(con_scale, zero(T))
     _set_scaling!(con_scale, jac)
-    con_scale .= min.(1.0, max_gradient ./ con_scale)
+    con_scale .= min.(one(T), max_gradient ./ con_scale)
 end
 
 """
@@ -62,11 +62,11 @@ before calling this function.
 
 """
 function scale_objective(
-    nlp::AbstractNLPModel,
+    nlp::AbstractNLPModel{T},
     grad::AbstractVector;
     max_gradient=1e-8,
-)
-    return min(1, max_gradient / norm(grad, Inf))
+) where T
+    return min(one(T), max_gradient / normInf(grad))
 end
 
 function get_index_constraints(nlp::AbstractNLPModel; fixed_variable_treatment=MAKE_PARAMETER)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -45,7 +45,12 @@ end
 # CUBLAS currently does not import symv!,
 # so using symv! is not dispatched to CUBLAS.symv!
 # symul! wraps symv! and dispatch based on the data type
-symul!(y, A, x::AbstractVector{T}, α = 1, β = 0) where T = BLAS.symv!('L', T(α), A, x, T(β), y) 
+symul!(y, A, x::AbstractVector{T}, α = 1, β = 0) where T = BLAS.symv!('L', T(α), A, x, T(β), y)
+
+# Two-arguments BLAS.scal! is not supported in Julia 1.6.
+function _scal!(a::T, x::AbstractVector{T}) where T
+    return BLAS.scal!(length(x), a, x, 1)
+end
 
 const blas_num_threads = Ref{Int}(1)
 function set_blas_num_threads(n::Integer;permanent::Bool=false)


### PR DESCRIPTION
- rewrite one-line functions to improve readibility 
- use `@inbounds @simd` in a systematic way before for loops
- fix easy broadcast calls in kernels.jl
- rewrite broadcast operators in `print_init` to ease compiler job (1s gain in itself)

x-ref #186 

Currently, we get on MadNLP#master:
```
InferenceTimingNode: 5.120791/8.009915 on Core.Compiler.Timings.ROOT() with 9 direct children
```
With this PR: 
```
InferenceTimingNode: 4.037863/6.572491 on Core.Compiler.Timings.ROOT() with 9 direct children 
```
(note that this is independent from the results already reported in #227 )


As a reminder, when we get `InferenceTimingNode: x/y`, that means we are spending `x` seconds in the LLVM compilation, and `y` seconds in total (compilation + precompilation). With this PR, it takes 4s to compile the call to MadNLP, 2.5s to precompile the code and do the type inference. 