### PR TITLE
Support MUMPS v5.8.0

### DIFF
--- a/lib/MadNLPMumps/Project.toml
+++ b/lib/MadNLPMumps/Project.toml
@@ -1,6 +1,6 @@
 name = "MadNLPMumps"
 uuid = "3b83494e-c0a4-4895-918b-9157a7a085a1"
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -9,11 +9,11 @@ MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
 OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 
 [compat]
-MUMPS_seq_jll = "~500.700"
+MUMPS_seq_jll = "~500.800"
 MadNLP = "0.5, 0.6, 0.7, 0.8"
 MadNLPTests = "0.5"
 OpenBLAS32_jll = "0.3"
-julia = "1.6"
+julia = "1.9"
 
 [extras]
 MadNLPTests = "b52a2a03-04ab-4a5f-9698-6a2deff93217"

--- a/lib/MadNLPMumps/src/MadNLPMumps.jl
+++ b/lib/MadNLPMumps/src/MadNLPMumps.jl
@@ -11,11 +11,9 @@ import MadNLP:
 import LinearAlgebra, OpenBLAS32_jll
 
 function __init__()
-    if VERSION ≥ v"1.9"
-        config = LinearAlgebra.BLAS.lbt_get_config()
-        if !any(lib -> lib.interface == :lp64, config.loaded_libs)
-            LinearAlgebra.BLAS.lbt_forward(OpenBLAS32_jll.libopenblas_path)
-        end
+    config = LinearAlgebra.BLAS.lbt_get_config()
+    if !any(lib -> lib.interface == :lp64, config.loaded_libs)
+        LinearAlgebra.BLAS.lbt_forward(OpenBLAS32_jll.libopenblas_path)
     end
 end
 


### PR DESCRIPTION
Support MUMPS `v5.8.0`.

Julia 1.9 is required by the artifact `MUMPS_seq_jll`, because it is cross-compiled with LBT.
We should have done with the previous release but I didn't checked the compat entry of Julia.