### PR TITLE
Update MadNLPPardiso 

### DIFF
--- a/lib/MadNLPPardiso/Project.toml
+++ b/lib/MadNLPPardiso/Project.toml
@@ -5,15 +5,13 @@ version = "0.3.4"
 [deps]
 MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
 
 [compat]
 MadNLP = "0.5, 0.6, 0.7, 0.8"
-BinaryProvider = "0.5"
 MadNLPTests = "0.5"
-julia = "1.6"
+julia = "1.10"
 MKL_jll = "~2021,2022"
 
 [extras]

--- a/lib/MadNLPPardiso/deps/build.jl
+++ b/lib/MadNLPPardiso/deps/build.jl
@@ -1,40 +1,38 @@
+# File adapted from Pardiso.jl:
+# https://github.com/JuliaSparse/Pardiso.jl/blob/master/deps/build.jl
+#
+# The Pardiso.jl package is licensed under the MIT "Expat" License:
+#   Copyright (c) 2015-2020: Kristoffer Carlsson, Julia Computing
+#
+# Original LICENSE file: https://github.com/JuliaSparse/Pardiso.jl/blob/master/LICENSE.md
+
 # remove deps.jl if it exists, in case build.jl fails
 isfile("deps.jl") && rm("deps.jl")
 
 using Libdl
 
-
 println("Pardiso library")
 println("===============")
 
-const LIBPARDISONAMES =
-if Sys.iswindows()
-[
-    "libpardiso.dll",
-    "libpardiso600-WIN-X86-64.dll",
-]
+const LIBPARDISONAMES = if Sys.iswindows()
+    ["libpardiso.dll", "libpardiso600-WIN-X86-64.dll"]
 elseif Sys.isapple()
-[
-    "libpardiso.dylib",
-    "libpardiso600-MACOS-X86-64.dylib",
-]
+    ["libpardiso.dylib", "libpardiso600-MACOS-X86-64.dylib"]
 elseif Sys.islinux()
-[
-    "libpardiso.so",
-    "libpardiso600-GNU800-X86-64.so",
-]
+    ["libpardiso.so", "libpardiso600-GNU800-X86-64.so"]
 else
     error("unhandled OS")
 end
 
 println("Looking for libraries with name: ", join(LIBPARDISONAMES, ", "), ".")
 
-
 PATH_PREFIXES = [@__DIR__; get(ENV, "JULIA_PARDISO", [])]
 
 if !haskey(ENV, "JULIA_PARDISO")
-    println("INFO: use the `JULIA_PARDISO` environment variable to set a path to " *
-            "the folder where the Pardiso library is located")
+    println(
+        "INFO: use the `JULIA_PARDISO` environment variable to set a path to " *
+        "the folder where the Pardiso library is located",
+    )
 end
 
 function find_paradisolib()
@@ -58,7 +56,7 @@ function find_paradisolib()
             end
         end
     end
-    println("did not find libpardiso, assuming PARDISO 5/6 is not installed")
+    println("did not find libpardiso, assuming Panua PARDISO is not installed")
     return "", false
 end
 
@@ -80,13 +78,12 @@ end
 found_mklpardiso = find_mklparadiso()
 
 open("deps.jl", "w") do f
-    print(f,
-"""
-const LOCAL_MKL_FOUND = $found_mklpardiso
-const PARDISO_LIB_FOUND = $found_pardisolib
-const PARDISO_PATH = raw"$pardisopath"
-"""
-)
-
+    return print(
+        f,
+        """
+        const LOCAL_MKL_FOUND = $found_mklpardiso
+        const PARDISO_LIB_FOUND = $found_pardisolib
+        const PARDISO_PATH = raw"$pardisopath"
+        """,
+    )
 end
-

--- a/lib/MadNLPPardiso/gen/Project.toml
+++ b/lib/MadNLPPardiso/gen/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
+JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"

