### PR TITLE
Fix warning related to memory in MadNLPGPU

### DIFF
--- a/lib/MadNLPGPU/Project.toml
+++ b/lib/MadNLPGPU/Project.toml
@@ -16,7 +16,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 AMD = "0.5"
-CUDA = "5"
+CUDA = "5.4.0"
 CUDSS = "0.3.1, 0.4"
 CUSOLVERRF = "0.2"
 KernelAbstractions = "0.9"

--- a/lib/MadNLPGPU/src/LinearSolvers/cusolverrf.jl
+++ b/lib/MadNLPGPU/src/LinearSolvers/cusolverrf.jl
@@ -23,8 +23,8 @@
 const CuSubVector{T} = SubArray{
     T,
     1,
-    CUDA.CuArray{T,1,CUDA.Mem.DeviceBuffer},
-    Tuple{CUDA.CuArray{Int64,1,CUDA.Mem.DeviceBuffer}},
+    CUDA.CuArray{T,1,CUDA.DeviceMemory},
+    Tuple{CUDA.CuArray{Int64,1,CUDA.DeviceMemory}},
     false,
 }
 


### PR DESCRIPTION
Fix the following warning:
```julia
  1 dependency had output during precompilation:
┌ MadNLPGPU
│  WARNING: Mem.DeviceBuffer is deprecated, use CUDA.DeviceMemory instead.
│    likely near /home/montalex/Argonne/MadNLP.jl/lib/MadNLPGPU/src/LinearSolvers/cusolverrf.jl:23
│  WARNING: Mem.DeviceBuffer is deprecated, use CUDA.DeviceMemory instead.
│    likely near /home/montalex/Argonne/MadNLP.jl/lib/MadNLPGPU/src/LinearSolvers/cusolverrf.jl:23
 ```
Related blog: https://juliagpu.org/post/2024-05-28-cuda_5.4/