### PR TITLE
Add new constructor for custom KKT type

### DIFF
--- a/src/IPM/IPM.jl
+++ b/src/IPM/IPM.jl
@@ -116,6 +116,13 @@ function MadNLPSolver(nlp::AbstractNLPModel{T}; kwargs...) where T
     return MadNLPSolver{T,KKTSystem}(nlp, opt_ipm, opt_linear_solver; logger=logger)
 end
 
+# Constructor for unregistered KKT systems
+function MadNLPSolver{T, KKTSystem}(nlp::AbstractNLPModel{T}; options...) where {T, KKTSystem}
+    opt_ipm, opt_linear_solver, logger = load_options(; options...)
+    @assert is_supported(opt_ipm.linear_solver, T)
+    return MadNLPSolver{T,KKTSystem}(nlp, opt_ipm, opt_linear_solver; logger=logger)
+end
+
 # Inner constructor
 function MadNLPSolver{T,KKTSystem}(
     nlp::AbstractNLPModel,

--- a/test/madnlp_dense.jl
+++ b/test/madnlp_dense.jl
@@ -122,6 +122,14 @@ end
     end
 end
 
+@testset "MadNLP: custom KKT constructor" begin
+    T, VT, MT = Float64, Vector{Float64}, Matrix{Float64}
+    nlp = MadNLPTests.DenseDummyQP{T}(; n=10, m=5)
+    KKT = MadNLP.DenseKKTSystem{T, VT, MT}
+    solver = MadNLPSolver{T, KKT}(nlp; linear_solver=LapackCPUSolver)
+    @test isa(solver.kkt, KKT)
+end
+
 @testset "MadNLP: restart (PR #113)" begin
     n, m = 10, 5
     nlp = MadNLPTests.DenseDummyQP(; n=n, m=m)
@@ -133,7 +141,7 @@ end
 
     solver = MadNLPSolver(nlp; sparse_options...)
     MadNLP.solve!(solver)
-    
+
     # Restart (should hit MadNLP.reinitialize function)
     res = MadNLP.solve!(solver)
     @test solver.status == MadNLP.SOLVE_SUCCEEDED


### PR DESCRIPTION
This new constructor allows to drastically simplify the support of custom KKT system outside MadNLP. 

Before, calling a custom KKT constructor was not straightforward, as illustrated by this code in Argos: 
https://github.com/exanauts/Argos.jl/blob/master/src/api.jl#L72-L80