--- a/lib/MadNLPPardiso/gen/README.md
+++ b/lib/MadNLPPardiso/gen/README.md
@@ -1,0 +1,13 @@
+# Wrapping headers
+
+This directory contains a script that can be used to automatically generate wrappers from C headers provided by [Panua-Pardiso](https://panua.ch/pardiso/).
+This is done using Clang.jl.
+
+# Setup
+
+You need to create an `include` folder that contains the header files `pardiso.h`.
+
+# Usage
+
+Either run `julia wrapper.jl` directly, or include it and call the `main()` function.
+Be sure to activate the project environment in this folder (`julia --project`), which will install `Clang.jl` and `JuliaFormatter.jl`.

--- a/lib/MadNLPPardiso/gen/generator.toml
+++ b/lib/MadNLPPardiso/gen/generator.toml
@@ -1,0 +1,11 @@
+[general]
+use_julia_native_enum_type = true
+print_using_CEnum = false
+
+[codegen]
+use_julia_bool = true
+always_NUL_terminated_string = true
+use_ccall_macro = true
+
+[codegen.macro]
+macro_mode = "basic"

--- a/lib/MadNLPPardiso/gen/wrapper.jl
+++ b/lib/MadNLPPardiso/gen/wrapper.jl
@@ -1,0 +1,38 @@
+# Script to parse the Pardiso header and generate Julia wrappers.
+using Clang
+using Clang.Generators
+using JuliaFormatter
+
+function main()
+  @info "Wrapping Pardiso"
+
+  cd(@__DIR__)
+  include_dir = joinpath(pwd(), "include")
+  headers = joinpath(include_dir, "pardiso.h")
+
+  options = load_options(joinpath(@__DIR__, "generator.toml"))
+  options["general"]["output_file_path"] = joinpath("..", "src", "libpardiso.jl")
+  options["general"]["library_name"] = "libpardiso"
+  options["general"]["output_ignorelist"] = ["doublecomplex"]
+
+  args = get_default_args()
+  push!(args, "-I$include_dir")
+
+  ctx = create_context(headers, args, options)
+  build!(ctx)
+
+  path = options["general"]["output_file_path"]
+  format_file(path, YASStyle())
+
+  text = read(path, String)
+  # text = replace(text, "Clong" => "SS_Int")
+  # text = replace(text, "end\n\nconst" => "end\n\n\nconst")
+  # text = replace(text, "\n\nconst" => "\nconst")
+  write(path, text)
+  return nothing
+end
+
+# If we want to use the file as a script with `julia wrapper.jl`
+if abspath(PROGRAM_FILE) == @__FILE__
+  main()
+end

--- a/lib/MadNLPPardiso/src/MadNLPPardiso.jl
+++ b/lib/MadNLPPardiso/src/MadNLPPardiso.jl
@@ -32,7 +32,10 @@ import MadNLP:
     default_options
 import MKL_jll: libmkl_rt
 
-@isdefined(libpardiso) && include("pardiso.jl")
+if @isdefined(libpardiso)
+    include("libpardiso.jl")
+    include("pardiso.jl")
+end
 include("pardisomkl.jl")
 
 function __init__()

--- a/lib/MadNLPPardiso/src/MadNLPPardiso.jl
+++ b/lib/MadNLPPardiso/src/MadNLPPardiso.jl
@@ -1,17 +1,35 @@
 module MadNLPPardiso
 
-include(joinpath("..","deps","deps.jl"))
+include(joinpath("..", "deps", "deps.jl"))
 const libpardiso = PARDISO_PATH
-
 
 import Libdl: dlopen, RTLD_DEEPBIND
 import MadNLP:
-    MadNLP, @kwdef, MadNLPLogger, @debug, @warn, @error,
-    SubVector, SparseMatrixCSC,
-    SymbolicException,FactorizationException,SolveException,InertiaException,
-    AbstractOptions, AbstractLinearSolver, set_options!,
-    introduce, factorize!, solve!, improve!, is_inertia, inertia, input_type,
-    blas_num_threads, is_supported, default_options
+    MadNLP,
+    @kwdef,
+    MadNLPLogger,
+    @debug,
+    @warn,
+    @error,
+    SubVector,
+    SparseMatrixCSC,
+    SymbolicException,
+    FactorizationException,
+    SolveException,
+    InertiaException,
+    AbstractOptions,
+    AbstractLinearSolver,
+    set_options!,
+    introduce,
+    factorize!,
+    solve!,
+    improve!,
+    is_inertia,
+    inertia,
+    input_type,
+    blas_num_threads,
+    is_supported,
+    default_options
 import MKL_jll: libmkl_rt
 
 @isdefined(libpardiso) && include("pardiso.jl")
@@ -19,13 +37,13 @@ include("pardisomkl.jl")
 
 function __init__()
     # check_deps()
-    @isdefined(libpardiso) && dlopen(libpardiso,RTLD_DEEPBIND)
+    return @isdefined(libpardiso) && dlopen(libpardiso, RTLD_DEEPBIND)
 end
 
 export PardisoSolver, PardisoMKLSolver
 
 # re-export MadNLP, including deprecated names
-for name in names(MadNLP, all=true)
+for name in names(MadNLP, all = true)
     if Base.isexported(MadNLP, name)
         @eval using MadNLP: $(name)
         @eval export $(name)

--- a/lib/MadNLPPardiso/src/MadNLPPardiso.jl
+++ b/lib/MadNLPPardiso/src/MadNLPPardiso.jl
@@ -1,6 +1,7 @@
 module MadNLPPardiso
 
 include(joinpath("..","deps","deps.jl"))
+const libpardiso = PARDISO_PATH
 
 
 import Libdl: dlopen, RTLD_DEEPBIND
@@ -17,7 +18,7 @@ import MKL_jll: libmkl_rt
 include("pardisomkl.jl")
 
 function __init__()
-    check_deps()
+    # check_deps()
     @isdefined(libpardiso) && dlopen(libpardiso,RTLD_DEEPBIND)
 end
 

--- a/lib/MadNLPPardiso/src/libpardiso.jl
+++ b/lib/MadNLPPardiso/src/libpardiso.jl
@@ -1,0 +1,115 @@
+function pardisoinit(arg1, arg2, arg3, arg4, arg5, arg6)
+    @ccall libpardiso.pardisoinit(arg1::Ptr{Cvoid}, arg2::Ptr{Cint}, arg3::Ptr{Cint},
+                                  arg4::Ptr{Cint}, arg5::Ptr{Cdouble},
+                                  arg6::Ptr{Cint})::Cvoid
+end
+
+function pardiso(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12,
+                 arg13, arg14, arg15, arg16, arg17)
+    @ccall libpardiso.pardiso(arg1::Ptr{Cvoid}, arg2::Ptr{Cint}, arg3::Ptr{Cint},
+                              arg4::Ptr{Cint}, arg5::Ptr{Cint}, arg6::Ptr{Cint},
+                              arg7::Ptr{Cvoid}, arg8::Ptr{Cint}, arg9::Ptr{Cint},
+                              arg10::Ptr{Cint}, arg11::Ptr{Cint}, arg12::Ptr{Cint},
+                              arg13::Ptr{Cint}, arg14::Ptr{Cvoid}, arg15::Ptr{Cvoid},
+                              arg16::Ptr{Cint}, arg17::Ptr{Cdouble})::Cvoid
+end
+
+function pardiso_chkmatrix(arg1, arg2, arg3, arg4, arg5, arg6)
+    @ccall libpardiso.pardiso_chkmatrix(arg1::Ptr{Cint}, arg2::Ptr{Cint},
+                                        arg3::Ptr{Cdouble}, arg4::Ptr{Cint},
+                                        arg5::Ptr{Cint}, arg6::Ptr{Cint})::Cvoid
+end
+
+function pardiso_chkvec(arg1, arg2, arg3, arg4)
+    @ccall libpardiso.pardiso_chkvec(arg1::Ptr{Cint}, arg2::Ptr{Cint}, arg3::Ptr{Cdouble},
+                                     arg4::Ptr{Cint})::Cvoid
+end
+
+function pardiso_printstats(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+    @ccall libpardiso.pardiso_printstats(arg1::Ptr{Cint}, arg2::Ptr{Cint},
+                                         arg3::Ptr{Cdouble}, arg4::Ptr{Cint},
+                                         arg5::Ptr{Cint}, arg6::Ptr{Cint},
+                                         arg7::Ptr{Cdouble}, arg8::Ptr{Cint})::Cvoid
+end
+
+function pardisoinit_z(arg1, arg2, arg3, arg4, arg5, arg6)
+    @ccall libpardiso.pardisoinit_z(arg1::Ptr{Cvoid}, arg2::Ptr{Cint}, arg3::Ptr{Cint},
+                                    arg4::Ptr{Cint}, arg5::Ptr{Cdouble},
+                                    arg6::Ptr{Cint})::Cvoid
+end
+
+function pardiso_z(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,
+                   arg12, arg13, arg14, arg15, arg16, arg17)
+    @ccall libpardiso.pardiso_z(arg1::Ptr{Cvoid}, arg2::Ptr{Cint}, arg3::Ptr{Cint},
+                                arg4::Ptr{Cint}, arg5::Ptr{Cint}, arg6::Ptr{Cint},
+                                arg7::Ptr{Cvoid}, arg8::Ptr{Cint}, arg9::Ptr{Cint},
+                                arg10::Ptr{Cint}, arg11::Ptr{Cint}, arg12::Ptr{Cint},
+                                arg13::Ptr{Cint}, arg14::Ptr{Cvoid}, arg15::Ptr{Cvoid},
+                                arg16::Ptr{Cint}, arg17::Ptr{Cdouble})::Cvoid
+end
+
+function pardiso_chkmatrix_z(arg1, arg2, arg3, arg4, arg5, arg6)
+    @ccall libpardiso.pardiso_chkmatrix_z(arg1::Ptr{Cint}, arg2::Ptr{Cint},
+                                          arg3::Ptr{Cvoid}, arg4::Ptr{Cint},
+                                          arg5::Ptr{Cint}, arg6::Ptr{Cint})::Cvoid
+end
+
+function pardiso_chkvec_z(arg1, arg2, arg3, arg4)
+    @ccall libpardiso.pardiso_chkvec_z(arg1::Ptr{Cint}, arg2::Ptr{Cint}, arg3::Ptr{Cvoid},
+                                       arg4::Ptr{Cint})::Cvoid
+end
+
+function pardiso_printstats_z(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+    @ccall libpardiso.pardiso_printstats_z(arg1::Ptr{Cint}, arg2::Ptr{Cint},
+                                           arg3::Ptr{Cvoid}, arg4::Ptr{Cint},
+                                           arg5::Ptr{Cint}, arg6::Ptr{Cint},
+                                           arg7::Ptr{Cvoid}, arg8::Ptr{Cint})::Cvoid
+end
+
+function pardiso_get_schur_z(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+    @ccall libpardiso.pardiso_get_schur_z(arg1::Ptr{Cvoid}, arg2::Ptr{Cint},
+                                          arg3::Ptr{Cint}, arg4::Ptr{Cint},
+                                          arg5::Ptr{Cvoid}, arg6::Ptr{Cint},
+                                          arg7::Ptr{Cint})::Cvoid
+end
+
+function pardisoinit_d(arg1, arg2, arg3, arg4, arg5, arg6)
+    @ccall libpardiso.pardisoinit_d(arg1::Ptr{Cvoid}, arg2::Ptr{Cint}, arg3::Ptr{Cint},
+                                    arg4::Ptr{Cint}, arg5::Ptr{Cdouble},
+                                    arg6::Ptr{Cint})::Cvoid
+end
+
+function pardiso_d(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,
+                   arg12, arg13, arg14, arg15, arg16, arg17)
+    @ccall libpardiso.pardiso_d(arg1::Ptr{Cvoid}, arg2::Ptr{Cint}, arg3::Ptr{Cint},
+                                arg4::Ptr{Cint}, arg5::Ptr{Cint}, arg6::Ptr{Cint},
+                                arg7::Ptr{Cvoid}, arg8::Ptr{Cint}, arg9::Ptr{Cint},
+                                arg10::Ptr{Cint}, arg11::Ptr{Cint}, arg12::Ptr{Cint},
+                                arg13::Ptr{Cint}, arg14::Ptr{Cvoid}, arg15::Ptr{Cvoid},
+                                arg16::Ptr{Cint}, arg17::Ptr{Cdouble})::Cvoid
+end
+
+function pardiso_chkmatrix_d(arg1, arg2, arg3, arg4, arg5, arg6)
+    @ccall libpardiso.pardiso_chkmatrix_d(arg1::Ptr{Cint}, arg2::Ptr{Cint},
+                                          arg3::Ptr{Cvoid}, arg4::Ptr{Cint},
+                                          arg5::Ptr{Cint}, arg6::Ptr{Cint})::Cvoid
+end
+
+function pardiso_chkvec_d(arg1, arg2, arg3, arg4)
+    @ccall libpardiso.pardiso_chkvec_d(arg1::Ptr{Cint}, arg2::Ptr{Cint}, arg3::Ptr{Cvoid},
+                                       arg4::Ptr{Cint})::Cvoid
+end
+
+function pardiso_printstats_d(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+    @ccall libpardiso.pardiso_printstats_d(arg1::Ptr{Cint}, arg2::Ptr{Cint},
+                                           arg3::Ptr{Cvoid}, arg4::Ptr{Cint},
+                                           arg5::Ptr{Cint}, arg6::Ptr{Cint},
+                                           arg7::Ptr{Cvoid}, arg8::Ptr{Cint})::Cvoid
+end
+
+function pardiso_get_schur_d(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+    @ccall libpardiso.pardiso_get_schur_d(arg1::Ptr{Cvoid}, arg2::Ptr{Cint},
+                                          arg3::Ptr{Cint}, arg4::Ptr{Cint},
+                                          arg5::Ptr{Cvoid}, arg6::Ptr{Cint},
+                                          arg7::Ptr{Cint})::Cvoid
+end

--- a/lib/MadNLPPardiso/src/pardiso.jl
+++ b/lib/MadNLPPardiso/src/pardiso.jl
@@ -134,7 +134,7 @@ function PardisoSolver(
     elseif opt.pardiso_algorithm == MadNLP.CHOLESKY
         Ref{Int32}(2)  # real and symmetric positive definite
     else
-        error("Only the factorizations CHOLESKY, LDL or BUNCHKAUFMAN are supported in MadNLPPardiso."
+        error("Only the factorizations CHOLESKY, LDL or BUNCHKAUFMAN are supported in MadNLPPardiso." *
               "Please change the option `pardiso_algorithm` accordingly.")
     end
 

--- a/lib/MadNLPPardiso/src/pardiso.jl
+++ b/lib/MadNLPPardiso/src/pardiso.jl
@@ -31,10 +31,7 @@ function _pardisoinit(
     dparm::Vector{Cdouble},
     err::Ref{Cint},
 )
-    return ccall(
-        (:pardisoinit, libpardiso),
-        Cvoid,
-        (Ptr{Int}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
+    return pardisoinit(
         pt,
         mtype,
         solver,
@@ -63,28 +60,7 @@ function _pardiso(
     err::Ref{Cint},
     dparm::Vector{Cdouble},
 )
-    return ccall(
-        (:pardiso, libpardiso),
-        Cvoid,
-        (
-            Ptr{Int},
-            Ptr{Cint},
-            Ptr{Cint},
-            Ptr{Cint},
-            Ptr{Cint},
-            Ptr{Cint},
-            Ptr{Cdouble},
-            Ptr{Cint},
-            Ptr{Cint},
-            Ptr{Cint},
-            Ptr{Cint},
-            Ptr{Cint},
-            Ptr{Cint},
-            Ptr{Cdouble},
-            Ptr{Cdouble},
-            Ptr{Cint},
-            Ptr{Cdouble},
-        ),
+    return pardiso(
         pt,
         maxfct,
         mnum,

--- a/lib/MadNLPPardiso/src/pardiso.jl
+++ b/lib/MadNLPPardiso/src/pardiso.jl
@@ -5,7 +5,9 @@
     pardiso_max_inner_refinement_steps::Int = 1
     pardiso_msglvl::Int = 0
     pardiso_order::Int = 2
+    pardiso_maxthreads::Int = parse(Int, ENV["OMP_NUM_THREADS"])
     pardiso_log_level::String = ""
+    pardiso_algorithm::MadNLP.LinearFactorization = MadNLP.BUNCHKAUFMAN
 end
 
 mutable struct PardisoSolver{T} <: AbstractLinearSolver{T}
@@ -14,6 +16,7 @@ mutable struct PardisoSolver{T} <: AbstractLinearSolver{T}
     dparm::Vector{T}
     perm::Vector{Int32}
     msglvl::Ref{Int32}
+    mtype::Ref{Int32}
     err::Ref{Int32}
     csc::SparseMatrixCSC{T,Int32}
     w::Vector{T}
@@ -56,58 +59,70 @@ function PardisoSolver(csc::SparseMatrixCSC{T,Int32};
     perm = Vector{Int32}(undef,csc.n)
     msglvl = Ref{Int32}(0)
     err = Ref{Int32}(0)
+    mtype = if opt.pardiso_algorithm ∈ [MadNLP.BUNCHKAUFMAN, MadNLP.LDL]
+        Ref{Int32}(-2)
+    elseif opt.pardiso_algorithm == MadNLP.CHOLESKY
+        Ref{Int32}(2)
+    end
 
     pt.=0
     iparm[1]=0
 
-    _pardisoinit(pt,Ref{Int32}(-2),Ref{Int32}(0),iparm,dparm,err)
+    _pardisoinit(pt,mtype,Ref{Int32}(0),iparm,dparm,err)
     err.x < 0  && throw(SymbolicException())
 
     iparm[1]=1
     iparm[2]=opt.pardiso_order # METIS
-    iparm[3]=haskey(ENV,"OMP_NUM_THREADS") ? parse(Int32,ENV["OMP_NUM_THREADS"]) : 1
+    iparm[3]= opt.pardiso_maxthreads
     iparm[6]=1
     iparm[8]=opt.pardiso_max_inner_refinement_steps
     iparm[10]=12 # pivot perturbation
     iparm[11]=0 # disable scaling
     iparm[13]=1 # matching strategy
-    iparm[21]=3 # bunch-kaufman pivotin
+    if opt.pardiso_algorithm == MadNLP.LDL
+        iparm[21] = 0 # LDL pivoting
+    elseif opt.pardiso_algorithm == MadNLP.BUNCHKAUFMAN
+        iparm[21] = 1 # Bunch-Kaufman pivoting
+    elseif opt.pardiso_algorithm == MadNLP.CHOLESKY
+        iparm[21] = 0 # LDL pivoting
+    end
     iparm[24]=1 # parallel factorization
     iparm[25]=1 # parallel solv
     iparm[29]= T == Float64 ? 0 : 1
 
-    _pardiso(pt,Ref{Int32}(1),Ref{Int32}(1),Ref{Int32}(-2),Ref{Int32}(11),
+    _pardiso(pt,Ref{Int32}(1),Ref{Int32}(1),mtype,Ref{Int32}(11),
              Ref{Int32}(csc.n),csc.nzval,csc.colptr,csc.rowval,perm,
              Ref{Int32}(1),iparm,msglvl,T[],T[],err,dparm)
     err.x < 0  && throw(SymbolicException())
 
-    M = PardisoSolver{T}(pt,iparm,dparm,perm,msglvl,err,csc,w,opt,logger)
+    M = PardisoSolver{T}(pt,iparm,dparm,perm,msglvl,mtype,err,csc,w,opt,logger)
 
     finalizer(finalize,M)
 
     return M
 end
 function factorize!(M::PardisoSolver{T}) where T
-    _pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),Ref{Int32}(-2),Ref{Int32}(22),
+    _pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),M.mtype,Ref{Int32}(22),
              Ref{Int32}(M.csc.n),M.csc.nzval,M.csc.colptr,M.csc.rowval,M.perm,
              Ref{Int32}(1),M.iparm,M.msglvl,T[],T[],M.err,M.dparm)
-    M.err.x < 0  && throw(FactorizationException())
-    M.iparm[14] == 0 && return M
-    _pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),Ref{Int32}(-2),Ref{Int32}(12),
+    if M.iparm[14] == 0 || M.err.x < 0
+        return M
+    end
+    _pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),M.mtype,Ref{Int32}(12),
              Ref{Int32}(M.csc.n),M.csc.nzval,M.csc.colptr,M.csc.rowval,M.perm,
              Ref{Int32}(1),M.iparm,M.msglvl,T[],T[],M.err,M.dparm)
     M.err.x < 0  && throw(FactorizationException())
     return M
 end
 function solve!(M::PardisoSolver{T},rhs::Vector{T}) where T
-    _pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),Ref{Int32}(-2),Ref{Int32}(33),
+    _pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),M.mtype,Ref{Int32}(33),
              Ref{Int32}(M.csc.n),M.csc.nzval,M.csc.colptr,M.csc.rowval,M.perm,
              Ref{Int32}(1),M.iparm,M.msglvl,rhs,M.w,M.err,M.dparm)
     M.err.x < 0  && throw(SolveException())
     return rhs
 end
 function finalize(M::PardisoSolver{T}) where T
-    _pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),Ref{Int32}(-2),Ref{Int32}(-1),
+    _pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),M.mtype,Ref{Int32}(-1),
              Ref{Int32}(M.csc.n),M.csc.nzval,M.csc.colptr,M.csc.rowval,M.perm,
              Ref{Int32}(1),M.iparm,M.msglvl,T[],M.w,M.err,M.dparm)
 end
@@ -115,7 +130,15 @@ is_inertia(::PardisoSolver)=true
 function inertia(M::PardisoSolver)
     pos = M.iparm[22]
     neg = M.iparm[23]
-    return (pos,M.csc.n-pos-neg,neg)
+    if M.err.x < 0
+        return (0, 0, M.csc.n)
+    else
+        if M.opt.pardiso_algorithm == MadNLP.CHOLESKY
+            return (M.csc.n, 0, 0)
+        else
+            return (pos,M.csc.n-pos-neg,neg)
+        end
+    end
 end
 function improve!(M::PardisoSolver)
     @debug(M.logger,"improve quality failed.")

--- a/lib/MadNLPPardiso/src/pardiso.jl
+++ b/lib/MadNLPPardiso/src/pardiso.jl
@@ -1,11 +1,10 @@
-@enum(MatchingStrategy::Int,COMPLETE=1,COMPLETE2x2=2,CONSTRAINTS=3)
+@enum(MatchingStrategy::Int, COMPLETE=1, COMPLETE2x2=2, CONSTRAINTS=3)
 
 @kwdef mutable struct PardisoOptions <: AbstractOptions
     pardiso_matching_strategy::MatchingStrategy = COMPLETE2x2
     pardiso_max_inner_refinement_steps::Int = 1
     pardiso_msglvl::Int = 0
     pardiso_order::Int = 2
-    pardiso_maxthreads::Int = parse(Int, ENV["OMP_NUM_THREADS"])
     pardiso_log_level::String = ""
     pardiso_algorithm::MadNLP.LinearFactorization = MadNLP.BUNCHKAUFMAN
 end
@@ -24,61 +23,137 @@ mutable struct PardisoSolver{T} <: AbstractLinearSolver{T}
     logger::MadNLPLogger
 end
 
-_pardisoinit(
-    pt::Vector{Int},mtype::Ref{Cint},solver::Ref{Cint},iparm::Vector{Cint},
-    dparm::Vector{Cdouble},err::Ref{Cint}) =
-        ccall(
-            (:pardisoinit,libpardiso),
-            Cvoid,
-            (Ptr{Int},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cdouble},Ptr{Cint}),
-            pt,mtype,solver,iparm,dparm,err)
-_pardiso(
-    pt::Vector{Int},maxfct::Ref{Cint},mnum::Ref{Cint},mtype::Ref{Cint},
-    phase::Ref{Cint},n::Ref{Cint},a::Vector{Cdouble},ia::Vector{Cint},ja::Vector{Cint},
-    perm::Vector{Cint},nrhs::Ref{Cint},iparm::Vector{Cint},msglvl::Ref{Cint},
-    b::Vector{Cdouble},x::Vector{Cdouble},err::Ref{Cint},dparm::Vector{Cdouble}) =
-        ccall(
-            (:pardiso,libpardiso),
-            Cvoid,
-            (Ptr{Int},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cdouble},Ptr{Cint},Ptr{Cint},Ptr{Cint},
-             Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint},Ptr{Cdouble}),
-            pt,maxfct,mnum,mtype,phase,n,a,ia,ja,perm,nrhs,iparm,msglvl,b,x,err,dparm)
+function _pardisoinit(
+    pt::Vector{Int},
+    mtype::Ref{Cint},
+    solver::Ref{Cint},
+    iparm::Vector{Cint},
+    dparm::Vector{Cdouble},
+    err::Ref{Cint},
+)
+    return ccall(
+        (:pardisoinit, libpardiso),
+        Cvoid,
+        (Ptr{Int}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
+        pt,
+        mtype,
+        solver,
+        iparm,
+        dparm,
+        err,
+    )
+end
 
-function PardisoSolver(csc::SparseMatrixCSC{T,Int32};
-                opt=PardisoOptions(),logger=MadNLPLogger(),
-                option_dict::Dict{Symbol,Any}=Dict{Symbol,Any}(),
-                kwargs...) where T
-    !isempty(kwargs) && (for (key,val) in kwargs; option_dict[key]=val; end)
-    set_options!(opt,option_dict)
+function _pardiso(
+    pt::Vector{Int},
+    maxfct::Ref{Cint},
+    mnum::Ref{Cint},
+    mtype::Ref{Cint},
+    phase::Ref{Cint},
+    n::Ref{Cint},
+    a::Vector{Cdouble},
+    ia::Vector{Cint},
+    ja::Vector{Cint},
+    perm::Vector{Cint},
+    nrhs::Ref{Cint},
+    iparm::Vector{Cint},
+    msglvl::Ref{Cint},
+    b::Vector{Cdouble},
+    x::Vector{Cdouble},
+    err::Ref{Cint},
+    dparm::Vector{Cdouble},
+)
+    return ccall(
+        (:pardiso, libpardiso),
+        Cvoid,
+        (
+            Ptr{Int},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Cdouble},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Cdouble},
+            Ptr{Cdouble},
+            Ptr{Cint},
+            Ptr{Cdouble},
+        ),
+        pt,
+        maxfct,
+        mnum,
+        mtype,
+        phase,
+        n,
+        a,
+        ia,
+        ja,
+        perm,
+        nrhs,
+        iparm,
+        msglvl,
+        b,
+        x,
+        err,
+        dparm,
+    )
+end
 
