### PR TITLE
Fix infinite loop in feasibility restoration

### DIFF
--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -523,9 +523,11 @@ function get_sc(zl_r, zu_r, s_max)
 end
 
 function get_mu(mu, mu_min, mu_linear_decrease_factor, mu_superlinear_decrease_power, tol)
+    # Warning: `a * tol` should be strictly less than 100 * mu_min, see issue #242
+    a = min(99.0 * mu_min / tol, 0.01)
     return max(
         mu_min,
-        tol/10,
+        a * tol,
         min(mu_linear_decrease_factor*mu, mu^mu_superlinear_decrease_power),
     )
 end

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -531,7 +531,7 @@ function robust!(solver::MadNLPSolver{T}) where T
 
         # update the barrier parameter
         @trace(solver.logger,"Updating restoration phase barrier parameter.")
-        while RR.mu_R != solver.opt.mu_min*100 &&
+        while RR.mu_R >= solver.opt.mu_min*100 &&
             max(RR.inf_pr_R,RR.inf_du_R,inf_compl_mu_R) <= solver.opt.barrier_tol_factor*RR.mu_R
             RR.mu_R = get_mu(RR.mu_R,solver.opt.mu_min,
                             solver.opt.mu_linear_decrease_factor,solver.opt.mu_superlinear_decrease_power,solver.opt.tol)


### PR DESCRIPTION
See issue #242
This issue happened when the barrier `RR.mu_R` used in the restoration reaches small values below 100 * mu_min. We had no guarantee the loop would finite in finite time.