### PR TITLE
[MadNLPMOI] Set `nln_nnzj` explicitly

### DIFF
--- a/ext/MadNLPMOI/MadNLPMOI.jl
+++ b/ext/MadNLPMOI/MadNLPMOI.jl
@@ -915,6 +915,8 @@ function MOIModel(model::Optimizer)
             lcon = g_L,
             ucon = g_U,
             nnzj = nnzj,
+            lin_nnzj = 0,
+            nln_nnzj = nnzj,
             nnzh = nnzh,
             minimize = model.sense == MOI.MIN_SENSE
         ),


### PR DESCRIPTION
This PR fixes the error coming from the assertion introduced in  https://github.com/JuliaSmoothOptimizers/NLPModels.jl/pull/468