### PR TITLE
[MOI] add support for MOI.Interval{Float64}

### DIFF
--- a/src/Interfaces/MOI_interface.jl
+++ b/src/Interfaces/MOI_interface.jl
@@ -70,8 +70,12 @@ function Optimizer(; kwargs...)
     )
 end
 
-const _SETS =
-    Union{MOI.GreaterThan{Float64},MOI.LessThan{Float64},MOI.EqualTo{Float64}}
+const _SETS = Union{
+    MOI.GreaterThan{Float64},
+    MOI.LessThan{Float64},
+    MOI.EqualTo{Float64},
+    MOI.Interval{Float64},
+}
 
 const _FUNCTIONS = Union{
     MOI.ScalarAffineFunction{Float64},
@@ -1088,6 +1092,17 @@ function MOI.get(
     model::Optimizer,
     attr::MOI.ConstraintDual,
     ci::MOI.ConstraintIndex{MOI.VariableIndex,MOI.EqualTo{Float64}},
+)
+    MOI.check_result_index_bounds(model, attr)
+    MOI.throw_if_not_valid(model, ci)
+    rc = model.result.multipliers_L[ci.value] - model.result.multipliers_U[ci.value]
+    return rc
+end
+
+function MOI.get(
+    model::Optimizer,
+    attr::MOI.ConstraintDual,
+    ci::MOI.ConstraintIndex{MOI.VariableIndex,MOI.Interval{Float64}},
 )
     MOI.check_result_index_bounds(model, attr)
     MOI.throw_if_not_valid(model, ci)


### PR DESCRIPTION
This has been added 6 weeks ago in Ipopt.jl. 

Supporting `MOI.Interval{Float64}` leads to consistent results with ExaModels, as otherwise the interval constraints are rewritten as one constraint with a lower-bound and another constraint with a upper-bound. 