### PR TITLE
Remove allocations in callbacks 

### DIFF
--- a/lib/MadNLPGPU/src/kernels.jl
+++ b/lib/MadNLPGPU/src/kernels.jl
@@ -112,9 +112,14 @@ end
 function MadNLP.set_aug_diagonal!(kkt::MadNLP.AbstractDenseKKTSystem{T, VT, MT}, solver::MadNLP.MadNLPSolver) where {T, VT<:CuVector{T}, MT<:CuMatrix{T}}
     haskey(kkt.etc, :pr_diag_host) || (kkt.etc[:pr_diag_host] = Vector{T}(undef, length(kkt.pr_diag)))
     pr_diag_h = kkt.etc[:pr_diag_host]::Vector{T}
+    x = MadNLP.full(solver.x)
+    zl = MadNLP.full(solver.zl)
+    zu = MadNLP.full(solver.zu)
+    xl = MadNLP.full(solver.xl)
+    xu = MadNLP.full(solver.xu)
     # Broadcast is not working as MadNLP array are allocated on the CPU,
     # whereas pr_diag is allocated on the GPU
-    pr_diag_h .= full(solver.zl)./(full(solver.x).-full(solver.xl)) .+ full(solver.zu)./(full(solver.xu).-full(solver.x))
+    pr_diag_h .= zl./(x.-xl) .+ zu./(xu.-x)
     copyto!(kkt.pr_diag, pr_diag_h)
     fill!(kkt.du_diag, 0.0)
 end

--- a/lib/MadNLPGPU/test/densekkt_gpu.jl
+++ b/lib/MadNLPGPU/test/densekkt_gpu.jl
@@ -22,18 +22,18 @@ function _compare_gpu_with_cpu(KKTSystem, n, m, ind_fixed)
 
         # Solve on CPU
         h_solver = MadNLP.MadNLPSolver(nlp; madnlp_options...)
-        MadNLP.solve!(h_solver)
+        results_cpu = MadNLP.solve!(h_solver)
 
         # Solve on GPU
         d_solver = MadNLPGPU.CuMadNLPSolver(nlp; madnlp_options...)
-        MadNLP.solve!(d_solver)
+        results_gpu = MadNLP.solve!(d_solver)
 
         @test isa(d_solver.kkt, KKTSystem{T, CuVector{T}, CuMatrix{T}})
         # # Check that both results match exactly
         @test h_solver.cnt.k == d_solver.cnt.k
-        @test h_solver.obj_val ≈ d_solver.obj_val atol=atol
-        @test h_solver.x ≈ d_solver.x atol=atol
-        @test h_solver.y ≈ d_solver.y atol=atol
+        @test results_cpu.objective ≈ results_gpu.objective
+        @test results_cpu.solution ≈ results_gpu.solution atol=atol
+        @test results_cpu.multipliers ≈ results_gpu.multipliers atol=atol
     end
 end
 

