### PR TITLE
add support for CUDA.jl v5

### DIFF
--- a/lib/MadNLPGPU/Project.toml
+++ b/lib/MadNLPGPU/Project.toml
@@ -10,7 +10,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
 
 [compat]
-CUDA = "~4"
+CUDA = "4, 5"
 CUSOLVERRF = "0.2"
 KernelAbstractions = "0.9"
 MadNLP = "0.7"

--- a/lib/MadNLPGPU/test/densekkt_gpu.jl
+++ b/lib/MadNLPGPU/test/densekkt_gpu.jl
@@ -3,7 +3,6 @@ using CUDA
 using MadNLPTests
 
 function _compare_gpu_with_cpu(KKTSystem, n, m, ind_fixed)
-
     for (T,tol,atol) in [
         (Float32,1e-3,1e-1),
         (Float64,1e-8,1e-6)
@@ -16,13 +15,9 @@ function _compare_gpu_with_cpu(KKTSystem, n, m, ind_fixed)
             :tol=>tol
         )
 
+        # Host evaluator
         nlph = MadNLPTests.DenseDummyQP(zeros(T,n); m=m, fixed_variables=ind_fixed)
-
-        # Some weird issue: there's some non-deterministic behavior in generating the model for the first call
-        # Not sure where this error is originating, but seems to be resolved in v1.10
-        # Here, we call this twice to avoid this error
-        nlpd = MadNLPTests.DenseDummyQP(CUDA.zeros(T,n); m=m, fixed_variables=CuArray(ind_fixed))
-        
+        # Device evaluator
         nlpd = MadNLPTests.DenseDummyQP(CUDA.zeros(T,n); m=m, fixed_variables=CuArray(ind_fixed))
 
         # Solve on CPU


### PR DESCRIPTION
Interestingly, it looks like the seed is not working if we call `randn`  after allocating arrays on the device. 

This PR adds support for CUDA.jl 5.0: the solution is to instantiate all the data in one place, to make sure the seed works correctly. 

cc #282 