### PR TITLE
Use GH Action Julia cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,16 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   test-github:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.9']
+        julia-version: ['1.10']
         julia-arch: [x64]
         os: [ubuntu-latest,macos-latest,windows-latest]
     steps:
@@ -20,6 +24,7 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
+      - uses: julia-actions/cache@v1
       - run: julia --color=yes --project=.ci .ci/ci.jl basic
   test-moonshot:
     env:
@@ -27,12 +32,13 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        julia-version: ['1.9']
+        julia-version: ['1.10']
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
+      - uses: julia-actions/cache@v1
       - run: julia --color=yes --project=.ci .ci/ci.jl full
       - uses: julia-actions/julia-processcoverage@v1
         with:
@@ -47,10 +53,11 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        julia-version: ['1.9']
+        julia-version: ['1.10']
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
+      - uses: julia-actions/cache@v1
       - run: julia --color=yes --project=.ci .ci/ci.jl cuda


### PR DESCRIPTION
This should speed up GH Actions CI and bump Julia to v1.10.