### PR TITLE
[Tests] Remove test nlp_009_010 from MINLPTests tests

### DIFF
--- a/test/minlp_test.jl
+++ b/test/minlp_test.jl
@@ -14,6 +14,7 @@ const OPTIMIZER = ()->MadNLP.Optimizer(
         exclude = [
             "005_011",  # Uses the function `\`
             "006_010",  # User-defined function without Hessian (autodiff only provides 1st order)
+            "009_010",  # Objective is non-smooth
         ],
         objective_tol = 1e-5,
         primal_tol = 1e-5,


### PR DESCRIPTION
Tests with min/max operators have been recently added in MINLPTests.jl: https://github.com/jump-dev/MINLPTests.jl/pull/42

It turns out MadNLP is breaking with `nlp_009_010`, as the objective is non-smooth. Investigating it further, the problem is with the line-search. If we force the switching condition in `is_switching` to `true`, MadNLP is converging. On this tests, MadNLP fails to satisfy the switching condition as the reference theta is hardcoded to `2.0`: https://github.com/MadNLP/MadNLP.jl/blob/master/src/IPM/solver.jl#L276

Ipopt uses the reference theta specified in Equation (19) of the Ipopt paper, and achieves convergence on `nlp_009_010`. That suggests we can fix this test by modifying the reference theta when we call `is_switching`. However, that would require careful testing to check if we are not deteriorating MadNLP's performance. 

As a short term remedy, I suggest we deactivate `nlp_009_010` in our tests. 