-    w   = Vector{T}(undef,csc.n)
+function PardisoSolver(
+    csc::SparseMatrixCSC{T,Int32};
+    opt = PardisoOptions(),
+    logger = MadNLPLogger(),
+    option_dict::Dict{Symbol,Any} = Dict{Symbol,Any}(),
+    kwargs...,
+) where {T}
+    !isempty(kwargs) && (
+        for (key, val) in kwargs
+            ;
+            option_dict[key]=val;
+        end
+    )
+    set_options!(opt, option_dict)
 
-    pt = Vector{Int}(undef,64)
-    iparm = Vector{Int32}(undef,64)
-    dparm = Vector{T}(undef,64)
-    perm = Vector{Int32}(undef,csc.n)
+    w = Vector{T}(undef, csc.n)
+
+    pt = Vector{Int}(undef, 64)
+    iparm = Vector{Int32}(undef, 64)
+    dparm = Vector{T}(undef, 64)
+    perm = Vector{Int32}(undef, csc.n)
     msglvl = Ref{Int32}(0)
     err = Ref{Int32}(0)
+
     mtype = if opt.pardiso_algorithm ∈ [MadNLP.BUNCHKAUFMAN, MadNLP.LDL]
-        Ref{Int32}(-2)
+        Ref{Int32}(-2) # real and symmetric indefinite
     elseif opt.pardiso_algorithm == MadNLP.CHOLESKY
