### PR TITLE
[hotfix] LDLFactorizations.jl added as dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
 version = "0.8.2"
 
 [deps]
+LDLFactorizations = "40e66cde-538c-5869-a4ad-c39174c6795b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
@@ -12,6 +13,12 @@ SolverCore = "ff4d7338-4cf1-434d-91df-b86cb86fb843"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
+[weakdeps]
+MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+
+[extensions]
+MadNLPMOI = "MathOptInterface"
+
 [compat]
 MINLPTests = "~0.5"
 MadNLPTests = "0.5"
@@ -20,16 +27,10 @@ NLPModels = "~0.17.2, 0.18, 0.19, 0.20"
 SolverCore = "~0.3"
 julia = "1.9"
 
-[weakdeps]
-MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-
-[extensions]
-MadNLPMOI = "MathOptInterface"
-
 [extras]
 MINLPTests = "ee0a3090-8ee9-5cdb-b8cb-8eeba3165522"
-Quadmath = "be4d8f0f-7fa4-5f49-b795-2f01399ab2dd"
 MadNLPTests = "b52a2a03-04ab-4a5f-9698-6a2deff93217"
+Quadmath = "be4d8f0f-7fa4-5f49-b795-2f01399ab2dd"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/LinearSolvers/ldl.jl
+++ b/src/LinearSolvers/ldl.jl
@@ -1,6 +1,6 @@
 @kwdef mutable struct LDLFactorizationsOptions <: AbstractOptions
 end
-const LDLF = NLPModels.LinearOperators.LDLFactorizations
+const LDLF = LDLFactorizations
 
 mutable struct LDLSolver{T} <: AbstractLinearSolver{T}
     inner::LDLF.LDLFactorization{T, Int32}

--- a/src/MadNLP.jl
+++ b/src/MadNLP.jl
@@ -12,6 +12,7 @@ import NLPModels
 import NLPModels: finalize, AbstractNLPModel, obj, grad!, cons!, jac_coord!, hess_coord!, hess_structure!, jac_structure!, NLPModelMeta, get_nvar, get_ncon, get_minimize, get_x0, get_y0, get_nnzj, get_nnzh, get_lvar, get_uvar, get_lcon, get_ucon
 import SolverCore: solve!, getStatus, AbstractOptimizationSolver, AbstractExecutionStats
 export MadNLPSolver, MadNLPOptions, UmfpackSolver, LDLSolver, CHOLMODSolver, LapackCPUSolver, madnlp, solve!
+import LDLFactorizations
 
 # Version info
 version() = parsefile(joinpath(@__DIR__,"..","Project.toml"))["version"]


### PR DESCRIPTION
The recent release of LinearOperators has moved LDLFactorizations.jl to weakdeps. We've been getting LDLFactorizations.jl from NLPMdoels -> LinearOperators -> LDLFactorizations, and this causes MadNLP breaking. This PR explicitly adds LDLFactorizations.jl as a dependency 