### PR TITLE
[MadNLPGPU] Support more ordering

### DIFF
--- a/lib/MadNLPGPU/src/LinearSolvers/cudss.jl
+++ b/lib/MadNLPGPU/src/LinearSolvers/cudss.jl
@@ -108,6 +108,12 @@ function CUDSSSolver(
         elseif opt.cudss_ordering == AMD_ORDERING
             A = SparseMatrixCSC(csc)
             opt.cudss_perm = AMD.amd(A)
+        elseif opt.cudss_ordering == SYMAMD_ORDERING
+            A = SparseMatrixCSC(csc)
+            opt.cudss_perm = AMD.symamd(A)
+        elseif opt.cudss_ordering == COLAMD_ORDERING
+            A = SparseMatrixCSC(csc)
+            opt.cudss_perm = AMD.colamd(A)
         elseif opt.cudss_ordering == USER_ORDERING
             (!isempty(opt.cudss_perm) && isperm(opt.cudss_perm)) || error("The vector opt.cudss_perm is not a valid permutation.")
         else
@@ -116,9 +122,9 @@ function CUDSSSolver(
         CUDSS.cudss_set(solver, "user_perm", opt.cudss_perm)
     end
 
+    # The phase "analysis" is "reordering" combined with "symbolic_factorization"
     x_gpu = CUDA.zeros(T, n)
     b_gpu = CUDA.zeros(T, n)
-
     CUDSS.cudss("analysis", solver, x_gpu, b_gpu)
 
     return CUDSSSolver(

--- a/lib/MadNLPGPU/src/utils.jl
+++ b/lib/MadNLPGPU/src/utils.jl
@@ -3,6 +3,8 @@
     METIS_ORDERING = 1
     AMD_ORDERING = 2
     USER_ORDERING = 3
+    SYMAMD_ORDERING = 4
+    COLAMD_ORDERING = 5
 end
 
 function MadNLP._madnlp_unsafe_wrap(vec::VT, n, shift=1) where {T, VT <: CuVector{T}}

--- a/lib/MadNLPGPU/test/madnlpgpu_test.jl
+++ b/lib/MadNLPGPU/test/madnlpgpu_test.jl
@@ -18,6 +18,24 @@ testset = [
         [],
     ],
     [
+        "CUDSS-SYMAMD",
+        ()->MadNLP.Optimizer(
+            linear_solver=MadNLPGPU.CUDSSSolver,
+            print_level=MadNLP.ERROR,
+            ordering=MadNLPGPU.SYMAMD_ORDERING,
+        ),
+        [],
+    ],
+    [
+        "CUDSS-COLAMD",
+        ()->MadNLP.Optimizer(
+            linear_solver=MadNLPGPU.CUDSSSolver,
+            print_level=MadNLP.ERROR,
+            ordering=MadNLPGPU.COLAMD_ORDERING,
+        ),
+        [],
+    ],
+    [
         "CUDSS-METIS",
         ()->MadNLP.Optimizer(
             linear_solver=MadNLPGPU.CUDSSSolver,


### PR DESCRIPTION
I also interfaced `symamd` and `colamd`, which are useful for reducing fill-in in Cholesky factorization of `A'A` and QR factorization of `A`, respectively.

Both compute a permutation based on the column intersection graph, without explicitly forming `A'A`.
