### PR TITLE
Replace `MadNLPSolver` by `AbstractMadNLPSolver` in IPM functions

### DIFF
--- a/src/IPM/callbacks.jl
+++ b/src/IPM/callbacks.jl
@@ -1,4 +1,4 @@
-function eval_f_wrapper(solver::MadNLPSolver, x::PrimalVector{T}) where T
+function eval_f_wrapper(solver::AbstractMadNLPSolver, x::PrimalVector{T}) where T
     nlp = solver.nlp
     cnt = solver.cnt
     @trace(solver.logger,"Evaluating objective.")
@@ -13,7 +13,7 @@ function eval_f_wrapper(solver::MadNLPSolver, x::PrimalVector{T}) where T
     return obj_val
 end
 
-function eval_grad_f_wrapper!(solver::MadNLPSolver, f::PrimalVector{T}, x::PrimalVector{T}) where T
+function eval_grad_f_wrapper!(solver::AbstractMadNLPSolver, f::PrimalVector{T}, x::PrimalVector{T}) where T
     nlp = solver.nlp
     cnt = solver.cnt
     @trace(solver.logger,"Evaluating objective gradient.")
@@ -33,7 +33,7 @@ function eval_grad_f_wrapper!(solver::MadNLPSolver, f::PrimalVector{T}, x::Prima
     return f
 end
 
-function eval_cons_wrapper!(solver::MadNLPSolver, c::AbstractVector{T}, x::PrimalVector{T}) where T
+function eval_cons_wrapper!(solver::AbstractMadNLPSolver, c::AbstractVector{T}, x::PrimalVector{T}) where T
     nlp = solver.nlp
     cnt = solver.cnt
     @trace(solver.logger, "Evaluating constraints.")
@@ -51,7 +51,7 @@ function eval_cons_wrapper!(solver::MadNLPSolver, c::AbstractVector{T}, x::Prima
     return c
 end
 
-function eval_jac_wrapper!(solver::MadNLPSolver, kkt::AbstractKKTSystem, x::PrimalVector{T}) where T
+function eval_jac_wrapper!(solver::AbstractMadNLPSolver, kkt::AbstractKKTSystem, x::PrimalVector{T}) where T
     nlp = solver.nlp
     cnt = solver.cnt
     ns = length(solver.ind_ineq)
@@ -71,7 +71,7 @@ function eval_jac_wrapper!(solver::MadNLPSolver, kkt::AbstractKKTSystem, x::Prim
     return jac
 end
 
-function eval_lag_hess_wrapper!(solver::MadNLPSolver, kkt::AbstractKKTSystem, x::PrimalVector{T},l::AbstractVector{T};is_resto=false) where T
+function eval_lag_hess_wrapper!(solver::AbstractMadNLPSolver, kkt::AbstractKKTSystem, x::PrimalVector{T},l::AbstractVector{T};is_resto=false) where T
     nlp = solver.nlp
     cnt = solver.cnt
     @trace(solver.logger,"Evaluating Lagrangian Hessian.")
@@ -92,7 +92,7 @@ function eval_lag_hess_wrapper!(solver::MadNLPSolver, kkt::AbstractKKTSystem, x:
     return hess
 end
 
-function eval_jac_wrapper!(solver::MadNLPSolver, kkt::AbstractDenseKKTSystem, x::PrimalVector{T}) where T
+function eval_jac_wrapper!(solver::AbstractMadNLPSolver, kkt::AbstractDenseKKTSystem, x::PrimalVector{T}) where T
     nlp = solver.nlp
     cnt = solver.cnt
     ns = length(solver.ind_ineq)
@@ -113,7 +113,7 @@ function eval_jac_wrapper!(solver::MadNLPSolver, kkt::AbstractDenseKKTSystem, x:
 end
 
 function eval_lag_hess_wrapper!(
-    solver::MadNLPSolver,
+    solver::AbstractMadNLPSolver,
     kkt::AbstractDenseKKTSystem{T, VT, MT, QN},
     x::PrimalVector{T},
     l::AbstractVector{T};
@@ -140,7 +140,7 @@ function eval_lag_hess_wrapper!(
 end
 
 function eval_lag_hess_wrapper!(
-    solver::MadNLPSolver,
+    solver::AbstractMadNLPSolver,
     kkt::AbstractKKTSystem{T, VT, MT, QN},
     x::PrimalVector{T},
     l::AbstractVector{T};

--- a/src/IPM/factorization.jl
+++ b/src/IPM/factorization.jl
@@ -16,7 +16,7 @@ function solve_refine_wrapper!(d, solver, p, w)
     return result
 end
 
-function factorize_wrapper!(solver::MadNLPSolver)
+function factorize_wrapper!(solver::AbstractMadNLPSolver)
     @trace(solver.logger,"Factorization started.")
     build_kkt!(solver.kkt)
     solver.cnt.linear_solver_time += @elapsed factorize!(solver.kkt.linear_solver)

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -1,7 +1,7 @@
 
 # KKT system updates -------------------------------------------------------
 # Set diagonal
-function set_aug_diagonal!(kkt::AbstractKKTSystem{T}, solver::MadNLPSolver{T}) where T
+function set_aug_diagonal!(kkt::AbstractKKTSystem{T}, solver::AbstractMadNLPSolver{T}) where T
     x = full(solver.x)
     xl = full(solver.xl)
     xu = full(solver.xu)
@@ -33,7 +33,7 @@ function _set_aug_diagonal!(kkt::AbstractUnreducedKKTSystem)
     return
 end
 
-function set_aug_diagonal!(kkt::ScaledSparseKKTSystem{T}, solver::MadNLPSolver{T}) where T
+function set_aug_diagonal!(kkt::ScaledSparseKKTSystem{T}, solver::AbstractMadNLPSolver{T}) where T
     fill!(kkt.reg, zero(T))
     fill!(kkt.du_diag, zero(T))
     # Ensure l_diag and u_diag have only non negative entries
@@ -69,7 +69,7 @@ end
 
 
 # Robust restoration
-function set_aug_RR!(kkt::AbstractKKTSystem, solver::MadNLPSolver, RR::RobustRestorer)
+function set_aug_RR!(kkt::AbstractKKTSystem, solver::AbstractMadNLPSolver, RR::RobustRestorer)
     x = full(solver.x)
     xl = full(solver.xl)
     xu = full(solver.xu)
@@ -86,7 +86,7 @@ function set_aug_RR!(kkt::AbstractKKTSystem, solver::MadNLPSolver, RR::RobustRes
     return
 end
 
-function set_aug_RR!(kkt::ScaledSparseKKTSystem, solver::MadNLPSolver, RR::RobustRestorer)
+function set_aug_RR!(kkt::ScaledSparseKKTSystem, solver::AbstractMadNLPSolver, RR::RobustRestorer)
     x = full(solver.x)
     xl = full(solver.xl)
     xu = full(solver.xu)
@@ -103,14 +103,14 @@ function set_aug_RR!(kkt::ScaledSparseKKTSystem, solver::MadNLPSolver, RR::Robus
     return
 end
 
-function set_f_RR!(solver::MadNLPSolver, RR::RobustRestorer)
+function set_f_RR!(solver::AbstractMadNLPSolver, RR::RobustRestorer)
     x = full(solver.x)
     RR.f_R .= RR.zeta .* RR.D_R .^ 2 .* (x .- RR.x_ref)
     return
 end
 
 # Set RHS
-function set_aug_rhs!(solver::MadNLPSolver, kkt::AbstractKKTSystem, c::AbstractVector)
+function set_aug_rhs!(solver::AbstractMadNLPSolver, kkt::AbstractKKTSystem, c::AbstractVector)
     px = primal(solver.p)
     x = primal(solver.x)
     f = primal(solver.f)
@@ -131,7 +131,7 @@ end
 
 # Set RHS RR
 function set_aug_rhs_RR!(
-    solver::MadNLPSolver, kkt::AbstractKKTSystem, RR::RobustRestorer, rho,
+    solver::AbstractMadNLPSolver, kkt::AbstractKKTSystem, RR::RobustRestorer, rho,
 )
     x = full(solver.x)
     xl = full(solver.xl)
@@ -208,7 +208,7 @@ function set_initial_bounds!(xl::AbstractVector{T}, xu::AbstractVector{T}, tol) 
     )
 end
 
-function set_initial_rhs!(solver::MadNLPSolver{T}, kkt::AbstractKKTSystem) where T
+function set_initial_rhs!(solver::AbstractMadNLPSolver{T}, kkt::AbstractKKTSystem) where T
     f = primal(solver.f)
     zl = primal(solver.zl)
     zu = primal(solver.zu)
@@ -221,7 +221,7 @@ function set_initial_rhs!(solver::MadNLPSolver{T}, kkt::AbstractKKTSystem) where
 end
 
 # Set ifr
-function set_aug_rhs_ifr!(solver::MadNLPSolver{T}, kkt::AbstractKKTSystem, p0::AbstractKKTVector) where T
+function set_aug_rhs_ifr!(solver::AbstractMadNLPSolver{T}, kkt::AbstractKKTSystem, p0::AbstractKKTVector) where T
     fill!(primal(p0), zero(T))
     fill!(dual_lb(p0), zero(T))
     fill!(dual_ub(p0), zero(T))
@@ -230,7 +230,7 @@ function set_aug_rhs_ifr!(solver::MadNLPSolver{T}, kkt::AbstractKKTSystem, p0::A
     return
 end
 
-function set_g_ifr!(solver::MadNLPSolver, g::AbstractArray)
+function set_g_ifr!(solver::AbstractMadNLPSolver, g::AbstractArray)
     f = full(solver.f)
     x = full(solver.x)
     xl = full(solver.xl)

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -88,10 +88,10 @@ abstract type DualInitializeOptions end
 struct DualInitializeSetZero <: DualInitializeOptions end
 struct DualInitializeLeastSquares <: DualInitializeOptions end
 
-function initialize_dual(solver::MadNLPSolver{T}, ::Type{DualInitializeSetZero}) where T
+function initialize_dual(solver::AbstractMadNLPSolver{T}, ::Type{DualInitializeSetZero}) where T
     fill!(solver.y, zero(T))
 end
-function initialize_dual(solver::MadNLPSolver{T}, ::Type{DualInitializeLeastSquares}) where T
+function initialize_dual(solver::AbstractMadNLPSolver{T}, ::Type{DualInitializeLeastSquares}) where T
     set_initial_rhs!(solver, solver.kkt)
     factorize_wrapper!(solver)
     is_solved = solve_refine_wrapper!(
@@ -527,7 +527,7 @@ function restore!(solver::AbstractMadNLPSolver{T}) where T
     end
 end
 
-function robust!(solver::MadNLPSolver{T}) where T
+function robust!(solver::AbstractMadNLPSolver{T}) where T
     initialize_robust_restorer!(solver)
     RR = solver.RR
     while true
@@ -827,7 +827,7 @@ end
 
 function inertia_correction!(
     inertia_corrector::InertiaBased,
-    solver::MadNLPSolver{T}
+    solver::AbstractMadNLPSolver{T}
     ) where {T}
 
     n_trial = 0
@@ -880,7 +880,7 @@ end
 
 function inertia_correction!(
     inertia_corrector::InertiaFree,
-    solver::MadNLPSolver{T}
+    solver::AbstractMadNLPSolver{T}
     ) where T
 
     n_trial = 0
@@ -943,7 +943,7 @@ end
 
 function inertia_correction!(
     inertia_corrector::InertiaIgnore,
-    solver::MadNLPSolver{T}
+    solver::AbstractMadNLPSolver{T}
     ) where T
 
     n_trial = 0

--- a/src/IPM/utils.jl
+++ b/src/IPM/utils.jl
@@ -6,7 +6,7 @@ algorithm has terminated.
 
 """
 mutable struct MadNLPExecutionStats{T, VT} <: AbstractExecutionStats
-    options::MadNLPOptions
+    options::AbstractOptions
     status::Status
     solution::VT
     objective::T
@@ -20,7 +20,7 @@ mutable struct MadNLPExecutionStats{T, VT} <: AbstractExecutionStats
     counters::MadNLPCounters
 end
 
-MadNLPExecutionStats(solver::MadNLPSolver) =MadNLPExecutionStats(
+MadNLPExecutionStats(solver::AbstractMadNLPSolver) =MadNLPExecutionStats(
     solver.opt,
     solver.status,
     primal(solver.x)[1:get_nvar(solver.nlp)],
@@ -35,7 +35,7 @@ MadNLPExecutionStats(solver::MadNLPSolver) =MadNLPExecutionStats(
     solver.cnt,
 )
 
-function update!(stats::MadNLPExecutionStats, solver::MadNLPSolver)
+function update!(stats::MadNLPExecutionStats, solver::AbstractMadNLPSolver)
     stats.status = solver.status
     stats.solution .= @view(primal(solver.x)[1:get_nvar(solver.nlp)])
     stats.multipliers .= solver.y


### PR DESCRIPTION
This PR allows to develop new extensions for MadNLP that re-use the kernels implemented in MadNLP. 

This is required by MadQP, which now implements a new structure `MPCSolver <: AbstractMadNLPSolver`. 