### PR TITLE
Don't call jac_structure! if nnzj == 0

### DIFF
--- a/src/nlpmodels.jl
+++ b/src/nlpmodels.jl
@@ -356,7 +356,9 @@ function create_callback(
     con_scale = similar(jac_buffer, m)    ; fill!(con_scale, one(T))
     jac_scale = similar(jac_buffer, nnzj) ; fill!(jac_scale, one(T))
 
-    NLPModels.jac_structure!(nlp, jac_I, jac_J)
+    if nnzj > 0
+        NLPModels.jac_structure!(nlp, jac_I, jac_J)
+    end
     if nnzh > 0
         NLPModels.hess_structure!(nlp, hess_I, hess_J)
     end


### PR DESCRIPTION
close #422 

Tested in https://github.com/exanauts/CompressedSensingIPM.jl/pull/19 if we don't define, `hess_structure!`, `hess_coord!`, `jac_structure!` and `jac_coord!`.