-        Ref{Int32}(2)
+        Ref{Int32}(2)  # real and symmetric positive definite
+    else
+        error("Only the factorizations CHOLESKY, LDL or BUNCHKAUFMAN are supported in MadNLPPardiso."
+              "Please change the option `pardiso_algorithm` accordingly.")
     end
 
     pt.=0
-    iparm[1]=0
+    iparm[1] = 0
 
-    _pardisoinit(pt,mtype,Ref{Int32}(0),iparm,dparm,err)
-    err.x < 0  && throw(SymbolicException())
+    _pardisoinit(pt, mtype, Ref{Int32}(0), iparm, dparm, err)
+    if err.x < 0
+        throw(SymbolicException())
+    end
 
-    iparm[1]=1
-    iparm[2]=opt.pardiso_order # METIS
-    iparm[3]= opt.pardiso_maxthreads
-    iparm[6]=1
-    iparm[8]=opt.pardiso_max_inner_refinement_steps
-    iparm[10]=12 # pivot perturbation
-    iparm[11]=0 # disable scaling
-    iparm[13]=1 # matching strategy
+    iparm[1] = 1
+    iparm[2] = opt.pardiso_order # METIS
+    iparm[3] = haskey(ENV,"OMP_NUM_THREADS") ? parse(Int32,ENV["OMP_NUM_THREADS"]) : 1
+    iparm[6] = 1
+    iparm[8] = opt.pardiso_max_inner_refinement_steps
+    iparm[10] = 12 # pivot perturbation
+    iparm[11] = 0 # disable scaling
+    iparm[13] = 1 # matching strategy
     if opt.pardiso_algorithm == MadNLP.LDL
         iparm[21] = 0 # LDL pivoting
     elseif opt.pardiso_algorithm == MadNLP.BUNCHKAUFMAN
