### PR TITLE
[TTFS] Replace broadcast operators by explicit for loops in IPM kernels

### DIFF
--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -2,47 +2,85 @@
 # KKT system updates -------------------------------------------------------
 # Set diagonal
 function set_aug_diagonal!(kkt::AbstractKKTSystem, solver::MadNLPSolver{T}) where T
-    kkt.pr_diag .= solver.zl./(solver.x.-solver.xl) .+ solver.zu./(solver.xu.-solver.x)
+    @inbounds for i in eachindex(kkt.pr_diag)
+        kkt.pr_diag[i] = solver.zl[i] /(solver.x[i] - solver.xl[i])
+        kkt.pr_diag[i] += solver.zu[i] /(solver.xu[i] - solver.x[i])
+    end
     fill!(kkt.du_diag, zero(T))
     return
 end
 function set_aug_diagonal!(kkt::SparseUnreducedKKTSystem, solver::MadNLPSolver{T}) where T
     fill!(kkt.pr_diag, zero(T))
     fill!(kkt.du_diag, zero(T))
-    kkt.l_lower .= .-sqrt.(solver.zl_r)
-    kkt.u_lower .= .-sqrt.(solver.zu_r)
-    kkt.l_diag  .= solver.xl_r .- solver.x_lr
-    kkt.u_diag  .= solver.x_ur .- solver.xu_r
+    for i in eachindex(kkt.l_lower)
+        kkt.l_lower[i] = -sqrt(solver.zl_r[i])
+        kkt.l_diag[i]  = solver.xl_r[i] - solver.x_lr[i]
+    end
+    for i in eachindex(kkt.u_lower)
+        kkt.u_lower[i] = -sqrt(solver.zu_r[i])
+        kkt.u_diag[i] = solver.x_ur[i] - solver.xu_r[i]
+    end
     return
 end
 
 # Robust restoration
 function set_aug_RR!(kkt::AbstractKKTSystem, solver::MadNLPSolver, RR::RobustRestorer)
-    kkt.pr_diag .= solver.zl./(solver.x.-solver.xl) .+ solver.zu./(solver.xu.-solver.x) .+ RR.zeta.*RR.D_R.^2
-    kkt.du_diag .= .-RR.pp./RR.zp .- RR.nn./RR.zn
+    @inbounds for i in eachindex(kkt.pr_diag)
+        kkt.pr_diag[i]  = solver.zl[i] / (solver.x[i] - solver.xl[i])
+        kkt.pr_diag[i] += solver.zu[i] / (solver.xu[i] - solver.x[i]) + RR.zeta * RR.D_R[i]^2
+    end
+    @inbounds for i in eachindex(kkt.du_diag)
+        kkt.du_diag[i] = -RR.pp[i] /RR.zp[i] - RR.nn[i] /RR.zn[i]
+    end
     return
 end
 function set_aug_RR!(kkt::SparseUnreducedKKTSystem, solver::MadNLPSolver, RR::RobustRestorer)
-    kkt.pr_diag .= RR.zeta.*RR.D_R.^2
-    kkt.du_diag .= .-RR.pp./RR.zp.-RR.nn./RR.zn
-    kkt.l_lower .=.-sqrt.(solver.zl_r)
-    kkt.u_lower .=.-sqrt.(solver.zu_r)
-    kkt.l_diag  .= solver.xl_r .- solver.x_lr
-    kkt.u_diag  .= solver.x_ur .- solver.xu_r
+    @inbounds for i in eachindex(kkt.pr_diag)
+        kkt.pr_diag[i] = RR.zeta * RR.D_R[i]^2
+    end
+    @inbounds for i in eachindex(kkt.du_diag)
+        kkt.du_diag[i] = -RR.pp[i] / RR.zp[i] - RR.nn[i] / RR.zn[i]
+    end
+    @inbounds for i in eachindex(kkt.l_lower)
+        kkt.l_lower[i] = -sqrt(solver.zl_r[i])
+        kkt.l_diag[i]  = solver.xl_r[i] - solver.x_lr[i]
+    end
+    @inbounds for i in eachindex(kkt.u_lower)
+        kkt.u_lower[i] = -sqrt(solver.zu_r[i])
+        kkt.u_diag[i]  = solver.x_ur[i] - solver.xu_r[i]
+    end
     return
 end
 
 # Set RHS
 function set_aug_rhs!(solver::MadNLPSolver, kkt::AbstractKKTSystem, c)