--- a/src/IPM/IPM.jl
+++ b/src/IPM/IPM.jl
@@ -154,8 +154,8 @@ function MadNLPSolver{T,KKTSystem}(
     nlb = length(ind_cons.ind_lb)
     nub = length(ind_cons.ind_ub)
 
-    x_trial=Vector{T}(undef,n)
-    c_trial=Vector{T}(undef,m)
+    x_trial = Vector{T}(undef,n)
+    c_trial = Vector{T}(undef,m)
 
     x_slk= _madnlp_unsafe_wrap(x,ns, get_nvar(nlp)+1)
     c_slk= view(c,ind_cons.ind_ineq)

--- a/src/IPM/callbacks.jl
+++ b/src/IPM/callbacks.jl
@@ -119,7 +119,7 @@ function eval_lag_hess_wrapper!(solver::MadNLPSolver, kkt::AbstractDenseKKTSyste
     @trace(solver.logger,"Evaluating Lagrangian Hessian.")
     dual(solver._w1) .= l .* solver.con_scale
     hess = get_hessian(kkt)
-    scale = is_resto ? zero(T) : get_minimize(nlp) ? one(T) : -one(T)
+    scale = is_resto ? zero(T) : get_minimize(nlp) ? solver.obj_scale[] : -solver.obj_scale[]
     cnt.eval_function_time += @elapsed hess_dense!(
         nlp,
         variable(x),

--- a/src/IPM/callbacks.jl
+++ b/src/IPM/callbacks.jl
@@ -2,46 +2,48 @@ function eval_f_wrapper(solver::MadNLPSolver, x::Vector{T}) where T
     nlp = solver.nlp
     cnt = solver.cnt
     @trace(solver.logger,"Evaluating objective.")
-    x_nlpmodel = _madnlp_unsafe_wrap(x, get_nvar(nlp))
-    cnt.eval_function_time += @elapsed obj_val = (get_minimize(nlp) ? 1. : -1.) * obj(nlp,x_nlpmodel)
-    cnt.obj_cnt+=1
-    cnt.obj_cnt==1 && (is_valid(obj_val) || throw(InvalidNumberException(:obj)))
-    return obj_val*solver.obj_scale[]
+    x_ = _madnlp_unsafe_wrap(x, get_nvar(nlp))
+    cnt.eval_function_time += @elapsed begin
+        sense = (get_minimize(nlp) ? one(T) : -one(T))
+        obj_val = sense * obj(nlp, x_)
+    end
+    cnt.obj_cnt += 1
+    if cnt.obj_cnt == 1 && !is_valid(obj_val)
+        throw(InvalidNumberException(:obj))
+    end
+    return obj_val * solver.obj_scale[]
 end
 
-function eval_grad_f_wrapper!(solver::MadNLPSolver, f::Vector{T},x::Vector{T}) where T
+function eval_grad_f_wrapper!(solver::MadNLPSolver, f::Vector{T}, x::Vector{T}) where T
     nlp = solver.nlp
     cnt = solver.cnt
     @trace(solver.logger,"Evaluating objective gradient.")
-    x_nlpmodel = _madnlp_unsafe_wrap(x, get_nvar(nlp))
-    f_nlpmodel = _madnlp_unsafe_wrap(f, get_nvar(nlp))
-    cnt.eval_function_time += @elapsed grad!(
-        nlp,
-        x_nlpmodel,
-        f_nlpmodel
-    )
-    f.*=solver.obj_scale[] * (get_minimize(nlp) ? 1. : -1.)
-    cnt.obj_grad_cnt+=1
-    cnt.obj_grad_cnt==1 && (is_valid(f)  || throw(InvalidNumberException(:grad)))
+    scale = solver.obj_scale[] * (get_minimize(nlp) ? one(T) : -one(T))
+    x_ = _madnlp_unsafe_wrap(x, get_nvar(nlp))
+    f_ = _madnlp_unsafe_wrap(f, get_nvar(nlp))
+    cnt.eval_function_time += @elapsed grad!(nlp, x_, f_)
+    f .*= scale
+    cnt.obj_grad_cnt += 1
+    if cnt.obj_grad_cnt == 1 && !is_valid(f)
+        throw(InvalidNumberException(:grad))
+    end
     return f
 end
 
-function eval_cons_wrapper!(solver::MadNLPSolver, c::Vector{T},x::Vector{T}) where T
+function eval_cons_wrapper!(solver::MadNLPSolver, c::Vector{T}, x::Vector{T}) where T
     nlp = solver.nlp
     cnt = solver.cnt
     @trace(solver.logger, "Evaluating constraints.")
-    x_nlpmodel = _madnlp_unsafe_wrap(x, get_nvar(nlp))
-    c_nlpmodel = _madnlp_unsafe_wrap(c, get_ncon(nlp))
-    cnt.eval_function_time += @elapsed cons!(
-        nlp,
-        x_nlpmodel,
-        c_nlpmodel
-    )
-    view(c,solver.ind_ineq).-=view(x,get_nvar(nlp)+1:solver.n)
-    c.-=solver.rhs
-    c.*=solver.con_scale
-    cnt.con_cnt+=1
-    cnt.con_cnt==2 && (is_valid(c) || throw(InvalidNumberException(:cons)))
+    x_ = _madnlp_unsafe_wrap(x, get_nvar(nlp))
+    c_ = _madnlp_unsafe_wrap(c, get_ncon(nlp))
+    cnt.eval_function_time += @elapsed cons!(nlp, x_, c_)
+    view(c,solver.ind_ineq) .-= view(x,get_nvar(nlp)+1:solver.n)
+    c .-= solver.rhs
+    c .*= solver.con_scale
+    cnt.con_cnt += 1
+    if cnt.con_cnt == 1 && !is_valid(c)
+        throw(InvalidNumberException(:cons))
+    end
     return c
 end
 
@@ -50,17 +52,18 @@ function eval_jac_wrapper!(solver::MadNLPSolver, kkt::AbstractKKTSystem, x::Vect
     cnt = solver.cnt
     ns = length(solver.ind_ineq)
     @trace(solver.logger, "Evaluating constraint Jacobian.")
+    x_ = _madnlp_unsafe_wrap(x, get_nvar(nlp))
     jac = get_jacobian(kkt)
-    x_nlpmodel = _madnlp_unsafe_wrap(x, get_nvar(nlp))
-    jac_nlpmodel = _madnlp_unsafe_wrap(jac, get_nnzj(nlp.meta))
     cnt.eval_function_time += @elapsed jac_coord!(
         nlp,
-        x_nlpmodel,
-        jac_nlpmodel
+        x_,
+        jac,
     )
     compress_jacobian!(kkt)
-    cnt.con_jac_cnt+=1
-    cnt.con_jac_cnt==1 && (is_valid(jac) || throw(InvalidNumberException(:jac)))
+    cnt.con_jac_cnt += 1
+    if cnt.con_jac_cnt == 1 && !is_valid(jac)
+        throw(InvalidNumberException(:jac))
+    end
     @trace(solver.logger,"Constraint jacobian evaluation started.")
     return jac
 end
@@ -69,20 +72,23 @@ function eval_lag_hess_wrapper!(solver::MadNLPSolver, kkt::AbstractKKTSystem, x:
     nlp = solver.nlp
     cnt = solver.cnt
     @trace(solver.logger,"Evaluating Lagrangian Hessian.")
-    dual(solver._w1) .= l.*solver.con_scale
+    dual(solver._w1) .= l .* solver.con_scale
+    x_ = _madnlp_unsafe_wrap(x, get_nvar(nlp))
     hess = get_hessian(kkt)
-    x_nlpmodel = _madnlp_unsafe_wrap(x, get_nvar(nlp))
-    hess_nlpmodel = _madnlp_unsafe_wrap(hess, get_nnzh(nlp.meta))
+    scale = (get_minimize(nlp) ? one(T) : -one(T))
+    scale *= (is_resto ? zero(T) : solver.obj_scale[])
     cnt.eval_function_time += @elapsed hess_coord!(
         nlp,
-        x_nlpmodel,
+        x_,
         dual(solver._w1),
-        hess_nlpmodel;
-        obj_weight = (get_minimize(nlp) ? 1. : -1.) * (is_resto ? 0.0 : solver.obj_scale[])
+        hess;
+        obj_weight = scale,
     )
     compress_hessian!(kkt)
-    cnt.lag_hess_cnt+=1
-    cnt.lag_hess_cnt==1 && (is_valid(hess) || throw(InvalidNumberException(:hess)))
+    cnt.lag_hess_cnt += 1
+    if cnt.lag_hess_cnt == 1 && !is_valid(hess)
+        throw(InvalidNumberException(:hess))
+    end
     return hess
 end
 
@@ -91,16 +97,18 @@ function eval_jac_wrapper!(solver::MadNLPSolver, kkt::AbstractDenseKKTSystem, x:
     cnt = solver.cnt
     ns = length(solver.ind_ineq)
     @trace(solver.logger, "Evaluating constraint Jacobian.")
+    x_ = _madnlp_unsafe_wrap(x, get_nvar(nlp))
     jac = get_jacobian(kkt)
-    x_nlpmodel = _madnlp_unsafe_wrap(x, get_nvar(nlp))
     cnt.eval_function_time += @elapsed jac_dense!(
         nlp,
-        x_nlpmodel,
-        jac
+        x_,
+        jac,
     )
     compress_jacobian!(kkt)
     cnt.con_jac_cnt+=1
-    cnt.con_jac_cnt==1 && (is_valid(jac) || throw(InvalidNumberException(:jac)))
+    if cnt.con_jac_cnt == 1 && !is_valid(jac)
+        throw(InvalidNumberException(:jac))
+    end
     @trace(solver.logger,"Constraint jacobian evaluation started.")
     return jac
 end
@@ -109,18 +117,23 @@ function eval_lag_hess_wrapper!(solver::MadNLPSolver, kkt::AbstractDenseKKTSyste
     nlp = solver.nlp
     cnt = solver.cnt
     @trace(solver.logger,"Evaluating Lagrangian Hessian.")
-    dual(solver._w1) .= l.*solver.con_scale
+    dual(solver._w1) .= l .* solver.con_scale
+    x_ = _madnlp_unsafe_wrap(x, get_nvar(nlp))
     hess = get_hessian(kkt)
-    x_nlpmodel = _madnlp_unsafe_wrap(x, get_nvar(nlp))
+    scale = (get_minimize(nlp) ? one(T) : -one(T))
+    scale *= (is_resto ? zero(T) : solver.obj_scale[])
     cnt.eval_function_time += @elapsed hess_dense!(
         nlp,
-        x_nlpmodel,
+        x_,
         dual(solver._w1),
         hess;
-        obj_weight = (get_minimize(nlp) ? 1. : -1.) * (is_resto ? 0.0 : solver.obj_scale[])
+        obj_weight = scale,
     )
     compress_hessian!(kkt)
     cnt.lag_hess_cnt+=1
-    cnt.lag_hess_cnt==1 && (is_valid(hess) || throw(InvalidNumberException(:hess)))
+    if cnt.lag_hess_cnt == 1 && !is_valid(hess)
+        throw(InvalidNumberException(:hess))
+    end
     return hess
 end
+

--- a/src/IPM/callbacks.jl
+++ b/src/IPM/callbacks.jl
@@ -1,11 +1,10 @@
-function eval_f_wrapper(solver::MadNLPSolver, x::Vector{T}) where T
+function eval_f_wrapper(solver::MadNLPSolver, x::PrimalVector{T}) where T
     nlp = solver.nlp
     cnt = solver.cnt
     @trace(solver.logger,"Evaluating objective.")
-    x_ = _madnlp_unsafe_wrap(x, get_nvar(nlp))
     cnt.eval_function_time += @elapsed begin
         sense = (get_minimize(nlp) ? one(T) : -one(T))
-        obj_val = sense * obj(nlp, x_)
+        obj_val = sense * obj(nlp, variable(x))
     end
     cnt.obj_cnt += 1
     if cnt.obj_cnt == 1 && !is_valid(obj_val)
@@ -14,30 +13,27 @@ function eval_f_wrapper(solver::MadNLPSolver, x::Vector{T}) where T
     return obj_val * solver.obj_scale[]
 end
 
-function eval_grad_f_wrapper!(solver::MadNLPSolver, f::Vector{T}, x::Vector{T}) where T
+function eval_grad_f_wrapper!(solver::MadNLPSolver, f::PrimalVector{T}, x::PrimalVector{T}) where T
     nlp = solver.nlp
     cnt = solver.cnt
     @trace(solver.logger,"Evaluating objective gradient.")
     scale = solver.obj_scale[] * (get_minimize(nlp) ? one(T) : -one(T))
-    x_ = _madnlp_unsafe_wrap(x, get_nvar(nlp))
-    f_ = _madnlp_unsafe_wrap(f, get_nvar(nlp))
-    cnt.eval_function_time += @elapsed grad!(nlp, x_, f_)
-    f .*= scale
+    cnt.eval_function_time += @elapsed grad!(nlp, variable(x), variable(f))
+    grad!(nlp, variable(x), variable(f))
+    full(f) .*= scale
     cnt.obj_grad_cnt += 1
-    if cnt.obj_grad_cnt == 1 && !is_valid(f)
+    if cnt.obj_grad_cnt == 1 && !is_valid(full(f))
         throw(InvalidNumberException(:grad))
     end
     return f
 end
 
-function eval_cons_wrapper!(solver::MadNLPSolver, c::Vector{T}, x::Vector{T}) where T
+function eval_cons_wrapper!(solver::MadNLPSolver, c::Vector{T}, x::PrimalVector{T}) where T
     nlp = solver.nlp
     cnt = solver.cnt
     @trace(solver.logger, "Evaluating constraints.")
-    x_ = _madnlp_unsafe_wrap(x, get_nvar(nlp))
-    c_ = _madnlp_unsafe_wrap(c, get_ncon(nlp))
-    cnt.eval_function_time += @elapsed cons!(nlp, x_, c_)
-    view(c,solver.ind_ineq) .-= view(x,get_nvar(nlp)+1:solver.n)
+    cnt.eval_function_time += @elapsed cons!(nlp, variable(x), c)
+    view(c,solver.ind_ineq) .-= slack(x)
     c .-= solver.rhs
     c .*= solver.con_scale
     cnt.con_cnt += 1
@@ -47,16 +43,15 @@ function eval_cons_wrapper!(solver::MadNLPSolver, c::Vector{T}, x::Vector{T}) wh
     return c
 end
 
-function eval_jac_wrapper!(solver::MadNLPSolver, kkt::AbstractKKTSystem, x::Vector{T}) where T
+function eval_jac_wrapper!(solver::MadNLPSolver, kkt::AbstractKKTSystem, x::PrimalVector{T}) where T
     nlp = solver.nlp
     cnt = solver.cnt
     ns = length(solver.ind_ineq)
     @trace(solver.logger, "Evaluating constraint Jacobian.")
-    x_ = _madnlp_unsafe_wrap(x, get_nvar(nlp))
     jac = get_jacobian(kkt)
     cnt.eval_function_time += @elapsed jac_coord!(
         nlp,
-        x_,
+        variable(x),
         jac,
     )
     compress_jacobian!(kkt)
@@ -68,18 +63,17 @@ function eval_jac_wrapper!(solver::MadNLPSolver, kkt::AbstractKKTSystem, x::Vect
     return jac
 end
 
-function eval_lag_hess_wrapper!(solver::MadNLPSolver, kkt::AbstractKKTSystem, x::Vector{T},l::Vector{T};is_resto=false) where T
+function eval_lag_hess_wrapper!(solver::MadNLPSolver, kkt::AbstractKKTSystem, x::PrimalVector{T},l::Vector{T};is_resto=false) where T
     nlp = solver.nlp
     cnt = solver.cnt
     @trace(solver.logger,"Evaluating Lagrangian Hessian.")
     dual(solver._w1) .= l .* solver.con_scale
-    x_ = _madnlp_unsafe_wrap(x, get_nvar(nlp))
     hess = get_hessian(kkt)
     scale = (get_minimize(nlp) ? one(T) : -one(T))
     scale *= (is_resto ? zero(T) : solver.obj_scale[])
     cnt.eval_function_time += @elapsed hess_coord!(
         nlp,
-        x_,
+        variable(x),
         dual(solver._w1),
         hess;
         obj_weight = scale,
@@ -92,16 +86,15 @@ function eval_lag_hess_wrapper!(solver::MadNLPSolver, kkt::AbstractKKTSystem, x:
     return hess
 end
 
-function eval_jac_wrapper!(solver::MadNLPSolver, kkt::AbstractDenseKKTSystem, x::Vector{T}) where T
+function eval_jac_wrapper!(solver::MadNLPSolver, kkt::AbstractDenseKKTSystem, x::PrimalVector{T}) where T
     nlp = solver.nlp
     cnt = solver.cnt
     ns = length(solver.ind_ineq)
     @trace(solver.logger, "Evaluating constraint Jacobian.")
-    x_ = _madnlp_unsafe_wrap(x, get_nvar(nlp))
     jac = get_jacobian(kkt)
     cnt.eval_function_time += @elapsed jac_dense!(
         nlp,
-        x_,
+        variable(x),
         jac,
     )
     compress_jacobian!(kkt)
@@ -113,18 +106,17 @@ function eval_jac_wrapper!(solver::MadNLPSolver, kkt::AbstractDenseKKTSystem, x:
     return jac
 end
 
-function eval_lag_hess_wrapper!(solver::MadNLPSolver, kkt::AbstractDenseKKTSystem, x::Vector{T},l::Vector{T};is_resto=false) where T
+function eval_lag_hess_wrapper!(solver::MadNLPSolver, kkt::AbstractDenseKKTSystem, x::PrimalVector{T},l::Vector{T};is_resto=false) where T
     nlp = solver.nlp
     cnt = solver.cnt
     @trace(solver.logger,"Evaluating Lagrangian Hessian.")
     dual(solver._w1) .= l .* solver.con_scale
-    x_ = _madnlp_unsafe_wrap(x, get_nvar(nlp))
     hess = get_hessian(kkt)
     scale = (get_minimize(nlp) ? one(T) : -one(T))
     scale *= (is_resto ? zero(T) : solver.obj_scale[])
     cnt.eval_function_time += @elapsed hess_dense!(
         nlp,
-        x_,
+        variable(x),
         dual(solver._w1),
         hess;
         obj_weight = scale,

--- a/src/IPM/callbacks.jl
+++ b/src/IPM/callbacks.jl
@@ -119,8 +119,7 @@ function eval_lag_hess_wrapper!(solver::MadNLPSolver, kkt::AbstractDenseKKTSyste
     @trace(solver.logger,"Evaluating Lagrangian Hessian.")
     dual(solver._w1) .= l .* solver.con_scale
     hess = get_hessian(kkt)
-    scale = (get_minimize(nlp) ? one(T) : -one(T))
-    scale *= (is_resto ? zero(T) : solver.obj_scale[])
+    scale = is_resto ? zero(T) : get_minimize(nlp) ? one(T) : -one(T)
     cnt.eval_function_time += @elapsed hess_dense!(
         nlp,
         variable(x),

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -2,7 +2,7 @@
 # KKT system updates -------------------------------------------------------
 # Set diagonal
 function set_aug_diagonal!(kkt::AbstractKKTSystem, solver::MadNLPSolver)
-    kkt.pr_diag .= solver.zl./(solver.x.-solver.xl) .+ solver.zu./(solver.xu.-solver.x)
+    kkt.pr_diag .= full(solver.zl)./(full(solver.x).-full(solver.xl)) .+ full(solver.zu)./(full(solver.xu).-full(solver.x))
     fill!(kkt.du_diag, 0.0)
 end
 function set_aug_diagonal!(kkt::SparseUnreducedKKTSystem, solver::MadNLPSolver)
@@ -16,7 +16,7 @@ end
 
 # Robust restoration
 function set_aug_RR!(kkt::AbstractKKTSystem, solver::MadNLPSolver, RR::RobustRestorer)
-    kkt.pr_diag .= solver.zl./(solver.x.-solver.xl) .+ solver.zu./(solver.xu.-solver.x) .+ RR.zeta.*RR.D_R.^2
+    kkt.pr_diag .= full(solver.zl)./(full(solver.x).-full(solver.xl)) .+ full(solver.zu)./(full(solver.xu).-full(solver.x)) .+ RR.zeta.*RR.D_R.^2
     kkt.du_diag .= .-RR.pp./RR.zp .- RR.nn./RR.zn
 end
 function set_aug_RR!(kkt::SparseUnreducedKKTSystem, solver::MadNLPSolver, RR::RobustRestorer)
@@ -30,12 +30,12 @@ end
 
 # Set RHS
 function set_aug_rhs!(solver::MadNLPSolver, kkt::AbstractKKTSystem, c)
-    primal(solver.p) .= .-solver.f.+solver.mu./(solver.x.-solver.xl).-solver.mu./(solver.xu.-solver.x).-solver.jacl
+    primal(solver.p) .= .-primal(solver.f).+solver.mu./(primal(solver.x).-primal(solver.xl)).-solver.mu./(primal(solver.xu).-primal(solver.x)).-solver.jacl
     dual(solver.p)   .= .-c
 end
 
 function set_aug_rhs!(solver::MadNLPSolver, kkt::SparseUnreducedKKTSystem, c)
-    primal(solver.p) .= .-solver.f.+solver.zl.-solver.zu.-solver.jacl
+    primal(solver.p) .= .-primal(solver.f).+primal(solver.zl).-primal(solver.zu).-solver.jacl
     dual(solver.p) .= .-c
     dual_lb(solver.p) .= (solver.xl_r-solver.x_lr).*kkt.l_lower .+ solver.mu./kkt.l_lower
     dual_ub(solver.p) .= (solver.xu_r-solver.x_ur).*kkt.u_lower .- solver.mu./kkt.u_lower
@@ -52,7 +52,7 @@ end
 function set_aug_rhs_RR!(
     solver::MadNLPSolver, kkt::AbstractKKTSystem, RR::RobustRestorer, rho,
 )
-    primal(solver.p) .= .-RR.f_R.-solver.jacl.+RR.mu_R./(solver.x.-solver.xl).-RR.mu_R./(solver.xu.-solver.x)
+    primal(solver.p) .= .-RR.f_R.-solver.jacl.+RR.mu_R./(full(solver.x).-full(solver.xl)).-RR.mu_R./(full(solver.xu).-full(solver.x))
     dual(solver.p) .= .-solver.c.+RR.pp.-RR.nn.+(RR.mu_R.-(rho.-solver.y).*RR.pp)./RR.zp.-(RR.mu_R.-(rho.+solver.y).*RR.nn)./RR.zn
 end
 
@@ -71,11 +71,11 @@ end
 
 # Initial
 function set_initial_rhs!(solver::MadNLPSolver, kkt::AbstractKKTSystem)
-    primal(solver.p) .= .-solver.f.+solver.zl.-solver.zu
+    primal(solver.p) .= .-primal(solver.f).+primal(solver.zl).-primal(solver.zu)
     dual(solver.p) .= 0.0
 end
 function set_initial_rhs!(solver::MadNLPSolver, kkt::SparseUnreducedKKTSystem)
-    primal(solver.p) .= .-solver.f.+solver.zl.-solver.zu
+    primal(solver.p) .= .-primal(solver.f).+primal(solver.zl).-primal(solver.zu)
     dual(solver.p) .= 0.0
     dual_lb(solver.p) .= 0.0
     dual_ub(solver.p) .= 0.0

--- a/src/IPM/restoration.jl
+++ b/src/IPM/restoration.jl
@@ -66,7 +66,7 @@ function initialize_robust_restorer!(solver::AbstractMadNLPSolver)
     solver.RR == nothing && (solver.RR = RobustRestorer(solver))
     RR = solver.RR
 
-    RR.x_ref .= solver.x
+    RR.x_ref .= full(solver.x)
     RR.theta_ref = get_theta(solver.c)
     RR.D_R   .= min.(1,1 ./abs.(RR.x_ref))
 
@@ -80,7 +80,7 @@ function initialize_robust_restorer!(solver::AbstractMadNLPSolver)
     RR.zp .= RR.mu_R./RR.pp
     RR.zn .= RR.mu_R./RR.nn
 
-    RR.obj_val_R = get_obj_val_R(RR.pp,RR.nn,RR.D_R,solver.x,RR.x_ref,solver.opt.rho,RR.zeta)
+    RR.obj_val_R = get_obj_val_R(RR.pp,RR.nn,RR.D_R,full(solver.x),RR.x_ref,solver.opt.rho,RR.zeta)
     RR.f_R.=0
     empty!(RR.filter)
     push!(RR.filter,(solver.theta_max,-Inf))

--- a/src/IPM/restoration.jl
+++ b/src/IPM/restoration.jl
@@ -1,4 +1,4 @@
-mutable struct RobustRestorer{T} 
+mutable struct RobustRestorer{T}
     obj_val_R::T
     f_R::Vector{T}
     x_ref::Vector{T}

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -29,7 +29,7 @@ function initialize!(solver::AbstractMadNLPSolver)
     @trace(solver.logger,"Initializing slack variables.")
     cons!(solver.nlp,get_x0(solver.nlp),_madnlp_unsafe_wrap(solver.c,get_ncon(solver.nlp)))
     solver.cnt.con_cnt += 1
-    solver.x_slk.=solver.c_slk
+    slack(solver.x) .=solver.c_slk
 
     # Initialization
     @trace(solver.logger,"Initializing primal and bound duals.")
@@ -37,7 +37,12 @@ function initialize!(solver::AbstractMadNLPSolver)
     solver.zu_r.=1.0
     solver.xl_r.-= max.(1,abs.(solver.xl_r)).*solver.opt.tol
     solver.xu_r.+= max.(1,abs.(solver.xu_r)).*solver.opt.tol
-    initialize_variables!(solver.x,solver.xl,solver.xu,solver.opt.bound_push,solver.opt.bound_fac)
+    initialize_variables!(
+        full(solver.x),
+        full(solver.xl),
+        full(solver.xu),
+        solver.opt.bound_push,solver.opt.bound_fac,
+    )
 
     # Automatic scaling (constraints)
     @trace(solver.logger,"Computing constraint scaling.")
@@ -55,8 +60,8 @@ function initialize!(solver::AbstractMadNLPSolver)
     eval_grad_f_wrapper!(solver, solver.f,solver.x)
     @trace(solver.logger,"Computing objective scaling.")
     if solver.opt.nlp_scaling
-        solver.obj_scale[] = scale_objective(solver.nlp, solver.f; max_gradient=solver.opt.nlp_scaling_max_gradient)
-        solver.f.*=solver.obj_scale[]
+        solver.obj_scale[] = scale_objective(solver.nlp, full(solver.f); max_gradient=solver.opt.nlp_scaling_max_gradient)
+        full(solver.f).*=solver.obj_scale[]
     end
 
     # Initialize dual variables
@@ -90,7 +95,7 @@ end
 
 
 function reinitialize!(solver::AbstractMadNLPSolver)
-    view(solver.x,1:get_nvar(solver.nlp)) .= get_x0(solver.nlp)
+    variable(solver.x) .= get_x0(solver.nlp)
 
     solver.obj_val = eval_f_wrapper(solver, solver.x)
     eval_grad_f_wrapper!(solver, solver.f, solver.x)
@@ -117,16 +122,16 @@ function solve!(
 )
 
     if x != nothing
-        solver.x[1:get_nvar(solver.nlp)] .= x
+        variable(solver.x) .= x
     end
     if y != nothing
         solver.y[1:get_ncon(solver.nlp)] .= y
     end
     if zl != nothing
-        solver.zl[1:get_nvar(solver.nlp)] .= zl
+        variable(solver.zl) .= zl
     end
     if zu != nothing
-        solver.zu[1:get_nvar(solver.nlp)] .= zu
+        variable(solver.zu) .= zu
     end
 
     if !isempty(kwargs)
@@ -193,23 +198,35 @@ function unscale!(solver::AbstractMadNLPSolver)
     solver.obj_val/=solver.obj_scale[]
     solver.c ./= solver.con_scale
     solver.c .+= solver.rhs
-    solver.c_slk .+= solver.x_slk
+    solver.c_slk .+= slack(solver.x)
 end
 
-function regular!(solver::AbstractMadNLPSolver)
+function regular!(solver::AbstractMadNLPSolver{T}) where T
     while true
         if (solver.cnt.k!=0 && !solver.opt.jacobian_constant)
             eval_jac_wrapper!(solver, solver.kkt, solver.x)
         end
         jtprod!(solver.jacl, solver.kkt, solver.y)
         fixed_variable_treatment_vec!(solver.jacl,solver.ind_fixed)
-        fixed_variable_treatment_z!(solver.zl,solver.zu,solver.f,solver.jacl,solver.ind_fixed)
+        fixed_variable_treatment_z!(
+            full(solver.zl),
+            full(solver.zu),
+            full(solver.f),
+            solver.jacl,
+            solver.ind_fixed,
+        )
 
         sd = get_sd(solver.y,solver.zl_r,solver.zu_r,solver.opt.s_max)
         sc = get_sc(solver.zl_r,solver.zu_r,solver.opt.s_max)
 
         solver.inf_pr = get_inf_pr(solver.c)
-        solver.inf_du = get_inf_du(solver.f,solver.zl,solver.zu,solver.jacl,sd)
+        solver.inf_du = get_inf_du(
+            full(solver.f),
+            full(solver.zl),
+            full(solver.zu),
+            solver.jacl,
+            sd,
+        )
         solver.inf_compl = get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,0.,sc)
         inf_compl_mu = get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,solver.mu,sc)
 
@@ -265,10 +282,22 @@ function regular!(solver::AbstractMadNLPSolver)
         @trace(solver.logger,"Backtracking line search initiated.")
         theta = get_theta(solver.c)
         varphi= get_varphi(solver.obj_val,solver.x_lr,solver.xl_r,solver.xu_r,solver.x_ur,solver.mu)
-        varphi_d = get_varphi_d(solver.f,solver.x,solver.xl,solver.xu,primal(solver.d),solver.mu)
+        varphi_d = get_varphi_d(
+            primal(solver.f),
+			primal(solver.x),
+			primal(solver.xl),
+			primal(solver.xu),
+			primal(solver.d),
+			solver.mu,
+		)
 
-
-        alpha_max = get_alpha_max(solver.x,solver.xl,solver.xu,primal(solver.d),solver.tau)
+        alpha_max = get_alpha_max(
+            primal(solver.x),
+            primal(solver.xl),
+            primal(solver.xu),
+            primal(solver.d),
+            solver.tau,
+        )
         solver.alpha_z = get_alpha_z(solver.zl_r,solver.zu_r,dual_lb(solver.d),dual_ub(solver.d),solver.tau)
         alpha_min = get_alpha_min(theta,varphi_d,solver.theta_min,solver.opt.gamma_theta,solver.opt.gamma_phi,
                                   solver.opt.alpha_min_frac,solver.opt.delta,solver.opt.s_theta,solver.opt.s_phi)
@@ -276,12 +305,12 @@ function regular!(solver::AbstractMadNLPSolver)
         solver.alpha = alpha_max
         varphi_trial= 0.
             theta_trial = 0.
-            small_search_norm = get_rel_search_norm(solver.x, primal(solver.d)) < 10*eps(eltype(solver.x))
+            small_search_norm = get_rel_search_norm(primal(solver.x), primal(solver.d)) < 10*eps(T)
         switching_condition = is_switching(varphi_d,solver.alpha,solver.opt.s_phi,solver.opt.delta,2.,solver.opt.s_theta)
         armijo_condition = false
         while true
-            copyto!(solver.x_trial, solver.x)
-            axpy!(solver.alpha, primal(solver.d), solver.x_trial)
+            copyto!(full(solver.x_trial), full(solver.x))
+            axpy!(solver.alpha, primal(solver.d), primal(solver.x_trial))
 
             solver.obj_val_trial = eval_f_wrapper(solver, solver.x_trial)
             eval_cons_wrapper!(solver, solver.c_trial, solver.x_trial)
@@ -310,14 +339,14 @@ function regular!(solver::AbstractMadNLPSolver)
                 return RESTORE
             else
                 @trace(solver.logger,"Step rejected; proceed with the next trial step.")
-                solver.alpha * norm(primal(solver.d)) < eps(eltype(solver.x))*10 &&
+                solver.alpha * norm(primal(solver.d)) < eps(T)*10 &&
                     return solver.cnt.acceptable_cnt >0 ?
                     SOLVED_TO_ACCEPTABLE_LEVEL : SEARCH_DIRECTION_BECOMES_TOO_SMALL
             end
         end
 
         @trace(solver.logger,"Updating primal-dual variables.")
-        solver.x.=solver.x_trial
+        copyto!(full(solver.x), full(solver.x_trial))
         solver.c.=solver.c_trial
         solver.obj_val=solver.obj_val_trial
         adjusted = adjust_boundary!(solver.x_lr,solver.xl_r,solver.x_ur,solver.xu_r,solver.mu)
@@ -327,8 +356,18 @@ function regular!(solver::AbstractMadNLPSolver)
         axpy!(solver.alpha,dual(solver.d),solver.y)
         axpy!(solver.alpha_z, dual_lb(solver.d), solver.zl_r)
         axpy!(solver.alpha_z, dual_ub(solver.d), solver.zu_r)
-        reset_bound_dual!(solver.zl,solver.x,solver.xl,solver.mu,solver.opt.kappa_sigma)
-        reset_bound_dual!(solver.zu,solver.xu,solver.x,solver.mu,solver.opt.kappa_sigma)
+        reset_bound_dual!(
+            primal(solver.zl),
+            primal(solver.x),
+            primal(solver.xl),
+            solver.mu,solver.opt.kappa_sigma,
+        )
+        reset_bound_dual!(
+            primal(solver.zu),
+            primal(solver.xu),
+            primal(solver.x),
+            solver.mu,solver.opt.kappa_sigma,
+        )
         eval_grad_f_wrapper!(solver, solver.f,solver.x)
 
         if !switching_condition || !armijo_condition
@@ -343,20 +382,42 @@ end
 
 function restore!(solver::AbstractMadNLPSolver)
     solver.del_w=0
-    primal(solver._w1) .= solver.x # backup the previous primal iterate
+    primal(solver._w1) .= full(solver.x) # backup the previous primal iterate
     dual(solver._w1) .= solver.y # backup the previous primal iterate
     dual(solver._w2) .= solver.c # backup the previous primal iterate
 
-    F = get_F(solver.c,solver.f,solver.zl,solver.zu,solver.jacl,solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,solver.mu)
+    F = get_F(
+        solver.c,
+        primal(solver.f),
+        primal(solver.zl),
+        primal(solver.zu),
+        solver.jacl,
+        solver.x_lr,
+        solver.xl_r,
+        solver.zl_r,
+        solver.xu_r,
+        solver.x_ur,
+        solver.zu_r,
+        solver.mu,
+    )
     solver.cnt.t = 0
     solver.alpha_z = 0.
     solver.ftype = "R"
 
     while true
-        solver.alpha = min(get_alpha_max(solver.x,solver.xl,solver.xu,primal(solver.d),solver.tau),
-                        get_alpha_z(solver.zl_r,solver.zu_r,dual_lb(solver.d),dual_ub(solver.d),solver.tau))
+        alpha_max = get_alpha_max(
+            primal(solver.x),
+            primal(solver.xl),
+            primal(solver.xu),
+            primal(solver.d),
+            solver.tau,
+        )
+        solver.alpha = min(
+            alpha_max,
+            get_alpha_z(solver.zl_r,solver.zu_r,dual_lb(solver.d),dual_ub(solver.d),solver.tau),
+            )
 
-        solver.x .+= solver.alpha.* primal(solver.d)
+        primal(solver.x) .+= solver.alpha.* primal(solver.d)
         solver.y .+= solver.alpha.* dual(solver.d)
         solver.zl_r.+=solver.alpha.* dual_lb(solver.d)
         solver.zu_r.+=solver.alpha.* dual_ub(solver.d)
@@ -369,9 +430,21 @@ function restore!(solver::AbstractMadNLPSolver)
         jtprod!(solver.jacl,solver.kkt,solver.y)
 
         F_trial = get_F(
-            solver.c,solver.f,solver.zl,solver.zu,solver.jacl,solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,solver.mu)
+            solver.c,
+            primal(solver.f),
+            primal(solver.zl),
+            primal(solver.zu),
+            solver.jacl,
+            solver.x_lr,
+            solver.xl_r,
+            solver.zl_r,
+            solver.xu_r,
+            solver.x_ur,
+            solver.zu_r,
+            solver.mu,
+        )
         if F_trial > solver.opt.soft_resto_pderror_reduction_factor*F
-            solver.x .= primal(solver._w1)
+            primal(solver.x) .= primal(solver._w1)
             solver.y .= dual(solver._w1)
             solver.c .= dual(solver._w2) # backup the previous primal iterate
             return ROBUST
@@ -397,7 +470,13 @@ function restore!(solver::AbstractMadNLPSolver)
         sd = get_sd(solver.y,solver.zl_r,solver.zu_r,solver.opt.s_max)
         sc = get_sc(solver.zl_r,solver.zu_r,solver.opt.s_max)
         solver.inf_pr = get_inf_pr(solver.c)
-        solver.inf_du = get_inf_du(solver.f,solver.zl,solver.zu,solver.jacl,sd)
+        solver.inf_du = get_inf_du(
+            primal(solver.f),
+            primal(solver.zl),
+            primal(solver.zu),
+            solver.jacl,
+            sd,
+        )
 
         solver.inf_compl = get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,0.,sc)
         inf_compl_mu = get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,solver.mu,sc)
@@ -416,7 +495,7 @@ function restore!(solver::AbstractMadNLPSolver)
     end
 end
 
-function robust!(solver::MadNLPSolver)
+function robust!(solver::MadNLPSolver{T}) where T
     initialize_robust_restorer!(solver)
     RR = solver.RR
     while true
@@ -425,19 +504,31 @@ function robust!(solver::MadNLPSolver)
         end
         jtprod!(solver.jacl, solver.kkt, solver.y)
         fixed_variable_treatment_vec!(solver.jacl,solver.ind_fixed)
-        fixed_variable_treatment_z!(solver.zl,solver.zu,solver.f,solver.jacl,solver.ind_fixed)
+        fixed_variable_treatment_z!(
+            full(solver.zl),
+            full(solver.zu),
+            full(solver.f),
+            solver.jacl,
+            solver.ind_fixed,
+        )
 
         # evaluate termination criteria
         @trace(solver.logger,"Evaluating restoration phase termination criteria.")
         sd = get_sd(solver.y,solver.zl_r,solver.zu_r,solver.opt.s_max)
         sc = get_sc(solver.zl_r,solver.zu_r,solver.opt.s_max)
         solver.inf_pr = get_inf_pr(solver.c)
-        solver.inf_du = get_inf_du(solver.f,solver.zl,solver.zu,solver.jacl,sd)
+        solver.inf_du = get_inf_du(
+            primal(solver.f),
+            primal(solver.zl),
+            primal(solver.zu),
+            solver.jacl,
+            sd,
+        )
         solver.inf_compl = get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,0.,sc)
 
         # Robust restoration phase error
         RR.inf_pr_R = get_inf_pr_R(solver.c,RR.pp,RR.nn)
-        RR.inf_du_R = get_inf_du_R(RR.f_R,solver.y,solver.zl,solver.zu,solver.jacl,RR.zp,RR.zn,solver.opt.rho,sd)
+        RR.inf_du_R = get_inf_du_R(RR.f_R,solver.y,primal(solver.zl),primal(solver.zu),solver.jacl,RR.zp,RR.zn,solver.opt.rho,sd)
         RR.inf_compl_R = get_inf_compl_R(
             solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,RR.pp,RR.zp,RR.nn,RR.zn,0.,sc)
         inf_compl_mu_R = get_inf_compl_R(
@@ -483,10 +574,23 @@ function robust!(solver::MadNLPSolver)
 
         theta_R = get_theta_R(solver.c,RR.pp,RR.nn)
         varphi_R = get_varphi_R(RR.obj_val_R,solver.x_lr,solver.xl_r,solver.xu_r,solver.x_ur,RR.pp,RR.nn,RR.mu_R)
-        varphi_d_R = get_varphi_d_R(RR.f_R,solver.x,solver.xl,solver.xu,primal(solver.d),RR.pp,RR.nn,RR.dpp,RR.dnn,RR.mu_R,solver.opt.rho)
+        varphi_d_R = get_varphi_d_R(
+            RR.f_R,
+            primal(solver.x),
+            primal(solver.xl),
+            primal(solver.xu),
+            primal(solver.d),
+            RR.pp,RR.nn,RR.dpp,RR.dnn,RR.mu_R,solver.opt.rho,
+        )
 
         # set alpha_min
-        alpha_max = get_alpha_max_R(solver.x,solver.xl,solver.xu,primal(solver.d),RR.pp,RR.dpp,RR.nn,RR.dnn,RR.tau_R)
+        alpha_max = get_alpha_max_R(
+			primal(solver.x),
+			primal(solver.xl),
+			primal(solver.xu),
+			primal(solver.d),
+			RR.pp,RR.dpp,RR.nn,RR.dnn,RR.tau_R,
+		)
         solver.alpha_z = get_alpha_z_R(solver.zl_r,solver.zu_r,dual_lb(solver.d),dual_ub(solver.d),RR.zp,RR.dzp,RR.zn,RR.dzn,RR.tau_R)
         alpha_min = get_alpha_min(theta_R,varphi_d_R,solver.theta_min,solver.opt.gamma_theta,solver.opt.gamma_phi,
                                   solver.opt.alpha_min_frac,solver.opt.delta,solver.opt.s_theta,solver.opt.s_phi)
@@ -497,20 +601,20 @@ function robust!(solver::MadNLPSolver)
         solver.cnt.l = 1
         theta_R_trial = 0.
         varphi_R_trial = 0.
-        small_search_norm = get_rel_search_norm(solver.x, primal(solver.d)) < 10*eps(eltype(solver.x))
+        small_search_norm = get_rel_search_norm(primal(solver.x), primal(solver.d)) < 10*eps(T)
         switching_condition = is_switching(varphi_d_R,solver.alpha,solver.opt.s_phi,solver.opt.delta,theta_R,solver.opt.s_theta)
         armijo_condition = false
 
         while true
-            copyto!(solver.x_trial,solver.x)
+            copyto!(full(solver.x_trial), full(solver.x))
             copyto!(RR.pp_trial,RR.pp)
             copyto!(RR.nn_trial,RR.nn)
-            axpy!(solver.alpha,primal(solver.d),solver.x_trial)
+            axpy!(solver.alpha,primal(solver.d),primal(solver.x_trial))
             axpy!(solver.alpha,RR.dpp,RR.pp_trial)
             axpy!(solver.alpha,RR.dnn,RR.nn_trial)
 
             RR.obj_val_R_trial = get_obj_val_R(
-                RR.pp_trial,RR.nn_trial,RR.D_R,solver.x_trial,RR.x_ref,solver.opt.rho,RR.zeta)
+                RR.pp_trial,RR.nn_trial,RR.D_R,primal(solver.x_trial),RR.x_ref,solver.opt.rho,RR.zeta)
             eval_cons_wrapper!(solver, solver.c_trial, solver.x_trial)
             theta_R_trial  = get_theta_R(solver.c_trial,RR.pp_trial,RR.nn_trial)
             varphi_R_trial = get_varphi_R(
@@ -533,19 +637,19 @@ function robust!(solver::MadNLPSolver)
                 return RESTORATION_FAILED
             else
                 @trace(solver.logger,"Step rejected; proceed with the next trial step.")
-                solver.alpha < eps(eltype(solver.x))*10 && return solver.cnt.acceptable_cnt >0 ?
+                solver.alpha < eps(T)*10 && return solver.cnt.acceptable_cnt >0 ?
                     SOLVED_TO_ACCEPTABLE_LEVEL : SEARCH_DIRECTION_BECOMES_TOO_SMALL
             end
         end
 
         @trace(solver.logger,"Updating primal-dual variables.")
-        solver.x.=solver.x_trial
+        full(solver.x) .= full(solver.x_trial)
         solver.c.=solver.c_trial
         RR.pp.=RR.pp_trial
         RR.nn.=RR.nn_trial
 
         RR.obj_val_R=RR.obj_val_R_trial
-        RR.f_R .= RR.zeta.*RR.D_R.^2 .*(solver.x.-RR.x_ref)
+        RR.f_R .= RR.zeta.*RR.D_R.^2 .*(full(solver.x).-RR.x_ref)
 
         axpy!(solver.alpha, dual(solver.d), solver.y)
         axpy!(solver.alpha_z, dual_lb(solver.d),solver.zl_r)
@@ -553,8 +657,18 @@ function robust!(solver::MadNLPSolver)
         axpy!(solver.alpha_z, RR.dzp,RR.zp)
         axpy!(solver.alpha_z, RR.dzn,RR.zn)
 
-        reset_bound_dual!(solver.zl,solver.x,solver.xl,RR.mu_R,solver.opt.kappa_sigma)
-        reset_bound_dual!(solver.zu,solver.xu,solver.x,RR.mu_R,solver.opt.kappa_sigma)
+        reset_bound_dual!(
+            primal(solver.zl),
+            primal(solver.x),
+            primal(solver.xl),
+            RR.mu_R, solver.opt.kappa_sigma,
+        )
+        reset_bound_dual!(
+            primal(solver.zu),
+            primal(solver.xu),
+            primal(solver.x),
+            RR.mu_R, solver.opt.kappa_sigma,
+        )
         reset_bound_dual!(RR.zp,RR.pp,RR.mu_R,solver.opt.kappa_sigma)
         reset_bound_dual!(RR.zn,RR.nn,RR.mu_R,solver.opt.kappa_sigma)
 
@@ -651,8 +765,10 @@ function inertia_free_reg(solver::MadNLPSolver)
     wx= primal(solver._w4)
     fill!(dual(solver._w3), 0)
 
-    g = solver.x_trial # just to avoid new allocation
-    g .= solver.f.-solver.mu./(solver.x.-solver.xl).+solver.mu./(solver.xu.-solver.x).+solver.jacl
+    g = full(solver.x_trial) # just to avoid new allocation
+    g .= full(solver.f)
+    g .-= solver.mu./(full(solver.x).-full(solver.xl))
+    g .+= solver.mu./(full(solver.xu).-full(solver.x)).+solver.jacl
 
     fixed_variable_treatment_vec!(primal(solver._w1), solver.ind_fixed)
     fixed_variable_treatment_vec!(primal(solver.p),   solver.ind_fixed)
@@ -704,12 +820,21 @@ function second_order_correction(solver::AbstractMadNLPSolver,alpha_max,theta,va
     for p=1:solver.opt.max_soc
         # compute second order correction
         set_aug_rhs!(solver, solver.kkt, dual(solver._w1))
-        dual_inf_perturbation!(primal(solver.p),solver.ind_llb,solver.ind_uub,solver.mu,solver.opt.kappa_d)
+        dual_inf_perturbation!(
+            primal(solver.p),
+            solver.ind_llb,solver.ind_uub,solver.mu,solver.opt.kappa_d,
+        )
         solve_refine_wrapper!(solver,solver._w1,solver.p)
-        alpha_soc = get_alpha_max(solver.x,solver.xl,solver.xu,primal(solver._w1),solver.tau)
+        alpha_soc = get_alpha_max(
+            primal(solver.x),
+            primal(solver.xl),
+            primal(solver.xu),
+            primal(solver._w1),
+            solver.tau,
+        )
 
-        solver.x_trial .= solver.x .+ alpha_soc .* primal(solver._w1)
-        eval_cons_wrapper!(solver, solver.c_trial,solver.x_trial)
+        primal(solver.x_trial) .= primal(solver.x) .+ alpha_soc .* primal(solver._w1)
+        eval_cons_wrapper!(solver, solver.c_trial, solver.x_trial)
         solver.obj_val_trial = eval_f_wrapper(solver, solver.x_trial)
 
         theta_soc = get_theta(solver.c_trial)

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -115,7 +115,7 @@ function solve!(
         full(solver.x)[1:get_nvar(nlp)] .= x
     end
     if y != nothing
-        full(solver.y)[1:get_ncon(nlp)] .= y
+        solver.y[1:get_ncon(nlp)] .= y
     end
     if zl != nothing
         full(solver.zl)[1:get_nvar(nlp)] .= zl

--- a/src/IPM/utils.jl
+++ b/src/IPM/utils.jl
@@ -20,12 +20,12 @@ struct NotEnoughDegreesOfFreedomException <: Exception end
 
 MadNLPExecutionStats(solver::MadNLPSolver) =MadNLPExecutionStats(
     solver.status,
-    _madnlp_unsafe_wrap(solver.x, get_nvar(solver.nlp)),
+    primal(solver.x),
     solver.obj_val,solver.c,
     solver.inf_du, solver.inf_pr,
     solver.y,
-    _madnlp_unsafe_wrap(solver.zl, get_nvar(solver.nlp)),
-    _madnlp_unsafe_wrap(solver.zu, get_nvar(solver.nlp)),
+    primal(solver.zl),
+    primal(solver.zu),
     solver.cnt.k, get_counters(solver.nlp),solver.cnt.total_time
 )
 

--- a/src/KKT/rhs.jl
+++ b/src/KKT/rhs.jl
@@ -152,3 +152,30 @@ primal_dual(rhs::UnreducedKKTVector) = rhs.x
 dual_lb(rhs::UnreducedKKTVector) = rhs.xzl
 dual_ub(rhs::UnreducedKKTVector) = rhs.xzu
 
+
+"""
+    PrimalVector{T, VT<:AbstractVector{T}} <: AbstractKKTVector{T, VT}
+
+Primal vector ``(x, s)``.
+
+"""
+struct PrimalVector{T, VT<:AbstractVector{T}} <: AbstractKKTVector{T, VT}
+    values::VT
+    x::VT  # unsafe view
+    s::VT # unsafe view
+end
+
+function PrimalVector{T, VT}(nx::Int, ns::Int) where {T, VT <: AbstractVector{T}}
+    values = VT(undef, nx+ns) ; fill!(values, zero(T))
+    return PrimalVector{T, VT}(
+        values,
+        _madnlp_unsafe_wrap(values, nx),
+        _madnlp_unsafe_wrap(values, ns, nx+1),
+    )
+end
+
+full(rhs::PrimalVector) = rhs.values
+primal(rhs::PrimalVector) = rhs.values
+variable(rhs::PrimalVector) = rhs.x
+slack(rhs::PrimalVector) = rhs.s
+

--- a/src/KKT/sparse.jl
+++ b/src/KKT/sparse.jl
@@ -7,6 +7,7 @@ Implement the [`AbstractReducedKKTSystem`](@ref) in sparse COO format.
 """
 struct SparseKKTSystem{T, VT, MT} <: AbstractReducedKKTSystem{T, VT, MT}
     hess::VT
+    jac_callback::VT
     jac::VT
     pr_diag::VT
     du_diag::VT
@@ -33,6 +34,7 @@ Implement the [`AbstractUnreducedKKTSystem`](@ref) in sparse COO format.
 """
 struct SparseUnreducedKKTSystem{T, VT, MT} <: AbstractUnreducedKKTSystem{T, VT, MT}
     hess::VT
+    jac_callback::VT
     jac::VT
     pr_diag::VT
     du_diag::VT
@@ -72,6 +74,8 @@ function jtprod!(y::AbstractVector, kkt::AbstractSparseKKTSystem, x::AbstractVec
     mul!(y, kkt.jac_com', x)
 end
 
+get_jacobian(kkt::AbstractSparseKKTSystem) = kkt.jac_callback
+
 nnz_jacobian(kkt::AbstractSparseKKTSystem) = nnz(kkt.jac_raw)
 
 function compress_jacobian!(kkt::AbstractSparseKKTSystem{T, VT, MT}) where {T, VT, MT<:SparseMatrixCSC{T, Int32}}
@@ -106,37 +110,47 @@ function SparseKKTSystem{T, VT, MT}(
     hess_sparsity_I, hess_sparsity_J,
     jac_sparsity_I, jac_sparsity_J,
 ) where {T, VT, MT}
+    n_slack = length(ind_ineq)
     n_jac = length(jac_sparsity_I)
     n_hess = length(hess_sparsity_I)
+    n_tot = n + n_slack
 
-    aug_vec_length = n+m
-    aug_mat_length = n+m+n_hess+n_jac
+    aug_vec_length = n_tot+m
+    aug_mat_length = n_tot+m+n_hess+n_jac+n_slack
 
     I = Vector{Int32}(undef, aug_mat_length)
     J = Vector{Int32}(undef, aug_mat_length)
     V = VT(undef, aug_mat_length)
     fill!(V, 0.0)  # Need to initiate V to avoid NaN
 
-    offset = n+n_jac+n_hess+m
+    offset = n_tot+n_jac+n_slack+n_hess+m
 
-    I[1:n] .= 1:n
-    I[n+1:n+n_hess] = hess_sparsity_I
-    I[n+n_hess+1:n+n_hess+n_jac] .= (jac_sparsity_I.+n)
-    I[n+n_hess+n_jac+1:offset] .= (n+1:n+m)
+    I[1:n_tot] .= 1:n_tot
+    I[n_tot+1:n_tot+n_hess] = hess_sparsity_I
+    I[n_tot+n_hess+1:n_tot+n_hess+n_jac] .= (jac_sparsity_I.+n_tot)
+    I[n_tot+n_hess+n_jac+1:n_tot+n_hess+n_jac+n_slack] .= ind_ineq .+ n_tot
+    I[n_tot+n_hess+n_jac+n_slack+1:offset] .= (n_tot+1:n_tot+m)
 
-    J[1:n] .= 1:n
-    J[n+1:n+n_hess] = hess_sparsity_J
-    J[n+n_hess+1:n+n_hess+n_jac] .= jac_sparsity_J
-    J[n+n_hess+n_jac+1:offset] .= (n+1:n+m)
+    J[1:n_tot] .= 1:n_tot
+    J[n_tot+1:n_tot+n_hess] = hess_sparsity_J
+    J[n_tot+n_hess+1:n_tot+n_hess+n_jac] .= jac_sparsity_J
+    J[n_tot+n_hess+n_jac+1:n_tot+n_hess+n_jac+n_slack] .= (n+1:n+n_slack)
+    J[n_tot+n_hess+n_jac+n_slack+1:offset] .= (n_tot+1:n_tot+m)
 
-    pr_diag = _madnlp_unsafe_wrap(V, n)
-    du_diag = _madnlp_unsafe_wrap(V, m, n_jac+n_hess+n+1)
+    pr_diag = _madnlp_unsafe_wrap(V, n_tot)
+    du_diag = _madnlp_unsafe_wrap(V, m, n_jac+n_slack+n_hess+n_tot+1)
 
-    hess = _madnlp_unsafe_wrap(V, n_hess, n+1)
-    jac = _madnlp_unsafe_wrap(V, n_jac, n_hess+n+1)
+    hess = _madnlp_unsafe_wrap(V, n_hess, n_tot+1)
+    jac = _madnlp_unsafe_wrap(V, n_jac+n_slack, n_hess+n_tot+1)
+    jac_callback = _madnlp_unsafe_wrap(V, n_jac, n_hess+n_tot+1)
 
     aug_raw = SparseMatrixCOO(aug_vec_length,aug_vec_length,I,J,V)
-    jac_raw = SparseMatrixCOO(m,n,jac_sparsity_I,jac_sparsity_J,jac)
+    jac_raw = SparseMatrixCOO(
+        m, n_tot,
+        Int32[jac_sparsity_I; ind_ineq],
+        Int32[jac_sparsity_J; n+1:n+n_slack],
+        jac,
+    )
 
     aug_com = MT(aug_raw)
     jac_com = MT(jac_raw)
@@ -149,10 +163,10 @@ function SparseKKTSystem{T, VT, MT}(
     else
         zeros(Int, 0)
     end
-    jac_scaling = ones(T, n_jac)
+    jac_scaling = ones(T, n_jac+n_slack)
 
     return SparseKKTSystem{T, VT, MT}(
-        hess, jac, pr_diag, du_diag,
+        hess, jac_callback, jac, pr_diag, du_diag,
         aug_raw, aug_com, aug_csc_map,
         jac_raw, jac_com, jac_csc_map,
         ind_ineq, ind_fixed, ind_aug_fixed, jac_scaling,
@@ -161,9 +175,8 @@ end
 
 # Build KKT system directly from AbstractNLPModel
 function SparseKKTSystem{T, VT, MT}(nlp::AbstractNLPModel, ind_cons=get_index_constraints(nlp)) where {T, VT, MT}
-    n_slack = length(ind_cons.ind_ineq)
     # Deduce KKT size.
-    n = get_nvar(nlp) + n_slack
+    n = get_nvar(nlp)
     m = get_ncon(nlp)
     # Evaluate sparsity pattern
     jac_I = Vector{Int32}(undef, get_nnzj(nlp.meta))
@@ -175,9 +188,6 @@ function SparseKKTSystem{T, VT, MT}(nlp::AbstractNLPModel, ind_cons=get_index_co
     hess_structure!(nlp,hess_I,hess_J)
 
     force_lower_triangular!(hess_I,hess_J)
-    # Incorporate slack's sparsity pattern
-    append!(jac_I, ind_cons.ind_ineq)
-    append!(jac_J, get_nvar(nlp)+1:get_nvar(nlp)+n_slack)
 
     return SparseKKTSystem{T, VT, MT}(
         n, m, ind_cons.ind_ineq, ind_cons.ind_fixed,
@@ -199,50 +209,60 @@ function SparseUnreducedKKTSystem{T, VT, MT}(
     jac_sparsity_I, jac_sparsity_J,
     ind_lb, ind_ub,
 ) where {T, VT, MT}
+    n_slack = length(ind_ineq)
     n_jac = length(jac_sparsity_I)
     n_hess = length(hess_sparsity_I)
+    n_tot = n + n_slack
 
-    aug_mat_length = n + m + n_hess + n_jac + 2*nlb + 2*nub
-    aug_vec_length = n+m+nlb+nub
+    aug_mat_length = n_tot + m + n_hess + n_jac + n_slack + 2*nlb + 2*nub
+    aug_vec_length = n_tot + m + nlb + nub
 
     I = Vector{Int32}(undef, aug_mat_length)
     J = Vector{Int32}(undef, aug_mat_length)
     V = zeros(aug_mat_length)
 
-    offset = n+n_jac+n_hess+m
+    offset = n_tot + n_jac + n_slack + n_hess + m
 
-    I[1:n] .= 1:n
-    I[n+1:n+n_hess] = hess_sparsity_I
-    I[n+n_hess+1:n+n_hess+n_jac].=(jac_sparsity_I.+n)
-    I[n+n_hess+n_jac+1:offset].=(n+1:n+m)
+    I[1:n_tot] .= 1:n_tot
+    I[n_tot+1:n_tot+n_hess] = hess_sparsity_I
+    I[n_tot+n_hess+1:n_tot+n_hess+n_jac].=(jac_sparsity_I.+n_tot)
+    I[n_tot+n_hess+n_jac+1:n_tot+n_hess+n_jac+n_slack].=(ind_ineq.+n_tot)
+    I[n_tot+n_hess+n_jac+n_slack+1:offset].=(n_tot+1:n_tot+m)
 
-    J[1:n] .= 1:n
-    J[n+1:n+n_hess] = hess_sparsity_J
-    J[n+n_hess+1:n+n_hess+n_jac].=jac_sparsity_J
-    J[n+n_hess+n_jac+1:offset].=(n+1:n+m)
+    J[1:n_tot] .= 1:n_tot
+    J[n_tot+1:n_tot+n_hess] = hess_sparsity_J
+    J[n_tot+n_hess+1:n_tot+n_hess+n_jac] .= jac_sparsity_J
+    J[n_tot+n_hess+n_jac+1:n_tot+n_hess+n_jac+n_slack] .= (n+1:n+n_slack)
+    J[n_tot+n_hess+n_jac+n_slack+1:offset].=(n_tot+1:n_tot+m)
 
-    I[offset+1:offset+nlb] .= (1:nlb).+(n+m)
-    I[offset+nlb+1:offset+2nlb] .= (1:nlb).+(n+m)
-    I[offset+2nlb+1:offset+2nlb+nub] .= (1:nub).+(n+m+nlb)
-    I[offset+2nlb+nub+1:offset+2nlb+2nub] .= (1:nub).+(n+m+nlb)
-    J[offset+1:offset+nlb] .= (1:nlb).+(n+m)
+    I[offset+1:offset+nlb] .= (1:nlb).+(n_tot+m)
+    I[offset+nlb+1:offset+2nlb] .= (1:nlb).+(n_tot+m)
+    I[offset+2nlb+1:offset+2nlb+nub] .= (1:nub).+(n_tot+m+nlb)
+    I[offset+2nlb+nub+1:offset+2nlb+2nub] .= (1:nub).+(n_tot+m+nlb)
+    J[offset+1:offset+nlb] .= (1:nlb).+(n_tot+m)
     J[offset+nlb+1:offset+2nlb] .= ind_lb
-    J[offset+2nlb+1:offset+2nlb+nub] .= (1:nub).+(n+m+nlb)
+    J[offset+2nlb+1:offset+2nlb+nub] .= (1:nub).+(n_tot+m+nlb)
     J[offset+2nlb+nub+1:offset+2nlb+2nub] .= ind_ub
 
-    pr_diag = _madnlp_unsafe_wrap(V,n)
-    du_diag = _madnlp_unsafe_wrap(V,m, n_jac+n_hess+n+1)
+    pr_diag = _madnlp_unsafe_wrap(V,n_tot)
+    du_diag = _madnlp_unsafe_wrap(V,m, n_jac + n_slack+n_hess+n_tot+1)
 
     l_diag = _madnlp_unsafe_wrap(V, nlb, offset+1)
     l_lower= _madnlp_unsafe_wrap(V, nlb, offset+nlb+1)
     u_diag = _madnlp_unsafe_wrap(V, nub, offset+2nlb+1)
     u_lower= _madnlp_unsafe_wrap(V, nub, offset+2nlb+nub+1)
 
-    hess = _madnlp_unsafe_wrap(V, n_hess, n+1)
-    jac = _madnlp_unsafe_wrap(V, n_jac, n_hess+n+1)
+    hess = _madnlp_unsafe_wrap(V, n_hess, n_tot+1)
+    jac = _madnlp_unsafe_wrap(V, n_jac + n_slack, n_hess+n_tot+1)
+    jac_callback = _madnlp_unsafe_wrap(V, n_jac, n_hess+n_tot+1)
 
     aug_raw = SparseMatrixCOO(aug_vec_length,aug_vec_length,I,J,V)
-    jac_raw = SparseMatrixCOO(m,n,jac_sparsity_I,jac_sparsity_J,jac)
+    jac_raw = SparseMatrixCOO(
+        m, n_tot,
+        Int32[jac_sparsity_I; ind_ineq],
+        Int32[jac_sparsity_J; n+1:n+n_slack],
+        jac,
+    )
 
     aug_com = MT(aug_raw)
     jac_com = MT(jac_raw)
@@ -250,7 +270,7 @@ function SparseUnreducedKKTSystem{T, VT, MT}(
     aug_csc_map = get_mapping(aug_com, aug_raw)
     jac_csc_map = get_mapping(jac_com, jac_raw)
 
-    jac_scaling = ones(T, n_jac)
+    jac_scaling = ones(T, n_jac+n_slack)
 
     ind_aug_fixed = if isa(aug_com, SparseMatrixCSC)
         _get_fixed_variable_index(aug_com, ind_fixed)
@@ -259,7 +279,7 @@ function SparseUnreducedKKTSystem{T, VT, MT}(
     end
 
     return SparseUnreducedKKTSystem{T, VT, MT}(
-        hess, jac, pr_diag, du_diag,
+        hess, jac_callback, jac, pr_diag, du_diag,
         l_diag, u_diag, l_lower, u_lower,
         aug_raw, aug_com, aug_csc_map,
         jac_raw, jac_com, jac_csc_map,
@@ -272,7 +292,7 @@ function SparseUnreducedKKTSystem{T, VT, MT}(nlp::AbstractNLPModel, ind_cons=get
     nlb = length(ind_cons.ind_lb)
     nub = length(ind_cons.ind_ub)
     # Deduce KKT size.
-    n = get_nvar(nlp) + n_slack
+    n = get_nvar(nlp)
     m = get_ncon(nlp)
     # Evaluate sparsity pattern
     jac_I = Vector{Int32}(undef, get_nnzj(nlp.meta))
@@ -284,9 +304,6 @@ function SparseUnreducedKKTSystem{T, VT, MT}(nlp::AbstractNLPModel, ind_cons=get
     hess_structure!(nlp,hess_I,hess_J)
 
     force_lower_triangular!(hess_I,hess_J)
-    # Incorporate slack's sparsity pattern
-    append!(jac_I, ind_cons.ind_ineq)
-    append!(jac_J, get_nvar(nlp)+1:get_nvar(nlp)+n_slack)
 
     return SparseUnreducedKKTSystem{T, VT, MT}(
         n, m, nlb, nub, ind_cons.ind_ineq, ind_cons.ind_fixed,

--- a/test/madnlp_dense.jl
+++ b/test/madnlp_dense.jl
@@ -33,15 +33,15 @@ function _compare_dense_with_sparse(
         solver = MadNLPSolver(nlp; sparse_options...)
         solverd = MadNLPSolver(nlp; dense_options...)
 
-        MadNLP.solve!(solver)
-        MadNLP.solve!(solverd)
+        result_sparse = MadNLP.solve!(solver)
+        result_dense = MadNLP.solve!(solverd)
 
         # Check that dense formulation matches exactly sparse formulation
-        @test solverd.status == MadNLP.SOLVE_SUCCEEDED
-        @test solver.cnt.k == solverd.cnt.k
-        @test solver.obj_val ≈ solverd.obj_val atol=atol
-        @test solver.x ≈ solverd.x atol=atol
-        @test solver.y ≈ solverd.y atol=atol
+        @test result_dense.status == MadNLP.SOLVE_SUCCEEDED
+        @test result_sparse.iter == result_dense.iter
+        @test result_sparse.objective ≈ result_dense.objective atol=atol
+        @test result_sparse.solution ≈ result_dense.solution atol=atol
+        @test result_sparse.multipliers ≈ result_dense.multipliers atol=atol
         @test solver.kkt.jac_com[:, 1:n] == solverd.kkt.jac
         if isa(solverd.kkt, MadNLP.AbstractReducedKKTSystem)
             @test Symmetric(solver.kkt.aug_com, :L) ≈ solverd.kkt.aug_com atol=atol
@@ -133,7 +133,7 @@ end
 
     solver = MadNLPSolver(nlp; sparse_options...)
     MadNLP.solve!(solver)
-    
+
     # Restart (should hit MadNLP.reinitialize function)
     res = MadNLP.solve!(solver)
     @test solver.status == MadNLP.SOLVE_SUCCEEDED

--- a/test/madnlp_test.jl
+++ b/test/madnlp_test.jl
@@ -123,6 +123,13 @@ end
     solver = MadNLPSolver(nlp)
     kkt = solver.kkt
     x, f, c = solver.x, solver.f, solver.c
+    # Precompile
+    MadNLP.eval_f_wrapper(solver, x)
+    MadNLP.eval_grad_f_wrapper!(solver, f, x)
+    MadNLP.eval_cons_wrapper!(solver, c, x)
+    MadNLP.eval_jac_wrapper!(solver, kkt, x)
+    MadNLP.eval_lag_hess_wrapper!(solver, kkt, x, solver.y)
+
     n_allocs = @allocated MadNLP.eval_f_wrapper(solver, x)
     @test n_allocs == 16 # objective is still allocating
     n_allocs = @allocated MadNLP.eval_grad_f_wrapper!(solver, f, x)

--- a/test/madnlp_test.jl
+++ b/test/madnlp_test.jl
@@ -118,6 +118,23 @@ end
     @test solver.status == MadNLP.SOLVE_SUCCEEDED
 end
 
+@testset "MadNLP callback allocations" begin
+    nlp = MadNLPTests.HS15Model()
+    solver = MadNLPSolver(nlp)
+    kkt = solver.kkt
+    x, f, c = solver.x, solver.f, solver.c
+    n_allocs = @allocated MadNLP.eval_f_wrapper(solver, x)
+    @test n_allocs == 16 # objective is still allocating
+    n_allocs = @allocated MadNLP.eval_grad_f_wrapper!(solver, f, x)
+    @test n_allocs == 0
+    n_allocs = @allocated MadNLP.eval_cons_wrapper!(solver, c, x)
+    @test n_allocs == 0
+    n_allocs = @allocated MadNLP.eval_jac_wrapper!(solver, kkt, x)
+    @test n_allocs == 0
+    n_allocs = @allocated MadNLP.eval_lag_hess_wrapper!(solver, kkt, x, solver.y)
+    @test n_allocs == 0
+end
+
 @testset "MadNLP timings" begin
     nlp = MadNLPTests.HS15Model()
     solver = MadNLPSolver(nlp)


### PR DESCRIPTION
- add `PrimalVector` abstraction to remove the need to use `_madnlp_unsafe_wrapper` 
- rework KKT system to pass only the Jacobian w.r.t. the original variable `x` (without the slack) 
- 