### PR TITLE
Iterative refinement tolerance tuning

### DIFF
--- a/src/LinearSolvers/backsolve.jl
+++ b/src/LinearSolvers/backsolve.jl
@@ -1,7 +1,7 @@
 @kwdef mutable struct RichardsonOptions <: AbstractOptions
     richardson_max_iter::Int = 10
-    richardson_tol::Float64 = 1e-10
-    richardson_acceptable_tol::Float64 = 1e-5
+    richardson_tol::Float64
+    richardson_acceptable_tol::Float64
 end
 
 struct RichardsonIterator{T, KKT <: AbstractKKTSystem{T}} <: AbstractIterator{T}
@@ -22,7 +22,7 @@ function RichardsonIterator(
     )
 end
 
-default_options(::Type{RichardsonIterator}) = RichardsonOptions()
+default_options(::Type{RichardsonIterator}, tol) = RichardsonOptions(richardson_tol=tol^(5/4), richardson_acceptable_tol=tol^(5/8))
 
 function solve_refine!(
     x::VT,

--- a/src/options.jl
+++ b/src/options.jl
@@ -182,7 +182,7 @@ function load_options(nlp; options...)
     opt_linear_solver = default_options(opt_ipm.linear_solver)
     iterator_options = set_options!(opt_linear_solver, linear_solver_options)
     # Initiate iterator options
-    opt_iterator = default_options(opt_ipm.iterator)
+    opt_iterator = default_options(opt_ipm.iterator, opt_ipm.tol)
     remaining_options = set_options!(opt_iterator, iterator_options)
 
     # Initiate logger


### PR DESCRIPTION
This PR implements tuning for the iterative refinement. Previously, the tolerance was fixed to `1e-8`, but this is impractical for single precisions. In this PR, we implement an adaptive tuning based on the overall tolerance of the solver. For double precision, we have the same behavior as before, but for single precision, this changes the behavior and makes things faster (less IR steps). 

It turns out that this PR makes the LiftedKKTSystem as it uses higher tolerance.