### PR TITLE
[API] Simplify arguments of create_kkt_system

### DIFF
--- a/src/IPM/IPM.jl
+++ b/src/IPM/IPM.jl
@@ -17,7 +17,7 @@ mutable struct MadNLPSolver{
     IC <: AbstractInertiaCorrector,
     KKTVec <: AbstractKKTVector{T, VT}
     } <: AbstractMadNLPSolver{T}
-    
+
     nlp::Model
     cb::CB
     kkt::KKTSystem
@@ -103,19 +103,19 @@ mutable struct MadNLPSolver{
 end
 
 function MadNLPSolver(nlp::AbstractNLPModel{T,VT}; kwargs...) where {T, VT}
-    
+
     opt, opt_linear_solver, logger = load_options(nlp; kwargs...)
     @assert is_supported(opt.linear_solver, T)
 
     cnt = MadNLPCounters(start_time=time())
     cb = create_callback(opt.callback, nlp, opt)
-    
+
     # generic options
     opt.disable_garbage_collector &&
         (GC.enable(false); @warn(logger,"Julia garbage collector is temporarily disabled"))
     set_blas_num_threads(opt.blas_num_threads; permanent=true)
     @trace(logger,"Initializing variables.")
-    
+
     ind_cons = get_index_constraints(
         get_lvar(nlp), get_uvar(nlp),
         get_lcon(nlp), get_ucon(nlp),
@@ -125,7 +125,7 @@ function MadNLPSolver(nlp::AbstractNLPModel{T,VT}; kwargs...) where {T, VT}
 
     ind_lb = ind_cons.ind_lb
     ind_ub = ind_cons.ind_ub
-    
+
     ns = length(ind_cons.ind_ineq)
     nx = get_nvar(nlp)
     n = nx+ns
@@ -137,10 +137,10 @@ function MadNLPSolver(nlp::AbstractNLPModel{T,VT}; kwargs...) where {T, VT}
     kkt = create_kkt_system(
         opt.kkt_system,
         cb,
-        opt,
-        opt_linear_solver,
-        cnt,
-        ind_cons
+        ind_cons,
+        opt.linear_solver;
+        hessian_approximation=opt.hessian_approximation,
+        opt_linear_solver=opt_linear_solver,
     )
 
     @trace(logger,"Initializing iterative solver.")
@@ -148,12 +148,12 @@ function MadNLPSolver(nlp::AbstractNLPModel{T,VT}; kwargs...) where {T, VT}
 
     x = PrimalVector(VT, nx, ns, ind_lb, ind_ub)
     xl = PrimalVector(VT, nx, ns, ind_lb, ind_ub)
-    xu = PrimalVector(VT, nx, ns, ind_lb, ind_ub)  
+    xu = PrimalVector(VT, nx, ns, ind_lb, ind_ub)
     zl = PrimalVector(VT, nx, ns, ind_lb, ind_ub)
     zu = PrimalVector(VT, nx, ns, ind_lb, ind_ub)
     f = PrimalVector(VT, nx, ns, ind_lb, ind_ub)
     x_trial = PrimalVector(VT, nx, ns, ind_lb, ind_ub)
-    
+
     d = UnreducedKKTVector(VT, n, m, nlb, nub, ind_lb, ind_ub)
     p = UnreducedKKTVector(VT, n, m, nlb, nub, ind_lb, ind_ub)
     _w1 = UnreducedKKTVector(VT, n, m, nlb, nub, ind_lb, ind_ub)
@@ -161,7 +161,7 @@ function MadNLPSolver(nlp::AbstractNLPModel{T,VT}; kwargs...) where {T, VT}
     _w3 = UnreducedKKTVector(VT, n, m, nlb, nub, ind_lb, ind_ub)
     _w4 = UnreducedKKTVector(VT, n, m, nlb, nub, ind_lb, ind_ub)
 
-    jacl = VT(undef,n) 
+    jacl = VT(undef,n)
     c_trial = VT(undef, m)
     y = VT(undef, m)
     c = VT(undef, m)
@@ -190,28 +190,28 @@ function MadNLPSolver(nlp::AbstractNLPModel{T,VT}; kwargs...) where {T, VT}
         VT,
         n, m, nlb, nub, ind_lb, ind_ub
     )
-    
+
     cnt.init_time = time() - cnt.start_time
 
     return MadNLPSolver(
         nlp, cb, kkt,
-        opt, cnt, logger, 
+        opt, cnt, logger,
         n, m, nlb, nub,
         x, y, zl, zu, xl, xu,
-        zero(T), f, c, 
-        jacl, 
-        d, p, 
-        _w1, _w2, _w3, _w4, 
-        x_trial, c_trial, zero(T), c_slk, rhs, 
-        ind_cons.ind_ineq, ind_cons.ind_fixed, ind_cons.ind_llb, ind_cons.ind_uub, 
-        x_lr, x_ur, xl_r, xu_r, zl_r, zu_r, dx_lr, dx_ur, x_trial_lr, x_trial_ur, 
-        iterator, 
+        zero(T), f, c,
+        jacl,
+        d, p,
+        _w1, _w2, _w3, _w4,
+        x_trial, c_trial, zero(T), c_slk, rhs,
+        ind_cons.ind_ineq, ind_cons.ind_fixed, ind_cons.ind_llb, ind_cons.ind_uub,
+        x_lr, x_ur, xl_r, xu_r, zl_r, zu_r, dx_lr, dx_ur, x_trial_lr, x_trial_ur,
+        iterator,
         zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T),
         " ",
         zero(T), zero(T), zero(T),
         Tuple{T, T}[],
         inertia_corrector, nothing,
-        INITIAL, Dict(), 
+        INITIAL, Dict(),
     )
 
 end