@@ -86,67 +161,161 @@ function PardisoSolver(csc::SparseMatrixCSC{T,Int32};
     elseif opt.pardiso_algorithm == MadNLP.CHOLESKY
         iparm[21] = 0 # LDL pivoting
     end
-    iparm[24]=1 # parallel factorization
-    iparm[25]=1 # parallel solv
-    iparm[29]= T == Float64 ? 0 : 1
+    iparm[24] = 1 # parallel factorization
+    iparm[25] = 1 # parallel solv
+    iparm[29] = T == Float64 ? 0 : 1
 
-    _pardiso(pt,Ref{Int32}(1),Ref{Int32}(1),mtype,Ref{Int32}(11),
-             Ref{Int32}(csc.n),csc.nzval,csc.colptr,csc.rowval,perm,
-             Ref{Int32}(1),iparm,msglvl,T[],T[],err,dparm)
-    err.x < 0  && throw(SymbolicException())
+    _pardiso(
+        pt,
+        Ref{Int32}(1),
+        Ref{Int32}(1),
+        mtype,
+        Ref{Int32}(11),
+        Ref{Int32}(csc.n),
+        csc.nzval,
+        csc.colptr,
+        csc.rowval,
+        perm,
+        Ref{Int32}(1),
+        iparm,
+        msglvl,
+        T[],
+        T[],
+        err,
+        dparm,
+    )
+    err.x < 0 && throw(SymbolicException())
 
-    M = PardisoSolver{T}(pt,iparm,dparm,perm,msglvl,mtype,err,csc,w,opt,logger)
+    M = PardisoSolver{T}(pt, iparm, dparm, perm, msglvl, mtype, err, csc, w, opt, logger)
 
-    finalizer(finalize,M)
+    finalizer(finalize, M)
 
     return M
 end
-function factorize!(M::PardisoSolver{T}) where T
-    _pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),M.mtype,Ref{Int32}(22),
-             Ref{Int32}(M.csc.n),M.csc.nzval,M.csc.colptr,M.csc.rowval,M.perm,
-             Ref{Int32}(1),M.iparm,M.msglvl,T[],T[],M.err,M.dparm)
-    if M.iparm[14] == 0 || M.err.x < 0
+
+function factorize!(M::PardisoSolver{T}) where {T}
+    _pardiso(
+        M.pt,
+        Ref{Int32}(1),
+        Ref{Int32}(1),
+        M.mtype,
+        Ref{Int32}(22),
+        Ref{Int32}(M.csc.n),
+        M.csc.nzval,
+        M.csc.colptr,
+        M.csc.rowval,
+        M.perm,
+        Ref{Int32}(1),
+        M.iparm,
+        M.msglvl,
+        T[],
+        T[],
+        M.err,
+        M.dparm,
+    )
+    # Get number of perturbed pivots
+    perturbed_pivots = M.iparm[14]
+    # If number of perturbed pivots is 0, stop the factorization.
+    # Otherwise, recompute the symbolic factorization.
+    if perturbed_pivots == 0
         return M
     end
