### PR TITLE
Remove some deps in the Project.toml of MadNLPGPU

### DIFF
--- a/lib/MadNLPGPU/Project.toml
+++ b/lib/MadNLPGPU/Project.toml
@@ -10,7 +10,6 @@ CUSOLVERRF = "a8cc9031-bad2-4722-94f5-40deabb4245c"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
-MadNLPTests = "b52a2a03-04ab-4a5f-9698-6a2deff93217"
 Metis = "2679e427-3c69-5b7f-982b-ece356f1e94b"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
@@ -26,9 +25,8 @@ Metis = "1"
 julia = "1.7"
 
 [extras]
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 MadNLPTests = "b52a2a03-04ab-4a5f-9698-6a2deff93217"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "MadNLPTests", "CUDA"]
+test = ["Test", "MadNLPTests"]


### PR DESCRIPTION
`MadNLPTests` should not be in the dependencies of `MadNLPGPU`.
We only use it for the tests.