### PR TITLE
Implement centering step as done in ipopt

### DIFF
--- a/src/IPM/barrier.jl
+++ b/src/IPM/barrier.jl
@@ -164,8 +164,8 @@ function set_cen_aug_rhs!(solver::AbstractMadNLPSolver, kkt::AbstractKKTSystem, 
 
     px .= 0
     py .= 0
-    pzl .= (solver.xl_r .- solver.x_lr) .* solver.zl_r .+ mu
-    pzu .= (solver.xu_r .- solver.x_ur) .* solver.zu_r .- mu
+    pzl .= mu
+    pzu .= -mu
     return
 end
 


### PR DESCRIPTION
The centering step is now (i believe) calculated the same way as in [these lines in ipopt.](https://github.com/coin-or/Ipopt/blob/cc58a7072fef5c4d660ea45ed931b75b697fc49b/src/Algorithm/IpQualityFunctionMuOracle.cpp#L228-L237) 
