### PR TITLE
Fix MOI.is_valid for ConstraintIndex{VariableIndex,Parameter}

### DIFF
--- a/ext/MadNLPMOI/MadNLPMOI.jl
+++ b/ext/MadNLPMOI/MadNLPMOI.jl
@@ -315,6 +315,11 @@ function MOI.is_valid(model::Optimizer, x::MOI.VariableIndex)
     return MOI.is_valid(model.variables, x)
 end
 
+function MOI.is_valid(model::Optimizer, ci::MOI.ConstraintIndex{MOI.VariableIndex, MOI.Parameter{Float64}})
+    p = MOI.VariableIndex(ci.value)
+    return haskey(model.parameters, p)
+end
+
 function MOI.get(model::Optimizer, ::MOI.ListOfVariableIndices)
     return model.list_of_variable_indices
 end
@@ -856,6 +861,7 @@ function MOIModel(model::Optimizer)
             clamp(0.0, model.variables.lower[i], model.variables.upper[i])
         end
     end
+
     # Constraints bounds
     g_L, g_U = copy(model.qp_data.g_L), copy(model.qp_data.g_U)
     for bound in model.nlp_data.constraint_bounds

--- a/test/MOI_interface_test.jl
+++ b/test/MOI_interface_test.jl
@@ -190,6 +190,16 @@ function test_param_in_quadratic_term2()
     @assert abs(3 * x_val + 9 * y_val - 15) <= 1e-6 # constraint has no slack
 end
 
+function test_parameter_is_valid()
+    model = MadNLP.Optimizer()
+    p, ci = MOI.add_constrained_variable(model, MOI.Parameter(2.0))
+    @test MOI.is_valid(model, p)
+    @test MOI.is_valid(model, ci)
+    @test !MOI.is_valid(model, typeof(p)(p.value + 1))
+    @test !MOI.is_valid(model, typeof(ci)(ci.value + 1))
+    return
+end
+
 end
 
 TestMOIWrapper.runtests()


### PR DESCRIPTION
When I want to set the value of a parameter using a direct model, I have a bug saying that the parameter is not a parameter.

```
 caused by: Variable _[67553994410557440] is not a parameter.
  Stacktrace:
    [1] error(s::String)
      @ Base ./error.jl:35
    [2] ParameterRef
      @ JuMP ~/.julia/packages/JuMP/LKjRR/src/variables.jl:1648 [inlined]
    [3] set_parameter_value(x::JuMP.VariableRef, value::Float64)
      @ JuMP ~/.julia/packages/JuMP/LKjRR/src/variables.jl:1720
```

The bug is MOI.is_valid not implemented for `ConstraintIndex{VariableIndex,Parameter}`

This PR is a copy-paste of https://github.com/jump-dev/Ipopt.jl/pull/415

