### PR TITLE
[MOI] Add support for nonlinear problems without Hessian

### DIFF
--- a/lib/MadNLPTests/src/Instances/hs15nohessian.jl
+++ b/lib/MadNLPTests/src/Instances/hs15nohessian.jl
@@ -1,0 +1,65 @@
+struct HS15NoHessianModel{T} <: NLPModels.AbstractNLPModel{T,Vector{T}}
+    meta::NLPModels.NLPModelMeta{T, Vector{T}}
+    counters::NLPModels.Counters
+end
+
+function HS15NoHessianModel(;T = Float64, x0=zeros(T,2), y0=zeros(T,2))
+    return HS15NoHessianModel(
+        NLPModels.NLPModelMeta(
+            2,     #nvar
+            ncon = 2,
+            nnzj = 4,
+            nnzh = 0,
+            x0 = x0,
+            y0 = y0,
+            lvar = T[-Inf, -Inf],
+            uvar = T[0.5, Inf],
+            lcon = T[1.0, 0.0],
+            ucon = T[Inf, Inf],
+            minimize = true
+        ),
+        NLPModels.Counters()
+    )
+end
+
+function NLPModels.obj(nlp::HS15NoHessianModel, x::AbstractVector)
+    return 100.0 * (x[2] - x[1]^2)^2 + (1.0 - x[1])^2
+end
+
+function NLPModels.grad!(nlp::HS15NoHessianModel, x::AbstractVector, g::AbstractVector)
+    z = x[2] - x[1]^2
+    g[1] = -400.0 * z * x[1] - 2.0 * (1.0 - x[1])
+    g[2] = 200.0 * z
+    return
+end
+
+function NLPModels.cons!(nlp::HS15NoHessianModel, x::AbstractVector, c::AbstractVector)
+    c[1] = x[1] * x[2]
+    c[2] = x[1] + x[2]^2
+end
+
+function NLPModels.jac_structure!(nlp::HS15NoHessianModel, I::AbstractVector{T}, J::AbstractVector{T}) where T
+    copyto!(I, [1, 1, 2, 2])
+    copyto!(J, [1, 2, 1, 2])
+end
+
+function NLPModels.jac_coord!(nlp::HS15NoHessianModel, x::AbstractVector, J::AbstractVector)
+    J[1] = x[2]    # (1, 1)
+    J[2] = x[1]    # (1, 2)
+    J[3] = 1.0     # (2, 1)
+    J[4] = 2*x[2]  # (2, 2)
+    return J
+end
+
+function NLPModels.jprod!(nlp::HS15NoHessianModel, x::AbstractVector, v::AbstractVector, jv::AbstractVector)
+    jv[1] = x[2] * v[1] + x[1] * v[2]
+    jv[2] = v[1] + 2 * x[2] * v[2]
+    return jv
+end
+
+function NLPModels.jtprod!(nlp::HS15NoHessianModel, x::AbstractVector, v::AbstractVector, jv::AbstractVector)
+    jv[1] = x[2] * v[1] + v[2]
+    jv[2] = x[1] * v[1] + 2 * x[2] * v[2]
+    return jv
+end
+

--- a/lib/MadNLPTests/src/MadNLPTests.jl
+++ b/lib/MadNLPTests/src/MadNLPTests.jl
@@ -333,6 +333,7 @@ end
 
 include("Instances/dummy_qp.jl")
 include("Instances/hs15.jl")
+include("Instances/hs15nohessian.jl")
 include("Instances/nls.jl")
 include("wrapper.jl")
 

--- a/src/nlpmodels.jl
+++ b/src/nlpmodels.jl
@@ -357,7 +357,9 @@ function create_callback(
     jac_scale = similar(jac_buffer, nnzj) ; fill!(jac_scale, one(T))
 
     NLPModels.jac_structure!(nlp, jac_I, jac_J)
-    NLPModels.hess_structure!(nlp, hess_I, hess_J)
+    if nnzh > 0
+        NLPModels.hess_structure!(nlp, hess_I, hess_J)
+    end
 
     fixed_handler, nnzj, nnzh = create_sparse_fixed_handler(
         fixed_variable_treatment,

--- a/test/MOI_interface_test.jl
+++ b/test/MOI_interface_test.jl
@@ -50,8 +50,6 @@ function test_MOI_Test()
             # - Excluded because Hessian information is needed
             "test_nonlinear_hs071_hessian_vector_product",
             # - Excluded because Hessian information is needed
-            "test_nonlinear_hs071_no_hessian",
-            # - Excluded because Hessian information is needed
             "test_nonlinear_invalid",
 
             #  - Excluded because this test is optional
@@ -97,6 +95,20 @@ function test_invalid_number_in_hessian_lagrangian()
     MOI.optimize!(model)
     @test MOI.get(model, MOI.TerminationStatus()) == MOI.LOCALLY_SOLVED
     return
+end
+
+# See issue #318
+function test_user_defined_function()
+    model = MadNLP.Optimizer()
+    MOI.set(model, MOI.Silent(), true)
+    # Define custom function.
+    f(a, b) = a^2 + b^2
+    x = MOI.add_variables(model, 2)
+    MOI.set(model, MOI.UserDefinedFunction(:f, 2), (f,))
+    obj_f = MOI.ScalarNonlinearFunction(:f, Any[x[1], x[2]])
+    MOI.set(model, MOI.ObjectiveFunction{typeof(obj_f)}(), obj_f)
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.LOCALLY_SOLVED
 end
 
 end

--- a/test/madnlp_quasi_newton.jl
+++ b/test/madnlp_quasi_newton.jl
@@ -34,7 +34,7 @@ end
 
 @testset "MadNLP: LBFGS" begin
     @testset "HS15" begin
-        nlp = MadNLPTests.HS15Model()
+        nlp = MadNLPTests.HS15NoHessianModel()
         solver_qn = MadNLP.MadNLPSolver(
             nlp;
             callback = MadNLP.SparseCallback,


### PR DESCRIPTION
Solve https://github.com/MadNLP/MadNLP.jl/issues/318

This PR adds support for MOI nonlinear problems without Hessian. This is needed to support problems with user-defined functions (whose support has been improved in the latest MOI releases). Now MadNLP switches automatically to the LBFGS algorithm if the Hessian is not available, as it is done in Ipopt.jl. 

Currently, we specify to NLPModels that the problem does not have Hessian by setting `nnzh=0` in `NLPModelMeta`, so the following code works if the Hessian callback is not defined: 
https://github.com/MadNLP/MadNLP.jl/blob/fp/moi_nohessian/src/nlpmodels.jl#L360-L362
I am not sure this is the correct approach. 