### PR TITLE
[MadNLPTests] Remove ADNLPModels in deps

### DIFF
--- a/lib/MadNLPTests/Project.toml
+++ b/lib/MadNLPTests/Project.toml
@@ -4,7 +4,6 @@ authors = ["Sungho Shin <sungho.shin.ss@gmail.com>"]
 version = "0.3.1"
 
 [deps]
-ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
@@ -14,7 +13,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ADNLPModels = "0.3, 0.4, 0.5"
 JuMP = "1"
 MadNLP = "0.5, 0.6"
 NLPModels = "~0.17.2, 0.18, 0.19"

--- a/lib/MadNLPTests/src/Instances/nls.jl
+++ b/lib/MadNLPTests/src/Instances/nls.jl
@@ -1,6 +1,93 @@
-F(x) = [x[1] - 1.0; 10 * (x[2] - x[1]^2)]
+struct NLSModel <: NLPModels.AbstractNLSModel{Float64,Vector{Float64}}
+    meta::NLPModels.NLPModelMeta{Float64, Vector{Float64}}
+    nls_meta::NLPModels.NLSMeta{Float64, Vector{Float64}}
+    counters::NLPModels.NLSCounters
+end
 
 function NLSModel()
     x0 = [-1.2; 1.0]
-    return ADNLSModel(F, x0, 2)
+    return NLSModel(
+        NLPModels.NLPModelMeta(
+            2,     #nvar
+            ncon = 0,
+            nnzj = 0,
+            nnzh = 3,
+            x0 = x0,
+            lvar = zeros(2),
+            uvar = ones(2),
+            minimize = true
+        ),
+        NLPModels.NLSMeta(2, 2; nnzj=3, nnzh=4),
+        NLPModels.NLSCounters()
+    )
 end
+
+function NLPModels.residual!(nls::NLSModel, x, Fx)
+    Fx[1] = x[1] - 1.0
+    Fx[2] = 10.0 * (x[2] - x[1]^2)
+    return Fx
+end
+
+function NLPModels.jac_structure_residual!(
+    nls::NLSModel,
+    rows::AbstractVector{<:Integer},
+    cols::AbstractVector{<:Integer},
+)
+    copyto!(rows, [1, 2, 2])
+    copyto!(cols, [1, 1, 2])
+    return rows, cols
+end
+
+function NLPModels.jac_coord_residual!(nls::NLSModel, x::AbstractVector, vals::AbstractVector)
+    vals[1] = 1.0
+    vals[2] = -20.0 * x[1]
+    vals[3] = 10.0
+    return vals
+end
+
+function NLPModels.jprod_residual!(nls::NLSModel, x::AbstractVector, v::AbstractVector, Jv::AbstractVector)
+    Jv[1] = v[1]
+    Jv[2] = -20.0 * x[1] * v[1] + 10.0 * v[2]
+    return Jv
+end
+
+function NLPModels.jtprod_residual!(nls::NLSModel, x::AbstractVector, v::AbstractVector, Jtv::AbstractVector)
+    Jtv[1] = v[1] - 20.0 * x[1] * v[2]
+    Jtv[2] = 10.0 * v[2]
+    return Jtv
+end
+
+function NLPModels.hess_structure_residual!(
+    nls::NLSModel,
+    rows::AbstractVector{<:Integer},
+    cols::AbstractVector{<:Integer},
+)
+    rows[1] = 1
+    cols[1] = 1
+    return rows, cols
+end
+
+function NLPModels.hess_coord_residual!(
+    nls::NLSModel,
+    x::AbstractVector,
+    v::AbstractVector,
+    vals::AbstractVector,
+)
+    vals[1] = -20.0 * v[2]
+    return vals
+end
+
+function NLPModels.hess_structure!(nlp::NLSModel, rows::AbstractVector{T}, cols::AbstractVector{T}) where T
+    copyto!(rows, [1, 2, 2])
+    copyto!(cols, [1, 1, 2])
+    return rows, cols
+end
+
+function NLPModels.hess_coord!(nlp::NLSModel, x, y, H::AbstractVector; obj_weight=1.0)
+    # Objective
+    H[1] = obj_weight * (1.0 - 200.0 * x[2] + 600 * x[1]^2)
+    H[2] = obj_weight * (-200.0 * x[1])
+    H[3] = obj_weight * 100.0
+    return H
+end
+

--- a/lib/MadNLPTests/src/MadNLPTests.jl
+++ b/lib/MadNLPTests/src/MadNLPTests.jl
@@ -11,7 +11,6 @@ import MadNLP
 import NLPModels
 import JuMP: Model, @variable, @constraint, @objective, @NLconstraint , @NLobjective, optimize!,
     MOI, termination_status, LowerBoundRef, UpperBoundRef, value, dual
-import ADNLPModels: ADNLSModel
 
 export test_madnlp, solcmp
 


### PR DESCRIPTION
ADNLPModels has too many dependencies (notably, Symbolics.jl) complicating the maintenance of MadNLPTests. 

Currently, we are using ADNLPModels only in the evaluation of the derivatives of the `NLSModel`. In this PR, we replace ADNLPModels by the analytical expressions of the derivatives. 

