### PR TITLE
[DNMY][MadNLPMumps] use MUMPS.jl as backend

### DIFF
--- a/lib/MadNLPMumps/Project.toml
+++ b/lib/MadNLPMumps/Project.toml
@@ -1,15 +1,19 @@
 name = "MadNLPMumps"
 uuid = "3b83494e-c0a4-4895-918b-9157a7a085a1"
-version = "0.4.1"
+version = "0.5.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+MUMPS = "55d2b088-9f4e-11e9-26c0-150b02ea6a46"
 MUMPS_seq_jll = "d7ed1dd3-d0ae-5e8e-bfb4-87a502085b8d"
 MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
 OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 
 [compat]
-MUMPS_seq_jll = "~5.3, ~500.600"
+MPI = "0.20.22"
+MUMPS = "1.5.0"
+MUMPS_seq_jll = "~500.700"
 MadNLP = "0.5, 0.6, 0.7, 0.8"
 MadNLPTests = "0.5"
 OpenBLAS32_jll = "0.3"

--- a/lib/MadNLPMumps/src/MadNLPMumps.jl
+++ b/lib/MadNLPMumps/src/MadNLPMumps.jl
@@ -1,6 +1,7 @@
 module MadNLPMumps
 
-using MUMPS_seq_jll
+import MUMPS
+
 import MadNLP:
     MadNLP, parsefile,
     @kwdef, MadNLPLogger, @debug, @warn, @error,
@@ -34,144 +35,17 @@ tzeros(n) = tuple((0 for i=1:n)...)
     mumps_scaling::Int = 77
 end
 
-@kwdef mutable struct Struc{T}
-    sym::Cint = 0
-    par::Cint = 0
-    job::Cint = 0
-
-    comm_fortran::Cint = 0
-
-    icntl::NTuple{60,Cint} = tzeros(60)
-    keep::NTuple{500,Cint} = tzeros(500)
-    cntl::NTuple{15,T} = tzeros(15)
-    dkeep::NTuple{230,T} = tzeros(230)
-    keep8::NTuple{150,Int64} = tzeros(150)
-    n::Cint = 0
-    nblk::Cint = 0
-
-    nz_alloc::Cint = 0
-
-    nz::Cint = 0
-    nnz::Int64 = 0
-    irn::Ptr{Cint} = C_NULL
-    jcn::Ptr{Cint} = C_NULL
-    a::Ptr{T} = C_NULL
-
-    nz_loc::Cint = 0
-    nnz_loc::Int64 = 0
-    irn_loc::Ptr{Cint} = C_NULL
-    jcn_loc::Ptr{Cint} = C_NULL
-    a_loc::Ptr{T} = C_NULL ###
-
-    nelt::Cint = 0
-    eltptr::Ptr{Cint} = C_NULL
-    eltvar::Ptr{Cint} = C_NULL
-    a_elt::Ptr{T} = C_NULL
-
-    blkptr::Ptr{Cint} = C_NULL
-    blkvar::Ptr{Cint} = C_NULL
-
-    perm_in::Ptr{Cint} = C_NULL
-
-    sym_perm::Ptr{Cint} = C_NULL
-    uns_perm::Ptr{Cint} = C_NULL
-
-    colsca::Ptr{T} = C_NULL
-    rowsca::Ptr{T} = C_NULL
-    colsca_from_mumps::Cint = 0
-    rowsca_from_mumps::Cint = 0
-
-    rhs::Ptr{T} = C_NULL
-    redrhs::Ptr{T} = C_NULL
-    rhs_sparse::Ptr{T} = C_NULL
-    sol_loc::Ptr{T} = C_NULL
-    rhs_loc::Ptr{T} = C_NULL
-
-    irhs_sparse::Ptr{Cint} = C_NULL
-    irhs_ptr::Ptr{Cint} = C_NULL
-    isol_loc::Ptr{Cint} = C_NULL
-    irhs_loc::Ptr{Cint} = C_NULL
-
-    nrhs::Cint = 0
-    lrhs::Cint = 0
-    lredrhs::Cint = 0
-    nz_rhs::Cint = 0
-    lsol_loc::Cint = 0
-    nloc_rhs::Cint = 0
-    lrhs_loc::Cint = 0
-
-    schur_mloc::Cint = 0
-    schur_nloc::Cint = 0
-    schur_lld::Cint = 0
-
-    mblock::Cint = 0
-    nblock::Cint = 0
-    nprow::Cint = 0
-    npcol::Cint = 0
-
-    info::NTuple{80,Cint} = tzeros(80)
-    infog::NTuple{80,Cint} = tzeros(80)
-    rinfo::NTuple{40,T} = tzeros(40)
-    rinfog::NTuple{40,T} = tzeros(40)
-
-    deficiency::Cint = 0
-    pivnul_list::Ptr{Cint} = C_NULL
-    mapping::Ptr{Cint} = C_NULL
-
-    size_schur::Cint = 0
-    listvar_schur::Ptr{Cint} = C_NULL
-    schur::Ptr{T} = C_NULL ##
-
-    instance_number::Cint = 0
-    wk_user::Ptr{T} = C_NULL
-
-    version_number::NTuple{32,Cchar} = tzeros(32)
-
-    ooc_tmpdir::NTuple{256,Cchar} = tzeros(256)
-    ooc_prefix::NTuple{64,Cchar} = tzeros(64)
-
-    write_problem::NTuple{256,Cchar} = tzeros(256)
-    lwk_user::Cint = 0
-
-    save_dir::NTuple{256,Cchar} = tzeros(256)
-    save_prefix::NTuple{256,Cchar} = tzeros(256)
-
-    metis_options::NTuple{40,Cint} = tzeros(40)
-end
-
 mutable struct MumpsSolver{T} <: AbstractLinearSolver{T}
     csc::SparseMatrixCSC{T,Int32}
     I::Vector{Int32}
     J::Vector{Int32}
     sym_perm::Vector{Int32}
     pivnul_list::Vector{Int32}
