### PR TITLE
[MOI] fix eval_constraint_jacobian_product

### DIFF
--- a/ext/MadNLPMOI/MadNLPMOI.jl
+++ b/ext/MadNLPMOI/MadNLPMOI.jl
@@ -492,15 +492,6 @@ function MOI.set(
     return
 end
 
-### ListOfSupportedNonlinearOperators
-
-function MOI.get(model::Optimizer, attr::MOI.ListOfSupportedNonlinearOperators)
-    if model.nlp_model === nothing
-        model.nlp_model = MOI.Nonlinear.Model()
-    end
-    return MOI.get(model.nlp_model, attr)
-end
-
 ### UserDefinedFunction
 
 MOI.supports(model::Optimizer, ::MOI.UserDefinedFunction) = true


### PR DESCRIPTION
This PR fixes two issues that were not caught in the tests: 
- a variable was not defined in `eval_constraint_jacobian_product` 
- we should use the function `eval_dense_gradient` instead of `eval_sparse_gradient` as the vector `Jtv` is dense. 

I think medium term, it would be nice to move the MOI utils functions directly inside MOI. 

solve #336 