### PR TITLE
Fix option `bound_relax_factor`

### DIFF
--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -34,7 +34,7 @@ function initialize!(solver::AbstractMadNLPSolver{T}) where T
         solver.y,
         solver.rhs,
         solver.ind_ineq;
-        tol=opt.tol,
+        tol=opt.bound_relax_factor,
         bound_push=opt.bound_push,
         bound_fac=opt.bound_fac,
     )
@@ -216,7 +216,7 @@ function regular!(solver::AbstractMadNLPSolver{T}) where T
         if (solver.cnt.k!=0 && !solver.opt.jacobian_constant)
             eval_jac_wrapper!(solver, solver.kkt, solver.x)
         end
-        
+
         jtprod!(solver.jacl, solver.kkt, solver.y)
         sd = get_sd(solver.y,solver.zl_r,solver.zu_r,T(solver.opt.s_max))
         sc = get_sc(solver.zl_r,solver.zu_r,T(solver.opt.s_max))

--- a/src/options.jl
+++ b/src/options.jl
@@ -45,9 +45,9 @@ end
 
     # NLP options
     kappa_d::Float64 = 1e-5
-    fixed_variable_treatment::Type = kkt_system <: MadNLP.SparseCondensedKKTSystem ? MadNLP.RelaxBound : MadNLP.MakeParameter 
+    fixed_variable_treatment::Type = kkt_system <: MadNLP.SparseCondensedKKTSystem ? MadNLP.RelaxBound : MadNLP.MakeParameter
     equality_treatment::Type = kkt_system <: MadNLP.SparseCondensedKKTSystem ? MadNLP.RelaxEquality : MadNLP.EnforceEquality
-    boudn_relax_factor::Float64 = 1e-8
+    bound_relax_factor::Float64 = 1e-8
     jacobian_constant::Bool = false
     hessian_constant::Bool = false
     hessian_approximation::Type = ExactHessian
@@ -171,9 +171,9 @@ function _get_primary_options(options)
 end
 
 function load_options(nlp; options...)
-    
+
     primary_opt, options = _get_primary_options(options)
-    
+
     # Initiate interior-point options
     opt_ipm = MadNLPOptions(nlp; primary_opt...)
     linear_solver_options = set_options!(opt_ipm, options)


### PR DESCRIPTION
- relax initial bounds with `bound_relax_factor` instead of `tol`. 
- significantly improve the performance of MadNLP on CUTEst 

[pprof-cpu.pdf](https://github.com/user-attachments/files/16383748/pprof-cpu.pdf)