-    _pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),M.mtype,Ref{Int32}(12),
-             Ref{Int32}(M.csc.n),M.csc.nzval,M.csc.colptr,M.csc.rowval,M.perm,
-             Ref{Int32}(1),M.iparm,M.msglvl,T[],T[],M.err,M.dparm)
-    M.err.x < 0  && throw(FactorizationException())
+
+    _pardiso(
+        M.pt,
+        Ref{Int32}(1),
+        Ref{Int32}(1),
+        M.mtype,
+        Ref{Int32}(12),
+        Ref{Int32}(M.csc.n),
+        M.csc.nzval,
+        M.csc.colptr,
+        M.csc.rowval,
+        M.perm,
+        Ref{Int32}(1),
+        M.iparm,
+        M.msglvl,
+        T[],
+        T[],
+        M.err,
+        M.dparm,
+    )
+    M.err.x < 0 && throw(FactorizationException())
     return M
 end
-function solve!(M::PardisoSolver{T},rhs::Vector{T}) where T
-    _pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),M.mtype,Ref{Int32}(33),
-             Ref{Int32}(M.csc.n),M.csc.nzval,M.csc.colptr,M.csc.rowval,M.perm,
-             Ref{Int32}(1),M.iparm,M.msglvl,rhs,M.w,M.err,M.dparm)
-    M.err.x < 0  && throw(SolveException())
+
+function solve!(M::PardisoSolver{T}, rhs::Vector{T}) where {T}
+    _pardiso(
+        M.pt,
+        Ref{Int32}(1),
+        Ref{Int32}(1),
+        M.mtype,
+        Ref{Int32}(33),
+        Ref{Int32}(M.csc.n),
+        M.csc.nzval,
+        M.csc.colptr,
+        M.csc.rowval,
+        M.perm,
+        Ref{Int32}(1),
+        M.iparm,
+        M.msglvl,
+        rhs,
+        M.w,
+        M.err,
+        M.dparm,
+    )
+    M.err.x < 0 && throw(SolveException())
     return rhs
 end
-function finalize(M::PardisoSolver{T}) where T
-    _pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),M.mtype,Ref{Int32}(-1),
-             Ref{Int32}(M.csc.n),M.csc.nzval,M.csc.colptr,M.csc.rowval,M.perm,
-             Ref{Int32}(1),M.iparm,M.msglvl,T[],M.w,M.err,M.dparm)
+
+function finalize(M::PardisoSolver{T}) where {T}
+    return _pardiso(
+        M.pt,
+        Ref{Int32}(1),
+        Ref{Int32}(1),
+        M.mtype,
+        Ref{Int32}(-1),
+        Ref{Int32}(M.csc.n),
+        M.csc.nzval,
+        M.csc.colptr,
+        M.csc.rowval,
+        M.perm,
+        Ref{Int32}(1),
+        M.iparm,
+        M.msglvl,
+        T[],
+        M.w,
+        M.err,
+        M.dparm,
+    )
 end
+
 is_inertia(::PardisoSolver)=true
+
 function inertia(M::PardisoSolver)
-    pos = M.iparm[22]
-    neg = M.iparm[23]
+    n = M.csc.n
+
+    # If the factorization has failed, return an invalid inertia.
     if M.err.x < 0
-        return (0, 0, M.csc.n)
+        return (0, 0, n)
     else
         if M.opt.pardiso_algorithm == MadNLP.CHOLESKY
-            return (M.csc.n, 0, 0)
+            return (n, 0, 0)
         else
-            return (pos,M.csc.n-pos-neg,neg)
+            pos = M.iparm[22]
+            neg = M.iparm[23]
+            return (pos, n-pos-neg, neg)
         end
     end
 end
+
 function improve!(M::PardisoSolver)
-    @debug(M.logger,"improve quality failed.")
+    @debug(M.logger, "improve quality failed.")
     return false
 end
 
 introduce(::PardisoSolver)="pardiso"
 input_type(::Type{PardisoSolver}) = :csc
 default_options(::Type{PardisoSolver}) = PardisoOptions()
-is_supported(::Type{PardisoSolver},::Type{Float32}) = true
-is_supported(::Type{PardisoSolver},::Type{Float64}) = true
+is_supported(::Type{PardisoSolver}, ::Type{Float32}) = true
+is_supported(::Type{PardisoSolver}, ::Type{Float64}) = true

--- a/lib/MadNLPPardiso/src/pardisomkl.jl
+++ b/lib/MadNLPPardiso/src/pardisomkl.jl
@@ -19,53 +19,97 @@ mutable struct PardisoMKLSolver{T} <: AbstractLinearSolver{T}
     logger::MadNLPLogger
 end
 