-    primal(solver.p) .= .-solver.f .+ solver.mu ./ (solver.x.-solver.xl) .- solver.mu ./ (solver.xu.-solver.x) .-solver.jacl
-    dual(solver.p)   .= .-c
+    px = primal(solver.p)
+    @inbounds for i in eachindex(px)
+        px[i] = -solver.f[i] + solver.mu / (solver.x[i] - solver.xl[i]) - solver.mu / (solver.xu[i] - solver.x[i]) - solver.jacl[i]
+    end
+    py = dual(solver.p)
+    @inbounds for i in eachindex(py)
+        py[i] = -c[i]
+    end
     return
 end
 function set_aug_rhs!(solver::MadNLPSolver, kkt::SparseUnreducedKKTSystem, c)
-    primal(solver.p) .= .-solver.f .+ solver.zl .- solver.zu .- solver.jacl
-    dual(solver.p) .= .-c
-    dual_lb(solver.p) .= (solver.xl_r-solver.x_lr) .* kkt.l_lower .+ solver.mu ./ kkt.l_lower
-    dual_ub(solver.p) .= (solver.xu_r-solver.x_ur) .* kkt.u_lower .- solver.mu ./ kkt.u_lower
+    px = primal(solver.p)
+    @inbounds for i in eachindex(px)
+        px[i] = -solver.f[i] + solver.zl[i] - solver.zu[i] - solver.jacl[i]
+    end
+    py = dual(solver.p)
+    @inbounds for i in eachindex(py)
+        py[i] = -c[i]
+    end
+    pzl = dual_lb(solver.p)
+    @inbounds for i in eachindex(pzl)
+        pzl[i] = (solver.xl_r[i] - solver.x_lr[i]) * kkt.l_lower[i] + solver.mu / kkt.l_lower[i]
+    end
+    pzu = dual_ub(solver.p)
+    @inbounds for i in eachindex(pzu)
+        pzu[i] = (solver.xu_r[i] -solver.x_ur[i]) * kkt.u_lower[i] - solver.mu / kkt.u_lower[i]
+    end
     return
 end
 