-    mumps_struc::Struc
+    mumps_struc::MUMPS.Mumps
     is_singular::Bool
     opt::MumpsOptions
     logger::MadNLPLogger
 end
-
-# this is necessary, when multi-threaded calls are made with Mumps, not to clash with MPI
-mumps_lock = Threads.SpinLock()
-
-function locked_mumps_c(mumps_struc::Struc{Float32})
-    lock(mumps_lock)
-    try
-        @ccall libsmumps.smumps_c(mumps_struc::Ref{Struc{Float32}})::Cvoid
-    finally
-        unlock(mumps_lock)
-    end
-end
-
-function locked_mumps_c(mumps_struc::Struc{Float64})
-    lock(mumps_lock)
-    try
-        @ccall libdmumps.dmumps_c(mumps_struc::Ref{Struc{Float64}})::Cvoid
-    finally
-        unlock(mumps_lock)
-    end
-end
-# ---------------------------------------------------------------------------------------
 
 function MumpsSolver(csc::SparseMatrixCSC{T,Int32};
     opt=MumpsOptions(), logger=MadNLPLogger(),
@@ -181,24 +55,16 @@ function MumpsSolver(csc::SparseMatrixCSC{T,Int32};
     sym_perm = zeros(Int32,csc.n)
     pivnul_list = zeros(Int32,csc.n)
 
-    mumps_struc = Struc{T}()
+    icntl = MUMPS.default_icntl[:]
+    mumps_struc = MUMPS.Mumps{T}(MUMPS.mumps_symmetric, icntl, MUMPS.default_cntl64)
 
-    mumps_struc.sym =  2
-    mumps_struc.par =  1
-    mumps_struc.job = -1
-    mumps_struc.comm_fortran = -987654 # MPI.COMM_WORLD.val
-
-    locked_mumps_c(mumps_struc)
     mumps_struc.n = csc.n;
-    mumps_struc.nz= nnz(csc);
+    mumps_struc.nnz= nnz(csc);
     mumps_struc.a = pointer(csc.nzval)
     mumps_struc.irn = pointer(I)
     mumps_struc.jcn = pointer(J)
     mumps_struc.sym_perm = pointer(sym_perm)
     mumps_struc.pivnul_list = pointer(pivnul_list)
-
-    # symbolic factorization
-    mumps_struc.job = 1;
 
     mumps_struc.icntl = setindex(mumps_struc.icntl,0,2)
     mumps_struc.icntl = setindex(mumps_struc.icntl,0,3)
@@ -212,15 +78,16 @@ function MumpsSolver(csc::SparseMatrixCSC{T,Int32};
 
     mumps_struc.cntl = setindex(mumps_struc.cntl,opt.mumps_pivtol,1)
 
+
+    mumps_struc.job = 1
     a = copy(csc.nzval) # would there be a better way?
     csc.nzval.=1
-
-    locked_mumps_c(mumps_struc);
+    MUMPS.invoke_mumps!(mumps_struc)
     mumps_struc.info[1] < 0 && throw(SymbolicException())
 
     csc.nzval.=a
 
-    M = MumpsSolver{T}(csc,I,J,sym_perm,pivnul_list,mumps_struc,false,opt,logger)
+    M = MumpsSolver{T}(csc, I, J, sym_perm, pivnul_list, mumps_struc, false, opt, logger)
     finalizer(finalize,M)
 
     return M
@@ -228,10 +95,10 @@ end
 
 function factorize!(M::MumpsSolver)
     M.is_singular = false
-    M.mumps_struc.job = 2;
+    M.mumps_struc.job = 2
     cnt = 0
     while true
-        locked_mumps_c(M.mumps_struc)
+        MUMPS.invoke_mumps!(M.mumps_struc)
         if M.mumps_struc.info[1] in [-8,-9]
             cnt >= 10 && throw(FactorizationException())
             M.mumps_struc.icntl = setindex(M.mumps_struc.icntl,M.mumps_struc.icntl[14]*2.,14)
@@ -251,8 +118,10 @@ end
 function solve!(M::MumpsSolver{T},rhs::Vector{T}) where T
     M.is_singular && return rhs
     M.mumps_struc.rhs = pointer(rhs)
+    M.mumps_struc.lrhs = length(rhs)
+    M.mumps_struc.nrhs = 1
     M.mumps_struc.job = 3
-    locked_mumps_c(M.mumps_struc)
+    MUMPS.invoke_mumps!(M.mumps_struc)
     M.mumps_struc.info[1] < 0 && throw(SolveException())
     return rhs
 end
@@ -276,11 +145,10 @@ function improve!(M::MumpsSolver)
 end
 
 function finalize(M::MumpsSolver)
-    M.mumps_struc.job = -2
-    locked_mumps_c(M.mumps_struc);
+    MUMPS.finalize(M.mumps_struc)
 end
 
-introduce(::MumpsSolver)="mumps"
+introduce(::MumpsSolver) = "mumps"
 input_type(::Type{MumpsSolver}) = :csc
 default_options(::Type{MumpsSolver}) = MumpsOptions()
 is_supported(::Type{MumpsSolver},::Type{Float32}) = true

--- a/lib/MadNLPMumps/test/runtests.jl
+++ b/lib/MadNLPMumps/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, MadNLP, MadNLPMumps, MadNLPTests
+using Test, MadNLP, MadNLPMumps, MadNLPTests, MPI
 
 testset = [
     [
@@ -11,11 +11,12 @@ testset = [
 ]
 
 @testset "MadNLPMumps test" begin
+    MPI.Init() # TODO: check if we really need MPI
+    comm = MPI.COMM_WORLD
     MadNLPTests.test_linear_solver(MadNLPMumps.MumpsSolver,Float32)
     MadNLPTests.test_linear_solver(MadNLPMumps.MumpsSolver,Float64)
     for (name,optimizer_constructor,exclude) in testset
         test_madnlp(name,optimizer_constructor,exclude)
     end
 end
-
 


### PR DESCRIPTION
MadNLP is breaking with MUMPS_jll 5.7.3. This PR attempts to fix this issue by using MUMPS.jl as a backend (this would reduce the maintenance burden long term). 

A question before merging this PR: do we necessarily need MPI to instantiate MUMPS? The previous version of MadNLPMumps was not depending on MPI, but MUMPS.jl requires an explicit call to `MPI.Init()` to ensure we can call MUMPS: https://github.com/JuliaSmoothOptimizers/MUMPS.jl/blob/main/src/interface.jl#L29