-pardisomkl_pardisoinit(pt,mtype::Ref{Cint},iparm::Vector{Cint}) =
-    ccall(
-        (:pardisoinit,libmkl_rt),
+function pardisomkl_pardisoinit(pt, mtype::Ref{Cint}, iparm::Vector{Cint})
+    return ccall(
+        (:pardisoinit, libmkl_rt),
         Cvoid,
-        (Ptr{Cvoid},Ptr{Cint},Ptr{Cint}),
-        pt,mtype,iparm)
-pardisomkl_pardiso(pt,maxfct::Ref{Cint},mnum::Ref{Cint},mtype::Ref{Cint},
-                   phase::Ref{Cint},n::Ref{Cint},a::Vector{T},ia::Vector{Cint},ja::Vector{Cint},
-                   perm::Vector{Cint},nrhs::Ref{Cint},iparm::Vector{Cint},msglvl::Ref{Cint},
-                   b::Vector{T},x::Vector{T},err::Ref{Cint}) where T =
-                       ccall(
-                           (:pardiso,libmkl_rt),
-                           Cvoid,
-                           (Ptr{Cvoid}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
-                            Ptr{Cint}, Ptr{T}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
-                            Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{T}, Ptr{T},Ptr{Cint}),
-                           pt,maxfct,mnum,mtype,phase,n,a,ia,ja,perm,nrhs,iparm,msglvl,b,x,err)
-
-function pardisomkl_set_num_threads!(n)
-    ccall((:mkl_set_dynamic, libmkl_rt),
-         Cvoid,
-         (Ptr{Cint},),
-          Ref{Cint}(0))
-    ccall((:mkl_set_num_threads, libmkl_rt),
-          Cvoid,
-          (Ptr{Cint},),
-          Ref{Cint}(n))
+        (Ptr{Cvoid}, Ptr{Cint}, Ptr{Cint}),
+        pt,
+        mtype,
+        iparm,
+    )
+end
+function pardisomkl_pardiso(
+    pt,
+    maxfct::Ref{Cint},
+    mnum::Ref{Cint},
+    mtype::Ref{Cint},
+    phase::Ref{Cint},
+    n::Ref{Cint},
+    a::Vector{T},
+    ia::Vector{Cint},
+    ja::Vector{Cint},
+    perm::Vector{Cint},
+    nrhs::Ref{Cint},
+    iparm::Vector{Cint},
+    msglvl::Ref{Cint},
+    b::Vector{T},
+    x::Vector{T},
+    err::Ref{Cint},
+) where {T}
+    return ccall(
+        (:pardiso, libmkl_rt),
+        Cvoid,
+        (
+            Ptr{Cvoid},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{T},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{T},
+            Ptr{T},
+            Ptr{Cint},
+        ),
+        pt,
+        maxfct,
+        mnum,
+        mtype,
+        phase,
+        n,
+        a,
+        ia,
+        ja,
+        perm,
+        nrhs,
+        iparm,
+        msglvl,
+        b,
+        x,
+        err,
+    )
 end
 
+function pardisomkl_set_num_threads!(n)
+    ccall((:mkl_set_dynamic, libmkl_rt), Cvoid, (Ptr{Cint},), Ref{Cint}(0))
+    return ccall((:mkl_set_num_threads, libmkl_rt), Cvoid, (Ptr{Cint},), Ref{Cint}(n))
+end
 
-function PardisoMKLSolver(csc::SparseMatrixCSC{T};
-    opt=PardisoMKLOptions(),logger=MadNLPLogger(),
-) where T
+function PardisoMKLSolver(
+    csc::SparseMatrixCSC{T};
+    opt = PardisoMKLOptions(),
+    logger = MadNLPLogger(),
+) where {T}
+    w = Vector{T}(undef, csc.n)
 
-    w   = Vector{T}(undef,csc.n)
+    pt = Vector{Ptr{Cvoid}}(undef, 64)
+    iparm = Vector{Int32}(undef, 64)
 
-    pt = Vector{Ptr{Cvoid}}(undef,64)
-    iparm = Vector{Int32}(undef,64)
-
-    perm = Vector{Int32}(undef,csc.n)
+    perm = Vector{Int32}(undef, csc.n)
     msglvl = Ref{Int32}(0)
     err = Ref{Int32}(0)
 
     pt.=0
     iparm[1]=0
 
-    pardisomkl_pardisoinit(pt,Ref{Int32}(-2),iparm)
+    pardisomkl_pardisoinit(pt, Ref{Int32}(-2), iparm)
 
     iparm[1]=1
     iparm[2]=opt.pardisomkl_order # METIS
@@ -78,68 +122,143 @@ function PardisoMKLSolver(csc::SparseMatrixCSC{T};
     iparm[21]=3 # bunch-kaufman pivotin
     iparm[24]=1 # parallel factorization
     iparm[25]=0 # parallel solv
-    iparm[28]= T == Float64 ? 0 : 1
+    iparm[28] = T == Float64 ? 0 : 1
 
     pardisomkl_set_num_threads!(opt.pardisomkl_num_threads)
-    pardisomkl_pardiso(pt,Ref{Int32}(1),Ref{Int32}(1),Ref{Int32}(-2),Ref{Int32}(11),
-                     Ref{Int32}(csc.n),csc.nzval,csc.colptr,csc.rowval,perm,
-                       Ref{Int32}(1),iparm,msglvl,T[],T[],err)
+    pardisomkl_pardiso(
+        pt,
+        Ref{Int32}(1),
+        Ref{Int32}(1),
+        Ref{Int32}(-2),
+        Ref{Int32}(11),
+        Ref{Int32}(csc.n),
+        csc.nzval,
+        csc.colptr,
+        csc.rowval,
+        perm,
+        Ref{Int32}(1),
+        iparm,
+        msglvl,
+        T[],
+        T[],
+        err,
+    )
     pardisomkl_set_num_threads!(blas_num_threads[])
 
-    err.x < 0  && throw(SymbolicException())
+    err.x < 0 && throw(SymbolicException())
 
-    M = PardisoMKLSolver{T}(pt,iparm,perm,msglvl,err,csc,w,opt,logger)
+    M = PardisoMKLSolver{T}(pt, iparm, perm, msglvl, err, csc, w, opt, logger)
 
-    finalizer(finalize,M)
+    finalizer(finalize, M)
 
     return M
 end
-function factorize!(M::PardisoMKLSolver{T}) where T
+function factorize!(M::PardisoMKLSolver{T}) where {T}
     pardisomkl_set_num_threads!(M.opt.pardisomkl_num_threads)
-    pardisomkl_pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),Ref{Int32}(-2),Ref{Int32}(22),
-                     Ref{Int32}(M.csc.n),M.csc.nzval,M.csc.colptr,M.csc.rowval,M.perm,
-                       Ref{Int32}(1),M.iparm,M.msglvl,T[],T[],M.err)
-    M.err.x < 0  && throw(FactorizationException())
+    pardisomkl_pardiso(
+        M.pt,
+        Ref{Int32}(1),
+        Ref{Int32}(1),
+        Ref{Int32}(-2),
+        Ref{Int32}(22),
+        Ref{Int32}(M.csc.n),
+        M.csc.nzval,
+        M.csc.colptr,
+        M.csc.rowval,
+        M.perm,
+        Ref{Int32}(1),
+        M.iparm,
+        M.msglvl,
+        T[],
+        T[],
+        M.err,
+    )
+    M.err.x < 0 && throw(FactorizationException())
     pardisomkl_set_num_threads!(blas_num_threads[])
 
     M.iparm[14] == 0 && return M
     pardisomkl_set_num_threads!(M.opt.pardisomkl_num_threads)
-    pardisomkl_pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),Ref{Int32}(-2),Ref{Int32}(12),
-                     Ref{Int32}(M.csc.n),M.csc.nzval,M.csc.colptr,M.csc.rowval,M.perm,
-                       Ref{Int32}(1),M.iparm,M.msglvl,T[],T[],M.err)
+    pardisomkl_pardiso(
+        M.pt,
+        Ref{Int32}(1),
+        Ref{Int32}(1),
+        Ref{Int32}(-2),
+        Ref{Int32}(12),
+        Ref{Int32}(M.csc.n),
+        M.csc.nzval,
+        M.csc.colptr,
+        M.csc.rowval,
+        M.perm,
+        Ref{Int32}(1),
+        M.iparm,
+        M.msglvl,
+        T[],
+        T[],
+        M.err,
+    )
     pardisomkl_set_num_threads!(blas_num_threads[])