@@ -50,7 +88,10 @@ function set_aug_rhs_ifr!(solver::MadNLPSolver{T}, kkt::SparseUnreducedKKTSystem
     fill!(primal(solver._w1), zero(T))
     fill!(dual_lb(solver._w1), zero(T))
     fill!(dual_ub(solver._w1), zero(T))
-    dual(solver._w1) .= .-c
+    wy = dual(solver._w1)
+    for i in eachindex(wy)
+        wy[i] = -c[i]
+    end
     return
 end
 
@@ -58,33 +99,55 @@ end
 function set_aug_rhs_RR!(
     solver::MadNLPSolver, kkt::AbstractKKTSystem, RR::RobustRestorer, rho,
 )
-    primal(solver.p) .= .-RR.f_R.-solver.jacl.+RR.mu_R./(solver.x.-solver.xl).-RR.mu_R./(solver.xu.-solver.x)
-    dual(solver.p) .= .-solver.c.+RR.pp.-RR.nn.+(RR.mu_R.-(rho.-solver.y).*RR.pp)./RR.zp.-(RR.mu_R.-(rho.+solver.y).*RR.nn)./RR.zn
+    px = primal(solver.p)
+    @inbounds for i in eachindex(px)
+        px[i] = -RR.f_R[i] -solver.jacl[i] + RR.mu_R / (solver.x[i] - solver.xl[i]) - RR.mu_R / (solver.xu[i] - solver.x[i])
+    end
+    py = dual(solver.p)
+    @inbounds for i in eachindex(py)
+        py[i] = -solver.c[i] + RR.pp[i] - RR.nn[i] + (RR.mu_R-(rho-solver.y[i])*RR.pp[i])/RR.zp[i]-(RR.mu_R-(rho+solver.y[i])*RR.nn[i]) / RR.zn[i]
+    end
     return
 end
 
 # Finish
 function finish_aug_solve!(solver::MadNLPSolver, kkt::AbstractKKTSystem, mu)
-    dual_lb(solver.d) .= (mu.-solver.zl_r.*solver.dx_lr)./(solver.x_lr.-solver.xl_r).-solver.zl_r
-    dual_ub(solver.d) .= (mu.+solver.zu_r.*solver.dx_ur)./(solver.xu_r.-solver.x_ur).-solver.zu_r
+    dlb = dual_lb(solver.d)
+    @inbounds for i in eachindex(dlb)
+        dlb[i] = (mu-solver.zl_r[i]*solver.dx_lr[i])/(solver.x_lr[i]-solver.xl_r[i])-solver.zl_r[i]
+    end
+    dub = dual_ub(solver.d)
+    @inbounds for i in eachindex(dub)
+        dub[i] = (mu+solver.zu_r[i]*solver.dx_ur[i])/(solver.xu_r[i]-solver.x_ur[i])-solver.zu_r[i]
+    end
     return
 end
 function finish_aug_solve!(solver::MadNLPSolver, kkt::SparseUnreducedKKTSystem, mu)
-    dual_lb(solver.d) .*= .-kkt.l_lower
-    dual_ub(solver.d) .*=   kkt.u_lower
-    dual_lb(solver.d) .= (mu.-solver.zl_r.*solver.dx_lr) ./ (solver.x_lr.-solver.xl_r) .- solver.zl_r
-    dual_ub(solver.d) .= (mu.+solver.zu_r.*solver.dx_ur) ./ (solver.xu_r.-solver.x_ur) .- solver.zu_r
+    dlb = dual_lb(solver.d)
+    @inbounds for i in eachindex(dlb)
+        dlb[i] = (mu-solver.zl_r[i]*solver.dx_lr[i]) / (solver.x_lr[i]-solver.xl_r[i]) - solver.zl_r[i]
+    end
+    dub = dual_ub(solver.d)
+    @inbounds for i in eachindex(dub)
+        dub[i] = (mu+solver.zu_r[i]*solver.dx_ur[i]) / (solver.xu_r[i]-solver.x_ur[i]) - solver.zu_r[i]
+    end
     return
 end
 
 # Initial
 function set_initial_rhs!(solver::MadNLPSolver{T}, kkt::AbstractKKTSystem) where T
-    primal(solver.p) .= .-solver.f .+ solver.zl .- solver.zu
+    px = primal(solver.p)
+    @inbounds for i in eachindex(px)
+        px[i] = -solver.f[i] + solver.zl[i] - solver.zu[i]
+    end
     fill!(dual(solver.p), zero(T))
     return
 end
 function set_initial_rhs!(solver::MadNLPSolver{T}, kkt::SparseUnreducedKKTSystem) where T
-    primal(solver.p) .= .-solver.f.+solver.zl.-solver.zu
+    px = primal(solver.p)
+    @inbounds for i in eachindex(px)
+        px[i] = -solver.f[i] + solver.zl[i] - solver.zu[i]
+    end
     fill!(dual(solver.p), zero(T))
     fill!(dual_lb(solver.p), zero(T))
     fill!(dual_ub(solver.p), zero(T))
@@ -94,16 +157,21 @@ end
 # Set ifr
 function set_aug_rhs_ifr!(solver::MadNLPSolver{T}, kkt::AbstractKKTSystem) where T
     fill!(primal(solver._w1), zero(T))
-    dual(solver._w1) .= .-solver.c
+    wy = dual(solver._w1)
+    @inbounds for i in eachindex(wy)
+        wy[i] = - solver.c[i]
+    end
     return
 end
 
 # Finish RR
 function finish_aug_solve_RR!(dpp, dnn, dzp, dzn, l, dl, pp, nn, zp, zn, mu_R, rho)
-    dpp .= (mu_R.+pp.*dl.-(rho.-l).*pp)./zp
-    dnn .= (mu_R.-nn.*dl.-(rho.+l).*nn)./zn
-    dzp .= (mu_R.-zp.*dpp)./pp.-zp
-    dzn .= (mu_R.-zn.*dnn)./nn.-zn
+    @inbounds for i in eachindex(dpp)
+        dpp[i] = (mu_R + pp[i] * dl[i] - (rho - l[i]) * pp[i]) / zp[i]
+        dnn[i] = (mu_R - nn[i] * dl[i] - (rho + l[i]) * nn[i]) / zn[i]
+        dzp[i] = (mu_R - zp[i] * dpp[i]) / pp[i] - zp[i]
+        dzn[i] = (mu_R - zn[i] * dnn[i]) / nn[i] - zn[i]
+    end
     return
 end
 
@@ -156,7 +224,7 @@ end
 function get_varphi_d(f, x, xl, xu, dx, mu)
     varphi_d = 0.0
     @inbounds @simd for i=1:length(f)
-        varphi_d += (f[i] - mu/(x[i]-xl[i]) + mu/(xu[i]-x[i])) *dx[i]
+        varphi_d += (f[i] - mu/(x[i]-xl[i]) + mu/(xu[i]-x[i])) * dx[i]
     end
     return varphi_d
 end
@@ -449,11 +517,15 @@ function is_barr_obj_rapid_increase(varphi, varphi_trial, obj_max_inc)
 end
 
 function reset_bound_dual!(z, x, mu, kappa_sigma)
-    z .= max.(min.(z, (kappa_sigma*mu)./x), (mu/kappa_sigma)./x)
+    @inbounds for i in eachindex(z)
+        z[i] = max(min(z[i], (kappa_sigma*mu)/x[i]), (mu/kappa_sigma)/x[i])
+    end
     return
 end
 function reset_bound_dual!(z, x1, x2, mu, kappa_sigma)
-    z .= max.(min.(z, (kappa_sigma*mu)./(x1.-x2)), (mu/kappa_sigma)./(x1.-x2))
+    @inbounds for i in eachindex(z)
+        z[i] = max(min(z[i], (kappa_sigma*mu)/(x1[i]-x2[i])), (mu/kappa_sigma)/(x1[i]-x2[i]))
+    end
     return
 end
 

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -12,11 +12,11 @@ end
 function set_aug_diagonal!(kkt::SparseUnreducedKKTSystem, solver::MadNLPSolver{T}) where T
     fill!(kkt.pr_diag, zero(T))
     fill!(kkt.du_diag, zero(T))
-    for i in eachindex(kkt.l_lower)
+    @inbounds @simd for i in eachindex(kkt.l_lower)
         kkt.l_lower[i] = -sqrt(solver.zl_r[i])
         kkt.l_diag[i]  = solver.xl_r[i] - solver.x_lr[i]
     end
-    for i in eachindex(kkt.u_lower)
+    @inbounds @simd for i in eachindex(kkt.u_lower)
         kkt.u_lower[i] = -sqrt(solver.zu_r[i])
         kkt.u_diag[i] = solver.x_ur[i] - solver.xu_r[i]
     end
@@ -89,7 +89,7 @@ function set_aug_rhs_ifr!(solver::MadNLPSolver{T}, kkt::SparseUnreducedKKTSystem
     fill!(dual_lb(solver._w1), zero(T))
     fill!(dual_ub(solver._w1), zero(T))
     wy = dual(solver._w1)
-    for i in eachindex(wy)
+    @inbounds @simd for i in eachindex(wy)
         wy[i] = -c[i]
     end
     return
@@ -363,18 +363,18 @@ end
 
 function get_F(c, f, zl, zu, jacl, x_lr, xl_r, zl_r, xu_r, x_ur, zu_r, mu)
     F = 0.0
-    @inbounds for i=1:length(c)
+    @inbounds @simd for i=1:length(c)
         F = max(F, c[i])
     end
-    @inbounds for i=1:length(f)
+    @inbounds @simd for i=1:length(f)
         F = max(F, f[i]-zl[i]+zu[i]+jacl[i])
     end
-    @inbounds for i=1:length(x_lr)
+    @inbounds @simd for i=1:length(x_lr)
         x_lr[i] >= xl_r[i] || return Inf
         zl_r[i] >= 0       || return Inf
         F = max(F, (x_lr[i]-xl_r[i])*zl_r[i]-mu)
     end
-    @inbounds for i=1:length(x_ur)
+    @inbounds @simd for i=1:length(x_ur)
         xu_r[i] >= x_ur[i] || return Inf
         zu_r[i] >= 0       || return Inf
         F = max(F, (xu_r[i]-xu_r[i])*zu_r[i]-mu)
@@ -517,13 +517,13 @@ function is_barr_obj_rapid_increase(varphi, varphi_trial, obj_max_inc)
 end
 
 function reset_bound_dual!(z, x, mu, kappa_sigma)
-    @inbounds for i in eachindex(z)
+    @inbounds @simd for i in eachindex(z)
         z[i] = max(min(z[i], (kappa_sigma*mu)/x[i]), (mu/kappa_sigma)/x[i])
     end
     return
 end
 function reset_bound_dual!(z, x1, x2, mu, kappa_sigma)
-    @inbounds for i in eachindex(z)
+    @inbounds @simd for i in eachindex(z)
         z[i] = max(min(z[i], (kappa_sigma*mu)/(x1[i]-x2[i])), (mu/kappa_sigma)/(x1[i]-x2[i]))
     end
     return
@@ -558,7 +558,7 @@ function _get_fixed_variable_index(
 end
 
 function fixed_variable_treatment_vec!(vec, ind_fixed)
-    @inbounds for i in ind_fixed
+    @inbounds @simd for i in ind_fixed
         vec[i] = 0.0
     end
 end

--- a/src/IPM/restoration.jl
+++ b/src/IPM/restoration.jl
@@ -68,7 +68,7 @@ function initialize_robust_restorer!(solver::AbstractMadNLPSolver{T}) where T
 
     copyto!(RR.x_ref, solver.x)
     RR.theta_ref = get_theta(solver.c)
-    @inbounds for i in eachindex(RR.D_R)
+    @inbounds @simd for i in eachindex(RR.D_R)
         RR.D_R[i] = min(one(T), one(T) / abs(RR.x_ref[i]))
     end
 
@@ -76,7 +76,7 @@ function initialize_robust_restorer!(solver::AbstractMadNLPSolver{T}) where T
     RR.tau_R= max(solver.opt.tau_min,1-RR.mu_R)
     RR.zeta = sqrt(RR.mu_R)
 
-    @inbounds for i in eachindex(RR.nn)
+    @inbounds @simd for i in eachindex(RR.nn)
         RR.nn[i] = (RR.mu_R - solver.opt.rho*solver.c[i])/2 /solver.opt.rho +
             sqrt(((RR.mu_R-solver.opt.rho*solver.c[i])/2 /solver.opt.rho)^2 + RR.mu_R*solver.c[i]/2 /solver.opt.rho)
         RR.pp[i] = solver.c[i] + RR.nn[i]
@@ -90,10 +90,10 @@ function initialize_robust_restorer!(solver::AbstractMadNLPSolver{T}) where T
     push!(RR.filter, (solver.theta_max,-Inf))
 
     fill!(solver.y, zero(T))
-    @inbounds for i in eachindex(solver.zl_r)
+    @inbounds @simd for i in eachindex(solver.zl_r)
         solver.zl_r[i] = min(solver.opt.rho, solver.zl_r[i])
     end
-    @inbounds for i in eachindex(solver.zu_r)
+    @inbounds @simd for i in eachindex(solver.zu_r)
         solver.zu_r[i] = min(solver.opt.rho, solver.zu_r[i])
     end
     solver.cnt.t = 0

--- a/src/IPM/restoration.jl
+++ b/src/IPM/restoration.jl
@@ -68,17 +68,21 @@ function initialize_robust_restorer!(solver::AbstractMadNLPSolver{T}) where T
 
     copyto!(RR.x_ref, solver.x)
     RR.theta_ref = get_theta(solver.c)
-    RR.D_R .= min.(one(T), one(T) ./abs.(RR.x_ref))
+    @inbounds for i in eachindex(RR.D_R)
+        RR.D_R[i] = min(one(T), one(T) / abs(RR.x_ref[i]))
+    end
 
     RR.mu_R = max(solver.mu, norm(solver.c, Inf))
     RR.tau_R= max(solver.opt.tau_min,1-RR.mu_R)
     RR.zeta = sqrt(RR.mu_R)
 
-    RR.nn .= (RR.mu_R.-solver.opt.rho.*solver.c)./2 ./solver.opt.rho .+
-        sqrt.(((RR.mu_R.-solver.opt.rho.*solver.c)./2 ./solver.opt.rho).^2 .+ RR.mu_R.*solver.c./2 ./solver.opt.rho)
-    RR.pp .= solver.c .+ RR.nn
-    RR.zp .= RR.mu_R./RR.pp
-    RR.zn .= RR.mu_R./RR.nn
+    @inbounds for i in eachindex(RR.nn)
+        RR.nn[i] = (RR.mu_R - solver.opt.rho*solver.c[i])/2 /solver.opt.rho +
+            sqrt(((RR.mu_R-solver.opt.rho*solver.c[i])/2 /solver.opt.rho)^2 + RR.mu_R*solver.c[i]/2 /solver.opt.rho)
+        RR.pp[i] = solver.c[i] + RR.nn[i]
+        RR.zp[i] = RR.mu_R / RR.pp[i]
+        RR.zn[i] = RR.mu_R / RR.nn[i]
+    end
 
     RR.obj_val_R = get_obj_val_R(RR.pp,RR.nn,RR.D_R,solver.x,RR.x_ref,solver.opt.rho,RR.zeta)
     fill!(RR.f_R, zero(T))
@@ -86,8 +90,12 @@ function initialize_robust_restorer!(solver::AbstractMadNLPSolver{T}) where T
     push!(RR.filter, (solver.theta_max,-Inf))
 
     fill!(solver.y, zero(T))
-    solver.zl_r .= min.(solver.opt.rho, solver.zl_r)
-    solver.zu_r .= min.(solver.opt.rho, solver.zu_r)
+    @inbounds for i in eachindex(solver.zl_r)
+        solver.zl_r[i] = min(solver.opt.rho, solver.zl_r[i])
+    end
+    @inbounds for i in eachindex(solver.zu_r)
+        solver.zu_r[i] = min(solver.opt.rho, solver.zu_r[i])
+    end
     solver.cnt.t = 0
 
     # misc

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -195,11 +195,11 @@ end
 
 function unscale!(solver::AbstractMadNLPSolver)
     solver.obj_val /= solver.obj_scale[]
-    for i in eachindex(solver.c)
+    @inbounds @simd for i in eachindex(solver.c)
         solver.c[i] /= solver.con_scale[i]
         solver.c[i] += solver.rhs[i]
     end
-    for i in eachindex(solver.c_slk)
+    @inbounds @simd for i in eachindex(solver.c_slk)
         solver.c_slk[i] += solver.x_slk[i]
     end
 end
@@ -561,7 +561,7 @@ function robust!(solver::MadNLPSolver)
         copyto!(RR.nn, RR.nn_trial)
 
         RR.obj_val_R=RR.obj_val_R_trial
-        @inbounds for i in eachindex(RR.f_R)
+        @inbounds @simd for i in eachindex(RR.f_R)
             RR.f_R[i] = RR.zeta * RR.D_R[i]^2 *(solver.x[i]-RR.x_ref[i])
         end
 
@@ -681,7 +681,7 @@ function inertia_free_reg(solver::MadNLPSolver)
 
     factorize_wrapper!(solver)
     solve_status = (solve_refine_wrapper!(solver,d0,p0) && solve_refine_wrapper!(solver,solver.d,solver.p))
-    for i in eachindex(t)
+    @inbounds @simd for i in eachindex(t)
         t[i] = dx[i] - n[i]
     end
     mul!(solver._w4, solver.kkt, solver._w3) # prepartation for curv_test
@@ -726,7 +726,7 @@ function second_order_correction(solver::AbstractMadNLPSolver,alpha_max,theta,va
 
     wx = primal(solver._w1)
     wy = dual(solver._w1)
-    for i in eachindex(wy)
+    @inbounds @simd for i in eachindex(wy)
         wy[i] = alpha_max * solver.c[i] + solver.c_trial[i]
     end
     theta_soc_old = theta_trial

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -372,8 +372,8 @@ function restore!(solver::AbstractMadNLPSolver)
         @inbounds @simd for i in eachindex(solver.zl_r)
             solver.zl_r[i] += solver.alpha * dlb[i]
         end
-        @inbounds @simd dub = dual_ub(solver.d)
-        for i in eachindex(solver.zu_r)
+        dub = dual_ub(solver.d)
+        @inbounds @simd for i in eachindex(solver.zu_r)
             solver.zu_r[i] += solver.alpha * dub[i]
         end
 

--- a/src/nlpmodels.jl
+++ b/src/nlpmodels.jl
@@ -40,7 +40,9 @@ function scale_constraints!(
 ) where T
     fill!(con_scale, zero(T))
     _set_scaling!(con_scale, jac)
-    con_scale .= min.(one(T), max_gradient ./ con_scale)
+    @inbounds for i in eachindex(con_scale)
+        con_scale[i] = min(one(T), max_gradient / con_scale[i])
+    end
 end
 
 """


### PR DESCRIPTION
Reduce drastically the precompile time. 

On current master, we get 
```
InferenceTimingNode: 3.715741/6.123850 on Core.Compiler.Timings.ROOT() with 1 direct children
```
On this branch:
```
InferenceTimingNode: 2.793325/3.842035 on Core.Compiler.Timings.ROOT() with 1 direct children
```

x-ref: #186 