### PR TITLE
[MadNLPHSL] Test the solvers in quadruple precision

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: ${{ matrix.julia-version }} 
+          version: ${{ matrix.julia-version }}
       - uses: julia-actions/cache@v1
       - run: julia --color=yes --project=.ci .ci/ci.jl basic
   test-mit:
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         julia-version: ['1.10']
-        hsl-version: ['2024.11.28'] # '2025.1.19'
+        hsl-version: ['2024.11.28', '2025.1.19']
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         julia-version: ['1.10']
-        hsl-version: ['2024.11.28', '2025.1.19']
+        hsl-version: ['2024.11.28', '2024.12.31']
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest


### PR DESCRIPTION
I created a copy of the folder `HSL_jll.v2024.12.31` with a new name `HSL_jll.v2024.12.31` on the cluster such that we don't have an issue with the compat entry (`2025.x.x`).