--- a/src/KKT/sparse.jl
+++ b/src/KKT/sparse.jl
@@ -192,9 +192,12 @@ end
 # Build KKT system directly from SparseCallback
 function create_kkt_system(
     ::Type{SparseKKTSystem},
-    cb::SparseCallback{T,VT}, opt,
-    opt_linear_solver,cnt, ind_cons
-    ) where {T,VT}
+    cb::SparseCallback{T,VT},
+    ind_cons,
+    linear_solver::Type;
+    opt_linear_solver=default_options(linear_solver),
+    hessian_approximation=ExactHessian,
+) where {T,VT}
 
     n_slack = length(ind_cons.ind_ineq)
     # Deduce KKT size.
@@ -206,8 +209,8 @@ function create_kkt_system(
     jac_sparsity_J = create_array(cb, Int32, cb.nnzj)
     _jac_sparsity_wrapper!(cb,jac_sparsity_I, jac_sparsity_J)
 
-    quasi_newton = create_quasi_newton(opt.hessian_approximation, cb, n)
-    hess_sparsity_I, hess_sparsity_J = build_hessian_structure(cb, opt.hessian_approximation)
+    quasi_newton = create_quasi_newton(hessian_approximation, cb, n)
+    hess_sparsity_I, hess_sparsity_J = build_hessian_structure(cb, hessian_approximation)
 
     nlb = length(ind_cons.ind_lb)
     nub = length(ind_cons.ind_ub)
@@ -275,7 +278,7 @@ function create_kkt_system(
     jac_com, jac_csc_map = coo_to_csc(jac_raw)
     hess_com, hess_csc_map = coo_to_csc(hess_raw)
 
-    cnt.linear_solver_time += @elapsed linear_solver = opt.linear_solver(
+    _linear_solver = linear_solver(
         aug_com; opt = opt_linear_solver
     )
 
@@ -285,7 +288,7 @@ function create_kkt_system(
         aug_raw, aug_com, aug_csc_map,
         hess_raw, hess_com, hess_csc_map,
         jac_raw, jac_com, jac_csc_map,
-        linear_solver,
+        _linear_solver,
         ind_ineq, ind_cons.ind_lb, ind_cons.ind_ub,
     )
 
@@ -301,9 +304,12 @@ num_variables(kkt::SparseKKTSystem) = length(kkt.pr_diag)
 
 function create_kkt_system(
     ::Type{SparseUnreducedKKTSystem},
-    cb::SparseCallback{T,VT}, opt,
-    opt_linear_solver,cnt, ind_cons
-    ) where {T, VT}
+    cb::SparseCallback{T,VT},
+    ind_cons,
+    linear_solver::Type;
+    opt_linear_solver=default_options(linear_solver),
+    hessian_approximation=ExactHessian,
+) where {T, VT}
     ind_ineq = ind_cons.ind_ineq
     ind_lb = ind_cons.ind_lb
     ind_ub = ind_cons.ind_ub
@@ -316,7 +322,7 @@ function create_kkt_system(
     m = cb.ncon
 
     # Quasi-newton
-    quasi_newton = create_quasi_newton(opt.hessian_approximation, cb, n)
+    quasi_newton = create_quasi_newton(hessian_approximation, cb, n)
 
     # Evaluate sparsity pattern
     jac_sparsity_I = create_array(cb, Int32, cb.nnzj)
@@ -397,17 +403,14 @@ function create_kkt_system(
     jac_com, jac_csc_map = coo_to_csc(jac_raw)
     hess_com, hess_csc_map = coo_to_csc(hess_raw)
 
-    cnt.linear_solver_time += @elapsed linear_solver = opt.linear_solver(aug_com; opt = opt_linear_solver)
-opt.linear_solver(
-        aug_com; opt = opt_linear_solver
-    )
+    _linear_solver = linear_solver(aug_com; opt = opt_linear_solver)
     return SparseUnreducedKKTSystem(
         hess, jac_callback, jac, quasi_newton, reg, pr_diag, du_diag,
         l_diag, u_diag, l_lower, u_lower, l_lower_aug, u_lower_aug,
         aug_raw, aug_com, aug_csc_map,
         hess_raw, hess_com, hess_csc_map,
         jac_raw, jac_com, jac_csc_map,
-        linear_solver,
+        _linear_solver,
         ind_ineq, ind_lb, ind_ub,
     )
 end
@@ -454,12 +457,11 @@ end
 function create_kkt_system(
     ::Type{SparseCondensedKKTSystem},
     cb::SparseCallback{T,VT},
-    opt,
-    opt_linear_solver,
-    cnt,
-    ind_cons
-    ) where {T, VT}
-
+    ind_cons,
+    linear_solver::Type;
+    opt_linear_solver=default_options(linear_solver),
+    hessian_approximation=ExactHessian,
+) where {T, VT}
     ind_ineq = ind_cons.ind_ineq
     n = cb.nvar
     m = cb.ncon
@@ -474,8 +476,8 @@ function create_kkt_system(
     jac_sparsity_J = create_array(cb, Int32, cb.nnzj)
     _jac_sparsity_wrapper!(cb,jac_sparsity_I, jac_sparsity_J)
 
-    quasi_newton = create_quasi_newton(opt.hessian_approximation, cb, n)
-    hess_sparsity_I, hess_sparsity_J = build_hessian_structure(cb, opt.hessian_approximation)
+    quasi_newton = create_quasi_newton(hessian_approximation, cb, n)
+    hess_sparsity_I, hess_sparsity_J = build_hessian_structure(cb, hessian_approximation)
 
     force_lower_triangular!(hess_sparsity_I,hess_sparsity_J)
 
@@ -516,7 +518,7 @@ function create_kkt_system(
         jt_csc
         )
 
-    cnt.linear_solver_time += @elapsed linear_solver = opt.linear_solver(aug_com; opt = opt_linear_solver)
+    _linear_solver = linear_solver(aug_com; opt = opt_linear_solver)
 
     ext = get_sparse_condensed_ext(VT, hess_com, jptr, jt_csc_map, hess_csc_map)
 
@@ -528,7 +530,7 @@ function create_kkt_system(
         l_diag, u_diag, l_lower, u_lower,
         buffer, buffer2,
         aug_com, diag_buffer, dptr, hptr, jptr,
-        linear_solver,
+        _linear_solver,
         ind_ineq, ind_cons.ind_lb, ind_cons.ind_ub,
         ext
     )

--- a/test/kkt_test.jl
+++ b/test/kkt_test.jl
@@ -34,7 +34,6 @@ end
 ]
     linear_solver = MadNLP.LapackCPUSolver
     options = MadNLP.MadNLPOptions(; linear_solver=linear_solver)
-    options_linear_solver = MadNLP.default_options(linear_solver)
     cnt = MadNLP.MadNLPCounters(; start_time=time())
 
     nlp = MadNLPTests.HS15Model()
@@ -53,10 +52,8 @@ end
     kkt = MadNLP.create_kkt_system(
         KKTSystem,
         cb,
-        options,
-        options_linear_solver,
-        cnt,
         ind_cons,
+        linear_solver;
     )
     MadNLPTests.test_kkt_system(kkt, cb)
 end


### PR DESCRIPTION
Simplify the call to `create_kkt_system` as 
```julia
kkt = create_kkt_system(
        kkt_system_type,
        cb,
        ind_cons,
        linear_solver;
        hessian_approximation=opt.hessian_approximation,
        opt_linear_solver=opt_linear_solver,
)
 ```

By doing so, we don't have to pass the counter `cnt` and the full options `MadNLPOptions` to create a KKT system.