### PR TITLE
Add proper testing for KKT systems

### DIFF
--- a/src/KKT/KKTsystem.jl
+++ b/src/KKT/KKTsystem.jl
@@ -80,7 +80,7 @@ abstract type AbstractCondensedKKTSystem{T, VT, MT, QN} <: AbstractKKTSystem{T, 
     Templates
 =#
 
-"Number of primal variables associated to the KKT system."
+"Number of primal variables (including slacks) associated to the KKT system."
 function num_variables end
 
 """
@@ -153,15 +153,6 @@ Called internally inside the interior-point routine.
 function regularize_diagonal! end
 
 """
-    set_jacobian_scaling!(kkt::AbstractKKTSystem, scaling::AbstractVector)
-
-Set the scaling of the Jacobian with the vector `scaling` storing
-the scaling for all the constraints in the problem.
-
-"""
-function set_jacobian_scaling! end
-
-"""
     is_inertia_correct(kkt::AbstractKKTSystem, n::Int, m::Int, p::Int)
 
 Check if the inertia ``(n, m, p)`` returned by the linear solver is adapted
@@ -193,6 +184,7 @@ function initialize!(kkt::AbstractKKTSystem)
     fill!(kkt.pr_diag, 1.0)
     fill!(kkt.du_diag, 0.0)
     fill!(kkt.hess, 0.0)
+    return
 end
 
 function regularize_diagonal!(kkt::AbstractKKTSystem, primal, dual)
@@ -215,7 +207,7 @@ function is_inertia_correct(kkt::AbstractKKTSystem, num_pos, num_zero, num_neg)
     return (num_zero == 0) && (num_pos == num_variables(kkt))
 end
 
-compress_hessian!(kkt::AbstractKKTSystem) = nothing 
+compress_hessian!(kkt::AbstractKKTSystem) = nothing
 
 
 include("rhs.jl")

--- a/src/KKT/sparse.jl
+++ b/src/KKT/sparse.jl
@@ -57,7 +57,7 @@ struct SparseUnreducedKKTSystem{T, VT, MT, QN, LS, VI, VI32} <: AbstractUnreduce
     u_lower::VT
     l_lower_aug::VT
     u_lower_aug::VT
-    
+
     # Augmented system
     aug_raw::SparseMatrixCOO{T,Int32,VT, VI32}
     aug_com::MT
@@ -72,10 +72,10 @@ struct SparseUnreducedKKTSystem{T, VT, MT, QN, LS, VI, VI32} <: AbstractUnreduce
     jac_raw::SparseMatrixCOO{T,Int32,VT, VI32}
     jac_com::MT
     jac_csc_map::Union{Nothing, VI}
-    
+
     # LinearSolver
     linear_solver::LS
-    
+
     # Info
     ind_ineq::VI
     ind_lb::VI
@@ -100,7 +100,7 @@ struct SparseCondensedKKTSystem{T, VT, MT, QN, LS, VI, VI32, VTu1, VTu2, EXT} <:
     jt_coo::SparseMatrixCOO{T,Int32,VT, VI32}
     jt_csc::MT
     jt_csc_map::Union{Nothing, VI}
-    
+
     quasi_newton::QN
     reg::VT
     pr_diag::VT
@@ -116,13 +116,13 @@ struct SparseCondensedKKTSystem{T, VT, MT, QN, LS, VI, VI32, VTu1, VTu2, EXT} <:
 
     # Augmented system
     aug_com::MT
-    
+
     # slack diagonal buffer
     diag_buffer::VT
     dptr::VTu1
     hptr::VTu1
     jptr::VTu2
-    
+
     # LinearSolver
     linear_solver::LS
 
@@ -134,7 +134,7 @@ struct SparseCondensedKKTSystem{T, VT, MT, QN, LS, VI, VI32, VTu1, VTu2, EXT} <:
     # extra
     ext::EXT
 end
- 
+
 # Template to dispatch on sparse representation
 const AbstractSparseKKTSystem{T, VT, MT, QN} = Union{
     SparseKKTSystem{T, VT, MT, QN},
@@ -157,13 +157,6 @@ function build_hessian_structure(cb::SparseCallback, ::Type{<:AbstractQuasiNewto
     hess_I = collect(Int32, 1:cb.nvar)
     hess_J = collect(Int32, 1:cb.nvar)
     return hess_I, hess_J
-end
-
-function mul!(y::AbstractVector, kkt::AbstractSparseKKTSystem, x::AbstractVector)
-    mul!(y, Symmetric(kkt.aug_com, :L), x)
-end
-function mul!(y::AbstractKKTVector, kkt::AbstractSparseKKTSystem, x::AbstractKKTVector)
-    mul!(full(y), Symmetric(kkt.aug_com, :L), full(x))
 end
 
 function jtprod!(y::AbstractVector, kkt::AbstractSparseKKTSystem, x::AbstractVector)
@@ -199,10 +192,10 @@ end
 # Build KKT system directly from SparseCallback
 function create_kkt_system(
     ::Type{SparseKKTSystem},
-    cb::SparseCallback{T,VT}, opt, 
+    cb::SparseCallback{T,VT}, opt,
     opt_linear_solver,cnt, ind_cons
     ) where {T,VT}
-    
+
     n_slack = length(ind_cons.ind_ineq)
     # Deduce KKT size.
 
@@ -222,7 +215,7 @@ function create_kkt_system(
     force_lower_triangular!(hess_sparsity_I,hess_sparsity_J)
 
     ind_ineq = ind_cons.ind_ineq
-    
+
     n_slack = length(ind_ineq)
     n_jac = length(jac_sparsity_I)
     n_hess = length(hess_sparsity_I)
@@ -259,7 +252,7 @@ function create_kkt_system(
     u_diag = VT(undef, nub)
     l_lower = VT(undef, nlb)
     u_lower = VT(undef, nub)
-    
+
     hess = _madnlp_unsafe_wrap(V, n_hess, n_tot+1)
     jac = _madnlp_unsafe_wrap(V, n_jac+n_slack, n_hess+n_tot+1)
     jac_callback = _madnlp_unsafe_wrap(V, n_jac, n_hess+n_tot+1)
@@ -288,7 +281,7 @@ function create_kkt_system(
 
     return SparseKKTSystem(
         hess, jac_callback, jac, quasi_newton, reg, pr_diag, du_diag,
-        l_diag, u_diag, l_lower, u_lower, 
+        l_diag, u_diag, l_lower, u_lower,
         aug_raw, aug_com, aug_csc_map,
         hess_raw, hess_com, hess_csc_map,
         jac_raw, jac_com, jac_csc_map,
@@ -308,13 +301,13 @@ num_variables(kkt::SparseKKTSystem) = length(kkt.pr_diag)
 
 function create_kkt_system(
     ::Type{SparseUnreducedKKTSystem},
-    cb::SparseCallback{T,VT}, opt, 
+    cb::SparseCallback{T,VT}, opt,
     opt_linear_solver,cnt, ind_cons
     ) where {T, VT}
     ind_ineq = ind_cons.ind_ineq
     ind_lb = ind_cons.ind_lb
     ind_ub = ind_cons.ind_ub
-    
+
     n_slack = length(ind_ineq)
     nlb = length(ind_cons.ind_lb)
     nub = length(ind_cons.ind_ub)
@@ -324,7 +317,7 @@ function create_kkt_system(
 
     # Quasi-newton
     quasi_newton = create_quasi_newton(opt.hessian_approximation, cb, n)
-    
+
     # Evaluate sparsity pattern
     jac_sparsity_I = create_array(cb, Int32, cb.nnzj)
     jac_sparsity_J = create_array(cb, Int32, cb.nnzj)
@@ -335,7 +328,7 @@ function create_kkt_system(
     _hess_sparsity_wrapper!(cb,hess_sparsity_I,hess_sparsity_J)
 
     force_lower_triangular!(hess_sparsity_I,hess_sparsity_J)
-    
+
     n_slack = length(ind_ineq)
     n_jac = length(jac_sparsity_I)
     n_hess = length(hess_sparsity_I)
@@ -428,10 +421,10 @@ function initialize!(kkt::AbstractSparseKKTSystem)
     fill!(kkt.u_lower, 0.0)
     fill!(kkt.l_diag, 1.0)
     fill!(kkt.u_diag, 1.0)
-    fill!(kkt.hess_com.nzval, 0.) # so that mul! in the initial primal-dual solve has no effect 
+    fill!(kkt.hess_com.nzval, 0.) # so that mul! in the initial primal-dual solve has no effect
 end
 
-function initialize!(kkt::SparseUnreducedKKTSystem) 
+function initialize!(kkt::SparseUnreducedKKTSystem)
     fill!(kkt.reg, 1.0)
     fill!(kkt.pr_diag, 1.0)
     fill!(kkt.du_diag, 0.0)
@@ -448,6 +441,10 @@ end
 is_reduced(::SparseUnreducedKKTSystem) = false
 num_variables(kkt::SparseUnreducedKKTSystem) = length(kkt.pr_diag)
 
+function is_inertia_correct(kkt::SparseUnreducedKKTSystem, num_pos, num_zero, num_neg)
+    n, nlb, nub = num_variables(kkt), length(kkt.ind_lb), length(kkt.ind_ub)
+    return (num_zero == 0) && (num_pos == n + nlb + nub)
+end
 
 #=
     SparseCondensedKKTSystem
@@ -457,7 +454,7 @@ num_variables(kkt::SparseUnreducedKKTSystem) = length(kkt.pr_diag)
 function create_kkt_system(
     ::Type{SparseCondensedKKTSystem},
     cb::SparseCallback{T,VT},
-    opt, 
+    opt,
     opt_linear_solver,
     cnt,
     ind_cons
@@ -467,11 +464,11 @@ function create_kkt_system(
     n = cb.nvar
     m = cb.ncon
     n_slack = length(ind_ineq)
-    
+
     if n_slack != m
         error("SparseCondensedKKTSystem does not support equality constrained NLPs.")
     end
-    
+
     # Evaluate sparsity pattern
     jac_sparsity_I = create_array(cb, Int32, cb.nnzj)
     jac_sparsity_J = create_array(cb, Int32, cb.nnzj)
@@ -501,11 +498,12 @@ function create_kkt_system(
     hess = VT(undef, n_hess)
     jac = VT(undef, n_jac)
     diag_buffer = VT(undef, m)
-    
+    fill!(jac, zero(T))
+
     hess_raw = SparseMatrixCOO(n, n, hess_sparsity_I, hess_sparsity_J, hess)
-    
+
     jt_coo = SparseMatrixCOO(
-        n, m, 
+        n, m,
         jac_sparsity_J,
         jac_sparsity_I,
         jac,
@@ -517,14 +515,14 @@ function create_kkt_system(
         hess_com,
         jt_csc
         )
-    
+
     cnt.linear_solver_time += @elapsed linear_solver = opt.linear_solver(aug_com; opt = opt_linear_solver)
 
     ext = get_sparse_condensed_ext(VT, hess_com, jptr, jt_csc_map, hess_csc_map)
 
-    return SparseCondensedKKTSystem( 
+    return SparseCondensedKKTSystem(
         hess, hess_raw, hess_com, hess_csc_map,
-        jac, jt_coo, jt_csc, jt_csc_map, 
+        jac, jt_coo, jt_csc, jt_csc_map,
         quasi_newton,
         reg, pr_diag, du_diag,
         l_diag, u_diag, l_lower, u_lower,
@@ -536,14 +534,14 @@ function create_kkt_system(
     )
 end
 
-    
+
 get_sparse_condensed_ext(::Type{Vector{T}},args...) where T = nothing
 
 
 is_reduced(::SparseCondensedKKTSystem) = true
 num_variables(kkt::SparseCondensedKKTSystem) = length(kkt.pr_diag)
 function is_inertia_correct(kkt::SparseCondensedKKTSystem, num_pos, num_zero, num_neg)
-    return (num_zero == 0) && (num_pos == num_variables(kkt))
+    return (num_zero == 0) && (num_pos == size(kkt.aug_com, 1))
 end
 
 
@@ -555,50 +553,6 @@ function compress_jacobian!(kkt::SparseCondensedKKTSystem{T, VT, MT}) where {T, 
     ns = length(kkt.ind_ineq)
     # kkt.jac[end-ns+1:end] .= -1.0
     transfer!(kkt.jt_csc, kkt.jt_coo, kkt.jt_csc_map)
-end
-
-function mul!(y::AbstractKKTVector, kkt::SparseCondensedKKTSystem, x::AbstractKKTVector)
-    mul!(full(y), kkt, full(x))
-end
-
-function mul!(y::AbstractVector, kkt::SparseCondensedKKTSystem, x::AbstractVector)
-    # TODO: implement properly with AbstractKKTRHS
-    if length(y) == length(x) == size(kkt.aug_com, 1)
-        mul!(y, Symmetric(kkt.aug_com, :L), x)
-        return
-    end
-
-    n = size(kkt.hess_csc, 1)
-    m = size(kkt.jt_csc, 2)
-
-
-    Σx = view(kkt.pr_diag, 1:n)
-    Σs = view(kkt.pr_diag, n+1:n+m)
-    Σd = kkt.du_diag
-
-    # Decompose x
-    xx = view(x, 1:n)
-    xs = view(x, 1+n:n+m)
-    xy = view(x, 1+n+m:n+2*m)
-
-    # Decompose y
-    yx = view(y, 1:n)
-    ys = view(y, 1+n:n+m)
-    yy = view(y, 1+n+m:n+2*m)
-
-    # / x (variable)
-    mul!(yx, Symmetric(kkt.hess_csc, :L), xx)
-    yx .+= Σx .* xx
-    mul!(yx, kkt.jt_csc, xy, 1.0, 1.0)
-
-    # / s (slack)
-    ys .= Σs .* xs
-    ys .-= xy
-
-    # / y (multiplier)
-    yy .= Σd .* xy
-    mul!(yy, kkt.jt_csc', xx, 1.0, 1.0)
-    yy .-= xs
 end
 
 function jtprod!(y::AbstractVector, kkt::SparseCondensedKKTSystem, x::AbstractVector)
@@ -651,10 +605,10 @@ function getptr(array; by = (x,y)->x != y)
 end
 
 nzval(H) = H.nzval
- 
+
 @inbounds function build_condensed_aug_symbolic(H::AbstractSparseMatrix{Tv,Ti}, Jt) where {Tv, Ti}
     nnzjtsj = _sym_length(Jt)
-    
+
     sym = similar(nzval(H), Tuple{Int,Int,Int},
         size(H,2) + nnz(H) + nnzjtsj
     )
@@ -675,9 +629,9 @@ nzval(H) = H.nzval
         one(Tv)
     )
     rowval = Ti[]
-    
+
     n = size(H,2)
-    
+
     map!(
         i->(-1,i,0),
         @view(sym[1:n]),
@@ -704,9 +658,9 @@ nzval(H) = H.nzval
     p = sortperm(sym2; by = ((i,j),) -> (j,i))
     permute!(sym, p)
     permute!(sym2, p)
-    
+
     by(x,y) = x != y
-    
+
     bitarray = similar(sym2, Bool, length(sym2))
     fill!(bitarray, true)
     bitarray[2:end] .= by.(@view(sym2[1:end-1]),  @view(sym2[2:end]))
@@ -721,10 +675,10 @@ nzval(H) = H.nzval
     b = findall(x->x[1] != -1 && x[1] != 0, sym)
     jptr = map((x,y)->(Int32(x),y), @view(guide[b]), @view(sym[b]))
 
-    
+
     ptr = findall(bitarray)
     rowval = map(((row,col),)->Int32(row), @view(sym2[ptr]))
-    
+
     by2(x,y) = x[2] != y[2]
     bitarray[2:end] .= by2.(@view(sym2[1:end-1]),  @view(sym2[2:end]))
     ptr2 = findall(bitarray)
@@ -765,7 +719,7 @@ end
 function _first_and_last_col(sym2,ptr2)
     first= sym2[1][2]
     last = sym2[ptr2[end]][2]
-    return (first, last)    
+    return (first, last)
 end
 
 function _set_colptr!(colptr, ptr2, sym2, guide)
@@ -773,19 +727,19 @@ function _set_colptr!(colptr, ptr2, sym2, guide)
 
         (~,prevcol) = sym2[i-1]
         (row,col) = sym2[i]
-        
+
         fill!(@view(colptr[prevcol+1:col]), guide[i])
     end
 end
 
 @inbounds function _build_condensed_aug_coord!(aug_com::SparseMatrixCSC{Tv,Ti}, pr_diag, H, Jt, diag_buffer, dptr, hptr, jptr) where {Tv, Ti}
     fill!(aug_com.nzval, zero(Tv))
-    
+
     @simd for idx in eachindex(hptr)
         i,j = hptr[idx]
         aug_com.nzval[i] += H.nzval[j]
     end
-    
+
     @simd for idx in eachindex(dptr)
         i,j = dptr[idx]
         aug_com.nzval[i] += pr_diag[j]
@@ -806,12 +760,10 @@ end
 
 
 function build_kkt!(kkt::SparseKKTSystem)
-
     transfer!(kkt.aug_com, kkt.aug_raw, kkt.aug_csc_map)
 end
 
 function build_kkt!(kkt::SparseUnreducedKKTSystem)
-    
     transfer!(kkt.aug_com, kkt.aug_raw, kkt.aug_csc_map)
 end
 
@@ -824,7 +776,7 @@ function build_kkt!(kkt::SparseCondensedKKTSystem)
     Σx = view(kkt.pr_diag, 1:n)
     Σs = view(kkt.pr_diag, n+1:n+m)
     Σd = kkt.du_diag
-        
+
     kkt.diag_buffer .= Σs ./ ( 1 .- Σd .* Σs)
     build_condensed_aug_coord!(kkt)
 end

--- a/src/LinearSolvers/backsolve.jl
+++ b/src/LinearSolvers/backsolve.jl
@@ -35,7 +35,6 @@ function solve_refine!(
 
     fill!(full(x), zero(T))
 
-
     if norm_b == zero(T)
         @debug(
             iterator.logger,

--- a/src/options.jl
+++ b/src/options.jl
@@ -20,7 +20,7 @@ end
     # General options
     rethrow_error::Bool = true
     disable_garbage_collector::Bool = false
-    blas_num_threads::Int = 1 
+    blas_num_threads::Int = 1
     linear_solver::Type = LapackCPUSolver
     iterator::Type = RichardsonIterator
 
@@ -45,7 +45,7 @@ end
     boudn_relax_factor::Float64 = 1e-8
     jacobian_constant::Bool = false
     hessian_constant::Bool = false
-    kkt_system::Type = SparseKKTSystemes
+    kkt_system::Type = SparseKKTSystem
     hessian_approximation::Type = ExactHessian
     callback::Type = SparseCallback
 
@@ -104,7 +104,7 @@ function MadNLPOptions(nlp::AbstractNLPModel{T}) where T
     is_dense_callback =
         hasmethod(MadNLP.jac_dense!, Tuple{typeof(nlp), AbstractVector, AbstractMatrix}) &&
         hasmethod(MadNLP.hess_dense!, Tuple{typeof(nlp), AbstractVector, AbstractVector, AbstractMatrix})
-    
+
     callback = is_dense_callback ? DenseCallback : SparseCallback
 
     # if dense callback is used, we use dense condensed kkt system
@@ -114,7 +114,7 @@ function MadNLPOptions(nlp::AbstractNLPModel{T}) where T
     linear_solver = is_dense_callback ? LapackCPUSolver : default_sparse_solver(nlp)
 
     tol = get_tolerance(T,kkt_system)
-    
+
     return MadNLPOptions(
         callback = callback,
         kkt_system = kkt_system,


### PR DESCRIPTION
- add tests for KKT systems, including solution found in backsolve and KKT multiplications. 
- ensure that `mul!` and `solve!` returns the reference to the input modified in-place. 
- fix `is_inertia_correct` for `SparseCondensedKKTSystem` and `SparseUnreducedKKTSystem`
- spot a few bugs in `mul!(y, kkt, x)` 
- add a constructor for `UnreducedKKTVector` 
```julia
UnreducedKKTVector(kkt::AbstractKKTSystem)
```
- set initial constraint's scaling to `1` in `DenseCallback` and `SparseCallback`
- fix a typo in `src/options.jl` 