### PR TITLE
Reexport MadNLP from MadNLP/libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ model = Model(()->MadNLP.Optimizer(linear_solver=LapackCPUSolver))
 #### HSL (requires extension `MadNLPHSL`)
 
 ```julia
-using MadNLP, MadNLPHSL, JuMP
+using MadNLPHSL, JuMP
 # ...
 model = Model(()->MadNLP.Optimizer(linear_solver=Ma27Solver))
 model = Model(()->MadNLP.Optimizer(linear_solver=Ma57Solver))
@@ -96,7 +96,7 @@ model = Model(()->MadNLP.Optimizer(linear_solver=Ma97Solver))
 #### Mumps (requires extension `MadNLPMumps`)
 
 ```julia
-using MadNLP, MadNLPMumps, JuMP
+using MadNLPMumps, JuMP
 # ...
 model = Model(()->MadNLP.Optimizer(linear_solver=MumpsSolver))
 ```
@@ -104,7 +104,7 @@ model = Model(()->MadNLP.Optimizer(linear_solver=MumpsSolver))
 #### Pardiso (requires extension `MadNLPPardiso`)
 
 ```julia
-using MadNLP, MadNLPPardiso, JuMP
+using MadNLPPardiso, JuMP
 # ...
 model = Model(()->MadNLP.Optimizer(linear_solver=PardisoSolver))
 model = Model(()->MadNLP.Optimizer(linear_solver=PardisoMKLSolver))
@@ -113,7 +113,7 @@ model = Model(()->MadNLP.Optimizer(linear_solver=PardisoMKLSolver))
 #### CUDA (requires extension `MadNLPGPU`)
 
 ```julia
-using MadNLP, MadNLPGPU, JuMP
+using MadNLPGPU, JuMP
 # ...
 model = Model(()->MadNLP.Optimizer(linear_solver=LapackGPUSolver))  # for dense problems
 model = Model(()->MadNLP.Optimizer(linear_solver=CUDSSSolver))      # for sparse problems

--- a/lib/MadNLPGPU/src/MadNLPGPU.jl
+++ b/lib/MadNLPGPU/src/MadNLPGPU.jl
@@ -57,4 +57,12 @@ end
 
 export LapackGPUSolver
 
+# re-export MadNLP, including deprecated names
+for name in names(MadNLP, all=true)
+    if Base.isexported(MadNLP, name)
+        @eval using MadNLP: $(name)
+        @eval export $(name)
+    end
+end
+
 end # module

--- a/lib/MadNLPHSL/src/MadNLPHSL.jl
+++ b/lib/MadNLPHSL/src/MadNLPHSL.jl
@@ -1,6 +1,6 @@
 module MadNLPHSL
 
-import MadNLP: @kwdef, MadNLPLogger, @debug, @warn, @error,
+import MadNLP: MadNLP, @kwdef, MadNLPLogger, @debug, @warn, @error,
     AbstractOptions, AbstractLinearSolver, set_options!, SparseMatrixCSC, SubVector,
     SymbolicException,FactorizationException,SolveException,InertiaException,
     introduce, factorize!, solve!, improve!, is_inertia, inertia, findIJ, nnz,

--- a/lib/MadNLPHSL/src/MadNLPHSL.jl
+++ b/lib/MadNLPHSL/src/MadNLPHSL.jl
@@ -21,4 +21,12 @@ include("ma97.jl")
 
 export Ma27Solver, Ma57Solver, Ma77Solver, Ma86Solver, Ma97Solver
 
+# re-export MadNLP, including deprecated names
+for name in names(MadNLP, all=true)
+    if Base.isexported(MadNLP, name)
+        @eval using MadNLP: $(name)
+        @eval export $(name)
+    end
+end
+
 end # module

--- a/lib/MadNLPMumps/src/MadNLPMumps.jl
+++ b/lib/MadNLPMumps/src/MadNLPMumps.jl
@@ -3,7 +3,7 @@ module MadNLPMumps
 import StaticArrays: SVector, setindex
 import MUMPS_seq_jll
 import MadNLP:
-    parsefile, dlopen,
+    MadNLP, parsefile, dlopen,
     @kwdef, MadNLPLogger, @debug, @warn, @error,
     SparseMatrixCSC, SubVector,
     SymbolicException,FactorizationException,SolveException,InertiaException,

--- a/lib/MadNLPMumps/src/MadNLPMumps.jl
+++ b/lib/MadNLPMumps/src/MadNLPMumps.jl
@@ -286,4 +286,12 @@ is_supported(::Type{MumpsSolver},::Type{Float64}) = true
 
 export MumpsSolver
 
+# re-export MadNLP, including deprecated names
+for name in names(MadNLP, all=true)
+    if Base.isexported(MadNLP, name)
+        @eval using MadNLP: $(name)
+        @eval export $(name)
+    end
+end
+
 end # module

--- a/lib/MadNLPPardiso/src/MadNLPPardiso.jl
+++ b/lib/MadNLPPardiso/src/MadNLPPardiso.jl
@@ -23,4 +23,12 @@ end
 
 export PardisoSolver, PardisoMKLSolver
 
+# re-export MadNLP, including deprecated names
+for name in names(MadNLP, all=true)
+    if Base.isexported(MadNLP, name)
+        @eval using MadNLP: $(name)
+        @eval export $(name)
+    end
+end
+
 end # module


### PR DESCRIPTION
With this change (approach taken in [Makie](https://github.com/MakieOrg/Makie.jl/blob/master/CairoMakie/src/CairoMakie.jl#L16-L22)), one can simply
```julia
using MadNLPGPU
```
instead of
```julia
using MadNLPGPU, MadNLP
```