### PR TITLE
Minor README link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Optionally, various extension packages can be installed together:
 ```julia
 pkg> add MadNLPHSL, MadNLPPardiso, MadNLPMumps, MadNLPGPU, MadNLPGraph, MadNLPKrylov
 ```
-These packages are stored in the `lib` subdirectory within the main MadNLP repository. Some extension packages may require additional dependencies or specific hardware. For the instructions for the build procedure, see the following links: [MadNLPHSL](https://github.com/sshin23/MadNLP.jl/tree/master/lib/MadNLPHSL), [MadNLPPardiso](https://github.com/sshin23/MadNLP.jl/tree/master/lib/MadNLPHSL), [MadNLPGPU](https://github.com/sshin23/MadNLP.jl/tree/master/lib/MadNLPGPU).
+These packages are stored in the `lib` subdirectory within the main MadNLP repository. Some extension packages may require additional dependencies or specific hardware. For the instructions for the build procedure, see the following links: [MadNLPHSL](https://github.com/MadNLP/MadNLP.jl/tree/master/lib/MadNLPHSL), [MadNLPPardiso](https://github.com/MadNLP/MadNLP.jl/tree/master/lib/MadNLPHSL), [MadNLPGPU](https://github.com/MadNLP/MadNLP.jl/tree/master/lib/MadNLPGPU).
 
 
 ## Usage
@@ -23,7 +23,7 @@ MadNLP is interfaced with modeling packages:
 - [JuMP](https://github.com/jump-dev/JuMP.jl)
 - [Plasmo](https://github.com/zavalab/Plasmo.jl)
 - [NLPModels](https://github.com/JuliaSmoothOptimizers/NLPModels.jl).
-Users can pass various options to MadNLP also through the modeling packages. The interface-specific syntaxes are shown below. To see the list of MadNLP solver options, check the [OPTIONS.md](https://github.com/sshin23/MadNLP/blob/master/OPTIONS.md) file.
+Users can pass various options to MadNLP also through the modeling packages. The interface-specific syntaxes are shown below. To see the list of MadNLP solver options, check the [OPTIONS.md](https://github.com/MadNLP/MadNLP/blob/master/OPTIONS.md) file.
 
 #### JuMP interface
 ```julia


### PR DESCRIPTION
Maybe also redirect https://github.com/sshin23/MadNLP.jl to here as Google still spits that out as the top link.