### PR TITLE
[MadNLPGPU] Fix race conditions in GPU kernels

### DIFF
--- a/lib/MadNLPGPU/Project.toml
+++ b/lib/MadNLPGPU/Project.toml
@@ -4,6 +4,7 @@ version = "0.7.2"
 
 [deps]
 AMD = "14f7f29c-3bd6-536c-9a0b-7339e30b5a3e"
+Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
 CUSOLVERRF = "a8cc9031-bad2-4722-94f5-40deabb4245c"

--- a/lib/MadNLPGPU/src/KKT/sparse.jl
+++ b/lib/MadNLPGPU/src/KKT/sparse.jl
@@ -367,15 +367,17 @@ end
 
 @kernel function _transfer_hessian_kernel!(y, @Const(ptr), @Const(x))
     index = @index(Global)
-    @inbounds i, j = ptr[index]
-    @inbounds y[i] += x[j]
+    @inbounds begin
+        i, j = ptr[index]
+        Atomix.@atomic y[i] += x[j]
+    end
 end
 
 @kernel function _transfer_jtsj_kernel!(y, @Const(ptr), @Const(ptrptr), @Const(x), @Const(s))
     index = @index(Global)
     @inbounds for index2 in ptrptr[index]:ptrptr[index+1]-1
         i, (j, k, l) = ptr[index2]
-        y[i] += s[j] * x[k] * x[l]
+        Atomix.@atomic y[i] += s[j] * x[k] * x[l]
     end
 end
 
@@ -427,7 +429,7 @@ end
     @inbounds begin
         to = idx_to[i]
         fr = idx_fr[i]
-        y[to] -= alpha * A[fr] * x[to]
+        Atomix.@atomic y[to] -= alpha * A[fr] * x[to]
     end
 end
 
@@ -439,7 +441,7 @@ end
     index = @index(Global)
     @inbounds for index2 in ptrptr[index]:ptrptr[index+1]-1
         i, j = ptr[index2]
-        y[i] += x[j]
+        Atomix.@atomic y[i] += x[j]
     end
 end
 

--- a/lib/MadNLPGPU/src/MadNLPGPU.jl
+++ b/lib/MadNLPGPU/src/MadNLPGPU.jl
@@ -13,6 +13,7 @@ import .CUBLAS: handle, CUBLAS_DIAG_NON_UNIT,
 import CUSOLVERRF
 
 # Kernels
+import Atomix
 import KernelAbstractions: @kernel, @index, synchronize, @Const
 
 import MadNLP: NLPModels


### PR DESCRIPTION
Use `Atomix.@atomic` to avoid race conditions in custom GPU kernels. 