### PR TITLE
[MadNLP] Fix the warning with SolverCore.solve!

### DIFF
--- a/src/KKT/KKTsystem.jl
+++ b/src/KKT/KKTsystem.jl
@@ -174,7 +174,7 @@ Solve the KKT system ``K x = w`` with the linear solver stored
 inside `kkt` and stores the result inplace inside the `AbstractKKTVector` `w`.
 
 """
-function solve! end
+function solve!(kkt, w) end
 
 """
     regularize_diagonal!(kkt::AbstractKKTSystem, primal_values::Number, dual_values::Number)


### PR DESCRIPTION
Fix the following warning:
```julia
   1 dependency had output during precompilation:
┌ MadNLP
│  ┌ Warning: Replacing docs for `SolverCore.solve! :: Union{}` in module `MadNLP`
│  └ @ Base.Docs docs/Docs.jl:243
└  
```