-    M.err.x < 0  && throw(FactorizationException())
+    M.err.x < 0 && throw(FactorizationException())
     return M
 end
-function solve!(M::PardisoMKLSolver{T},rhs::Vector{T}) where T
+function solve!(M::PardisoMKLSolver{T}, rhs::Vector{T}) where {T}
     pardisomkl_set_num_threads!(M.opt.pardisomkl_num_threads)
-    pardisomkl_pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),Ref{Int32}(-2),Ref{Int32}(33),
-                     Ref{Int32}(M.csc.n),M.csc.nzval,M.csc.colptr,M.csc.rowval,M.perm,
-                       Ref{Int32}(1),M.iparm,M.msglvl,rhs,M.w,M.err)
+    pardisomkl_pardiso(
+        M.pt,
+        Ref{Int32}(1),
+        Ref{Int32}(1),
+        Ref{Int32}(-2),
+        Ref{Int32}(33),
+        Ref{Int32}(M.csc.n),
+        M.csc.nzval,
+        M.csc.colptr,
+        M.csc.rowval,
+        M.perm,
+        Ref{Int32}(1),
+        M.iparm,
+        M.msglvl,
+        rhs,
+        M.w,
+        M.err,
+    )
     pardisomkl_set_num_threads!(blas_num_threads[])
-    M.err.x < 0  && throw(SolveException())
+    M.err.x < 0 && throw(SolveException())
     return rhs
 end
 
-function finalize(M::PardisoMKLSolver{T}) where T
-    pardisomkl_pardiso(M.pt,Ref{Int32}(1),Ref{Int32}(1),Ref{Int32}(-2),Ref{Int32}(-1),
-                     Ref{Int32}(M.csc.n),M.csc.nzval,M.csc.colptr,M.csc.rowval,M.perm,
-                     Ref{Int32}(1),M.iparm,M.msglvl,T[],M.w,M.err)
+function finalize(M::PardisoMKLSolver{T}) where {T}
+    return pardisomkl_pardiso(
+        M.pt,
+        Ref{Int32}(1),
+        Ref{Int32}(1),
+        Ref{Int32}(-2),
+        Ref{Int32}(-1),
+        Ref{Int32}(M.csc.n),
+        M.csc.nzval,
+        M.csc.colptr,
+        M.csc.rowval,
+        M.perm,
+        Ref{Int32}(1),
+        M.iparm,
+        M.msglvl,
+        T[],
+        M.w,
+        M.err,
+    )
 end
 is_inertia(::PardisoMKLSolver)=true
 function inertia(M::PardisoMKLSolver)
     pos = M.iparm[22]
     neg = M.iparm[23]
-    return (pos,M.csc.n-pos-neg,neg)
+    return (pos, M.csc.n-pos-neg, neg)
 end
 
 function improve!(M::PardisoMKLSolver)
-    @debug(M.logger,"improve quality failed.")
+    @debug(M.logger, "improve quality failed.")
     return false
 end
 introduce(::PardisoMKLSolver)="pardiso-mkl"
 
 input_type(::Type{PardisoMKLSolver}) = :csc
 default_options(::Type{PardisoMKLSolver}) = PardisoMKLOptions()
-is_supported(::Type{PardisoMKLSolver},::Type{Float32}) = true
-is_supported(::Type{PardisoMKLSolver},::Type{Float64}) = true
+is_supported(::Type{PardisoMKLSolver}, ::Type{Float32}) = true
+is_supported(::Type{PardisoMKLSolver}, ::Type{Float64}) = true

--- a/lib/MadNLPPardiso/src/pardisomkl.jl
+++ b/lib/MadNLPPardiso/src/pardisomkl.jl
@@ -1,4 +1,3 @@
-@enum(MatchingStrategy::Int,COMPLETE=1,COMPLETE2x2=2,CONSTRAINTS=3)
 
 @kwdef mutable struct PardisoMKLOptions <: AbstractOptions
     pardisomkl_num_threads::Int = 1
@@ -20,7 +19,7 @@ mutable struct PardisoMKLSolver{T} <: AbstractLinearSolver{T}
     logger::MadNLPLogger
 end
 
-pardisomkl_pardisoinit(pt,mtype::Ref{Cint},iparm::Vector{Cint}) where T =
+pardisomkl_pardisoinit(pt,mtype::Ref{Cint},iparm::Vector{Cint}) =
     ccall(
         (:pardisoinit,libmkl_rt),
         Cvoid,

--- a/lib/MadNLPPardiso/test/runtests.jl
+++ b/lib/MadNLPPardiso/test/runtests.jl
@@ -1,34 +1,28 @@
 using Test, MadNLP, MadNLPPardiso, MadNLPTests
 
 testset = [
-    # TODO; Pardiso license has expired
-    # [
-    #     "Pardiso",
-    #     ()->MadNLP.Optimizer(
-    #         linear_solver=MadNLPPardiso,
-    #         print_level=MadNLP.ERROR),
-    #     [],
-    #     @isdefined(MadNLPPardiso)
-    # ],
+# TODO; Pardiso license has expired
+# [
+#     "Pardiso",
+#     ()->MadNLP.Optimizer(
+#         linear_solver=MadNLPPardiso,
+#         print_level=MadNLP.ERROR),
+#     [],
+#     @isdefined(MadNLPPardiso)
+# ],
     [
-        "PardisoMKL",
-        ()->MadNLP.Optimizer(
-            linear_solver=PardisoMKLSolver,
-            print_level=MadNLP.ERROR),
-        ["eigmina"]
-    ]
-]
+    "PardisoMKL",
+    ()->MadNLP.Optimizer(linear_solver = PardisoMKLSolver, print_level = MadNLP.ERROR),
+    ["eigmina"],
+]]
 
 @testset "MadNLPPardiso test" begin
-
-    MadNLPTests.test_linear_solver(PardisoMKLSolver,Float32)
-    MadNLPTests.test_linear_solver(PardisoMKLSolver,Float64)
+    MadNLPTests.test_linear_solver(PardisoMKLSolver, Float32)
+    MadNLPTests.test_linear_solver(PardisoMKLSolver, Float64)
     # TODO; Pardiso license has expired
     # MadNLPTests.test_linear_solver(PardisoSolver)
-    
-    for (name,optimizer_constructor,exclude) in testset
-        test_madnlp(name,optimizer_constructor,exclude)
+
+    for (name, optimizer_constructor, exclude) in testset
+        test_madnlp(name, optimizer_constructor, exclude)
     end
 end
-
-


### PR DESCRIPTION
- adapt the build procedure from [Pardiso.jl](https://github.com/JuliaSparse/Pardiso.jl/). 
- drop dependency from BinaryProvider, which is now deprecated. 
- add support for the Cholesky factorization and the LDL factorization in Pardiso. 
- format the files with JuliaFormatter 