### PR TITLE
Check for NaN in linear solver's backsolve

### DIFF
--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -185,7 +185,6 @@ function solve!(
             solver.status=NOT_ENOUGH_DEGREES_OF_FREEDOM
         elseif e isa LinearSolverException
             solver.status=ERROR_IN_STEP_COMPUTATION;
-            solver.opt.rethrow_error && rethrow(e)
         elseif e isa InterruptException
             solver.status=USER_REQUESTED_STOP
             solver.opt.rethrow_error && rethrow(e)
@@ -216,7 +215,7 @@ function regular!(solver::AbstractMadNLPSolver{T}) where T
         if (solver.cnt.k!=0 && !solver.opt.jacobian_constant)
             eval_jac_wrapper!(solver, solver.kkt, solver.x)
         end
-        
+
         jtprod!(solver.jacl, solver.kkt, solver.y)
         sd = get_sd(solver.y,solver.zl_r,solver.zu_r,T(solver.opt.s_max))
         sc = get_sc(solver.zl_r,solver.zu_r,T(solver.opt.s_max))

--- a/src/LinearSolvers/backsolve.jl
+++ b/src/LinearSolvers/backsolve.jl
@@ -62,12 +62,17 @@ function solve_refine!(
         norm_x = norm(full(x), Inf)
         residual_ratio = norm_w / (min(norm_x, 1e6 * norm_b) + norm_b)
 
+
         if mod(iter, 10)==0
             @debug(iterator.logger,"iter ||res||")
         end
         @debug(iterator.logger, @sprintf("%4i %6.2e", iter, residual_ratio))
         iter += 1
 
+        # Check residual is finite. Otherwise throw an exception.
+        if isnan(residual_ratio)
+            throw(SolveException())
+        end
         if (iter >= iterator.opt.richardson_max_iter) || (residual_ratio < iterator.opt.richardson_tol)
             break
         end


### PR DESCRIPTION
Throw an error in the iterative refinement algorithm if the residual has `NaN` . 
By throwing an error, we ensure that MadNLP exits the algorithm properly, and we avoid the behavior observed in #349 . 