### PR TITLE
Don't support CUDA 5.8.3

### DIFF
--- a/lib/MadNLPGPU/Project.toml
+++ b/lib/MadNLPGPU/Project.toml
@@ -14,7 +14,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 AMD = "0.5"
-CUDA = "5.4.0"
+CUDA = "5.4.0 - 5.8.2"
 CUDSS = "0.5.0"
 KernelAbstractions = "0.9"
 MadNLP = "0.8.8"


### PR DESCRIPTION
CUDA 5.8.3 supports the toolkit v13.0 and they removed all the legacy API of CUSOLVER.
See https://github.com/JuliaGPU/CUDA.jl/pull/2842