### PR TITLE
Print improvement

### DIFF
--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -198,7 +198,7 @@ function solve!(
         if !(solver.status < SOLVE_SUCCEEDED)
             print_summary(solver)
         end
-        @notice(solver.logger,"EXIT: $(get_status_output(solver.status, solver.opt))")
+        @notice(solver.logger,"$(Base.text_colors[color_status(solver.status)])EXIT: $(get_status_output(solver.status, solver.opt))$(Base.text_colors[:normal])")
         solver.opt.disable_garbage_collector &&
             (GC.enable(true); @warn(solver.logger,"Julia garbage collector is turned back on"))
         finalize(solver.logger)
@@ -209,6 +209,10 @@ function solve!(
 
     return stats
 end
+
+color_status(status::Status) =
+    status <= SOLVE_SUCCEEDED ? :green :
+    status <= SOLVED_TO_ACCEPTABLE_LEVEL ? :blue : :red
 
 
 function regular!(solver::AbstractMadNLPSolver{T}) where T

--- a/src/IPM/utils.jl
+++ b/src/IPM/utils.jl
@@ -140,7 +140,7 @@ end
 function print_iter(solver::AbstractMadNLPSolver; is_resto=false)
     obj_scale = solver.cb.obj_scale[]
     mod(solver.cnt.k,10)==0&& @info(solver.logger,@sprintf(
-        "iter    objective    inf_pr   inf_du inf_compl lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls"))
+        "iter    objective    inf_pr   inf_du inf_compl lg(mu) lg(rg) ls"))
     if is_resto
         RR = solver.RR::RobustRestorer
         inf_du = RR.inf_du_R
@@ -154,12 +154,13 @@ function print_iter(solver::AbstractMadNLPSolver; is_resto=false)
         mu = log10(solver.mu)
     end
     @info(solver.logger,@sprintf(
-        "%4i%s% 10.7e %6.2e %6.2e %7.2e %5.1f %6.2e %s %6.2e %6.2e%s  %i",
+        "%4i%s% 10.7e %6.2e %6.2e %7.2e %5.1f  %s  %i",
         solver.cnt.k,is_resto ? "r" : " ",solver.obj_val/obj_scale,
         inf_pr, inf_du, inf_compl, mu,
-        solver.cnt.k == 0 ? 0. : norm(primal(solver.d),Inf),
+        # solver.cnt.k == 0 ? 0. : norm(primal(solver.d),Inf),
         solver.del_w == 0 ? "   - " : @sprintf("%5.1f",log(10,solver.del_w)),
-        solver.alpha_z,solver.alpha,solver.ftype,solver.cnt.l))
+        # solver.alpha_z,solver.alpha,solver.ftype,
+        solver.cnt.l))
     return
 end
 
@@ -185,12 +186,14 @@ function print_summary(solver::AbstractMadNLPSolver)
     @notice(solver.logger,"Number of constraint evaluations                     = $(solver.cnt.con_cnt)")
     @notice(solver.logger,"Number of constraint Jacobian evaluations            = $(solver.cnt.con_jac_cnt)")
     @notice(solver.logger,"Number of Lagrangian Hessian evaluations             = $(solver.cnt.lag_hess_cnt)")
-    @notice(solver.logger,@sprintf("Total wall-clock secs in solver (w/o fun. eval./lin. alg.)  = %6.3f",
-                                solver.cnt.solver_time))
+    @notice(solver.logger,@sprintf("Total wall-clock secs in initializtion                      = %6.3f",
+                                solver.cnt.init_time))
     @notice(solver.logger,@sprintf("Total wall-clock secs in linear solver                      = %6.3f",
                                 solver.cnt.linear_solver_time))
     @notice(solver.logger,@sprintf("Total wall-clock secs in NLP function evaluations           = %6.3f",
                                 solver.cnt.eval_function_time))
+    @notice(solver.logger,@sprintf("Total wall-clock secs in solver (w/o init./fun./lin. alg.)  = %6.3f",
+                                solver.cnt.total_time - solver.cnt.init_time - solver.cnt.linear_solver_time - solver.cnt.eval_function_time))
     @notice(solver.logger,@sprintf("Total wall-clock secs                                       = %6.3f\n",
                                 solver.cnt.total_time))
 end

--- a/src/IPM/utils.jl
+++ b/src/IPM/utils.jl
@@ -140,7 +140,7 @@ end
 function print_iter(solver::AbstractMadNLPSolver; is_resto=false)
     obj_scale = solver.cb.obj_scale[]
     mod(solver.cnt.k,10)==0&& @info(solver.logger,@sprintf(
-        "iter    objective    inf_pr   inf_du inf_compl lg(mu) lg(rg) ir ls"))
+        "iter    objective    inf_pr   inf_du inf_compl lg(mu) lg(rg) alpha_pr ir ls"))
     if is_resto
         RR = solver.RR::RobustRestorer
         inf_du = RR.inf_du_R
@@ -154,11 +154,12 @@ function print_iter(solver::AbstractMadNLPSolver; is_resto=false)
         mu = log10(solver.mu)
     end
     @info(solver.logger,@sprintf(
-        "%4i%s% 10.7e %6.2e %6.2e %7.2e %5.1f  %s  %2i %2i%s",
+        "%4i%s% 10.7e %6.2e %6.2e %7.2e %5.1f  %s  %6.2e %2i %2i%s",
         solver.cnt.k,is_resto ? "r" : " ",solver.obj_val/obj_scale,
         inf_pr, inf_du, inf_compl, mu,
         # solver.cnt.k == 0 ? 0. : norm(primal(solver.d),Inf),
         solver.del_w == 0 ? "   - " : @sprintf("%5.1f",log(10,solver.del_w)),
+        solver.alpha,
         solver.cnt.ir,
         solver.cnt.l,
         solver.ftype,))
@@ -172,13 +173,13 @@ function print_summary(solver::AbstractMadNLPSolver)
 
     @notice(solver.logger,"")
     @notice(solver.logger,"Number of Iterations....: $(solver.cnt.k)\n")
-    @notice(solver.logger,"                               (scaled)             (unscaled)")
-    @notice(solver.logger,@sprintf("Objective...............:  % 1.11e   % 1.11e",solver.obj_val,solver.obj_val/obj_scale))
-    @notice(solver.logger,@sprintf("Dual infeasibility......:   %1.11e    %1.11e",solver.inf_du,solver.inf_du/obj_scale))
-    @notice(solver.logger,@sprintf("Constraint violation....:   %1.11e    %1.11e",norm(solver.c,Inf),solver.inf_pr))
-    @notice(solver.logger,@sprintf("Complementarity.........:   %1.11e    %1.11e",
+    @notice(solver.logger,"                                   (scaled)                 (unscaled)")
+    @notice(solver.logger,@sprintf("Objective...............:  % 1.16e   % 1.16e",solver.obj_val,solver.obj_val/obj_scale))
+    @notice(solver.logger,@sprintf("Dual infeasibility......:   %1.16e    %1.16e",solver.inf_du,solver.inf_du/obj_scale))
+    @notice(solver.logger,@sprintf("Constraint violation....:   %1.16e    %1.16e",norm(solver.c,Inf),solver.inf_pr))
+    @notice(solver.logger,@sprintf("Complementarity.........:   %1.16e    %1.16e",
                                 solver.inf_compl*obj_scale,solver.inf_compl))
-    @notice(solver.logger,@sprintf("Overall NLP error.......:   %1.11e    %1.11e\n",
+    @notice(solver.logger,@sprintf("Overall NLP error.......:   %1.16e    %1.16e\n",
                                 max(solver.inf_du*obj_scale,norm(solver.c,Inf),solver.inf_compl),
                                 max(solver.inf_du,solver.inf_pr,solver.inf_compl)))
 

--- a/src/IPM/utils.jl
+++ b/src/IPM/utils.jl
@@ -140,7 +140,7 @@ end
 function print_iter(solver::AbstractMadNLPSolver; is_resto=false)
     obj_scale = solver.cb.obj_scale[]
     mod(solver.cnt.k,10)==0&& @info(solver.logger,@sprintf(
-        "iter    objective    inf_pr   inf_du inf_compl lg(mu) lg(rg) ls"))
+        "iter    objective    inf_pr   inf_du inf_compl lg(mu) lg(rg) ir ls"))
     if is_resto
         RR = solver.RR::RobustRestorer
         inf_du = RR.inf_du_R
@@ -154,13 +154,14 @@ function print_iter(solver::AbstractMadNLPSolver; is_resto=false)
         mu = log10(solver.mu)
     end
     @info(solver.logger,@sprintf(
-        "%4i%s% 10.7e %6.2e %6.2e %7.2e %5.1f  %s  %i",
+        "%4i%s% 10.7e %6.2e %6.2e %7.2e %5.1f  %s  %2i %2i%s",
         solver.cnt.k,is_resto ? "r" : " ",solver.obj_val/obj_scale,
         inf_pr, inf_du, inf_compl, mu,
         # solver.cnt.k == 0 ? 0. : norm(primal(solver.d),Inf),
         solver.del_w == 0 ? "   - " : @sprintf("%5.1f",log(10,solver.del_w)),
-        # solver.alpha_z,solver.alpha,solver.ftype,
-        solver.cnt.l))
+        solver.cnt.ir,
+        solver.cnt.l,
+        solver.ftype,))
     return
 end
 
@@ -171,30 +172,30 @@ function print_summary(solver::AbstractMadNLPSolver)
 
     @notice(solver.logger,"")
     @notice(solver.logger,"Number of Iterations....: $(solver.cnt.k)\n")
-    @notice(solver.logger,"                                   (scaled)                 (unscaled)")
-    @notice(solver.logger,@sprintf("Objective...............:  % 1.16e   % 1.16e",solver.obj_val,solver.obj_val/obj_scale))
-    @notice(solver.logger,@sprintf("Dual infeasibility......:   %1.16e    %1.16e",solver.inf_du,solver.inf_du/obj_scale))
-    @notice(solver.logger,@sprintf("Constraint violation....:   %1.16e    %1.16e",norm(solver.c,Inf),solver.inf_pr))
-    @notice(solver.logger,@sprintf("Complementarity.........:   %1.16e    %1.16e",
+    @notice(solver.logger,"                               (scaled)             (unscaled)")
+    @notice(solver.logger,@sprintf("Objective...............:  % 1.11e   % 1.11e",solver.obj_val,solver.obj_val/obj_scale))
+    @notice(solver.logger,@sprintf("Dual infeasibility......:   %1.11e    %1.11e",solver.inf_du,solver.inf_du/obj_scale))
+    @notice(solver.logger,@sprintf("Constraint violation....:   %1.11e    %1.11e",norm(solver.c,Inf),solver.inf_pr))
+    @notice(solver.logger,@sprintf("Complementarity.........:   %1.11e    %1.11e",
                                 solver.inf_compl*obj_scale,solver.inf_compl))
-    @notice(solver.logger,@sprintf("Overall NLP error.......:   %1.16e    %1.16e\n",
+    @notice(solver.logger,@sprintf("Overall NLP error.......:   %1.11e    %1.11e\n",
                                 max(solver.inf_du*obj_scale,norm(solver.c,Inf),solver.inf_compl),
                                 max(solver.inf_du,solver.inf_pr,solver.inf_compl)))
 
-    @notice(solver.logger,"Number of objective function evaluations             = $(solver.cnt.obj_cnt)")
-    @notice(solver.logger,"Number of objective gradient evaluations             = $(solver.cnt.obj_grad_cnt)")
-    @notice(solver.logger,"Number of constraint evaluations                     = $(solver.cnt.con_cnt)")
-    @notice(solver.logger,"Number of constraint Jacobian evaluations            = $(solver.cnt.con_jac_cnt)")
-    @notice(solver.logger,"Number of Lagrangian Hessian evaluations             = $(solver.cnt.lag_hess_cnt)")
-    @notice(solver.logger,@sprintf("Total wall-clock secs in initializtion                      = %6.3f",
+    @notice(solver.logger,"Number of objective function evaluations              = $(solver.cnt.obj_cnt)")
+    @notice(solver.logger,"Number of objective gradient evaluations              = $(solver.cnt.obj_grad_cnt)")
+    @notice(solver.logger,"Number of constraint evaluations                      = $(solver.cnt.con_cnt)")
+    @notice(solver.logger,"Number of constraint Jacobian evaluations             = $(solver.cnt.con_jac_cnt)")
+    @notice(solver.logger,"Number of Lagrangian Hessian evaluations              = $(solver.cnt.lag_hess_cnt)\n")
+    @notice(solver.logger,@sprintf("Total wall secs in initializtion                      = %6.3f",
                                 solver.cnt.init_time))
-    @notice(solver.logger,@sprintf("Total wall-clock secs in linear solver                      = %6.3f",
+    @notice(solver.logger,@sprintf("Total wall secs in linear solver                      = %6.3f",
                                 solver.cnt.linear_solver_time))
-    @notice(solver.logger,@sprintf("Total wall-clock secs in NLP function evaluations           = %6.3f",
+    @notice(solver.logger,@sprintf("Total wall secs in NLP function evaluations           = %6.3f",
                                 solver.cnt.eval_function_time))
-    @notice(solver.logger,@sprintf("Total wall-clock secs in solver (w/o init./fun./lin. alg.)  = %6.3f",
+    @notice(solver.logger,@sprintf("Total wall secs in solver (w/o init./fun./lin. alg.)  = %6.3f",
                                 solver.cnt.total_time - solver.cnt.init_time - solver.cnt.linear_solver_time - solver.cnt.eval_function_time))
-    @notice(solver.logger,@sprintf("Total wall-clock secs                                       = %6.3f\n",
+    @notice(solver.logger,@sprintf("Total wall secs                                       = %6.3f\n",
                                 solver.cnt.total_time))
 end
 

--- a/src/LinearSolvers/backsolve.jl
+++ b/src/LinearSolvers/backsolve.jl
@@ -37,47 +37,38 @@ function solve_refine!(
 
     fill!(full(x), zero(T))
 
-    if norm_b == zero(T)
-        @debug(
-            iterator.logger,
-            @sprintf(
-                "Iterative solver terminated with %4i refinement steps and residual = %6.2e",
-                0, 0
-            ),
-        )
-        return true
-    end
-
-    copyto!(full(w), full(b))
-    iter = 0
-
-    while true
-        solve!(iterator.kkt, w)
-        axpy!(1., full(w), full(x))
+    if norm_b != zero(T)
         copyto!(full(w), full(b))
+        iterator.cnt.ir = 0
 
-        mul!(w, iterator.kkt, x, -one(T), one(T))
+        while true
+            solve!(iterator.cnt.irator.kkt, w)
+            axpy!(1., full(w), full(x))
+            copyto!(full(w), full(b))
 
-        norm_w = norm(full(w), Inf)
-        norm_x = norm(full(x), Inf)
-        residual_ratio = norm_w / (min(norm_x, 1e6 * norm_b) + norm_b)
+            mul!(w, iterator.cnt.irator.kkt, x, -one(T), one(T))
 
-        if mod(iter, 10)==0
-            @debug(iterator.logger,"iter ||res||")
-        end
-        @debug(iterator.logger, @sprintf("%4i %6.2e", iter, residual_ratio))
-        iter += 1
+            norm_w = norm(full(w), Inf)
+            norm_x = norm(full(x), Inf)
+            residual_ratio = norm_w / (min(norm_x, 1e6 * norm_b) + norm_b)
 
-        if (iter >= iterator.opt.richardson_max_iter) || (residual_ratio < iterator.opt.richardson_tol)
-            break
+            if mod(iterator.cnt.ir, 10)==0
+                @debug(iterator.cnt.irator.logger,"iterator.cnt.ir ||res||")
+            end
+            @debug(iterator.cnt.irator.logger, @sprintf("%4i %6.2e", iterator.cnt.ir, residual_ratio))
+            iterator.cnt.ir += 1
+
+            if (iterator.cnt.ir >= iterator.cnt.irator.opt.richardson_max_iterator.cnt.ir) || (residual_ratio < iterator.cnt.irator.opt.richardson_tol)
+                break
+            end
         end
     end
 
     @debug(
-        iterator.logger,
+        iterator.cnt.irator.logger,
         @sprintf(
-            "Iterative solver terminated with %4i refinement steps and residual = %6.2e",
-            iter, residual_ratio
+            "Iterator.Cnt.Irative solver terminated with %4i refinement steps and residual = %6.2e",
+            iterator.cnt.ir, residual_ratio
         ),
     )
 

--- a/src/LinearSolvers/backsolve.jl
+++ b/src/LinearSolvers/backsolve.jl
@@ -42,32 +42,32 @@ function solve_refine!(
         iterator.cnt.ir = 0
 
         while true
-            solve!(iterator.cnt.irator.kkt, w)
+            solve!(iterator.kkt, w)
             axpy!(1., full(w), full(x))
             copyto!(full(w), full(b))
 
-            mul!(w, iterator.cnt.irator.kkt, x, -one(T), one(T))
+            mul!(w, iterator.kkt, x, -one(T), one(T))
 
             norm_w = norm(full(w), Inf)
             norm_x = norm(full(x), Inf)
             residual_ratio = norm_w / (min(norm_x, 1e6 * norm_b) + norm_b)
 
             if mod(iterator.cnt.ir, 10)==0
-                @debug(iterator.cnt.irator.logger,"iterator.cnt.ir ||res||")
+                @debug(iterator.logger,"iterator.cnt.ir ||res||")
             end
-            @debug(iterator.cnt.irator.logger, @sprintf("%4i %6.2e", iterator.cnt.ir, residual_ratio))
+            @debug(iterator.logger, @sprintf("%4i %6.2e", iterator.cnt.ir, residual_ratio))
             iterator.cnt.ir += 1
 
-            if (iterator.cnt.ir >= iterator.cnt.irator.opt.richardson_max_iterator.cnt.ir) || (residual_ratio < iterator.cnt.irator.opt.richardson_tol)
+            if (iterator.cnt.ir >= iterator.opt.richardson_max_iter) || (residual_ratio < iterator.opt.richardson_tol)
                 break
             end
         end
     end
 
     @debug(
-        iterator.cnt.irator.logger,
+        iterator.logger,
         @sprintf(
-            "Iterator.Cnt.Irative solver terminated with %4i refinement steps and residual = %6.2e",
+            "Iterative solver terminated with %4i refinement steps and residual = %6.2e",
             iterator.cnt.ir, residual_ratio
         ),
     )

--- a/src/MadNLP.jl
+++ b/src/MadNLP.jl
@@ -16,7 +16,7 @@ import LDLFactorizations
 
 # Version info
 version() = string(pkgversion(@__MODULE__))
-introduce() = "MadNLP version v$(version())"
+introduce() = "\033[34mMad\033[31mN\033[32mL\033[35mP\033[0m version v$(version())"
 
 include("enums.jl")
 include("utils.jl")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -86,6 +86,7 @@ const SubVector{Tv,VT, VI} = SubArray{Tv, 1, VT, Tuple{VI}, false}
     k::Int = 0 # total iteration counter
     l::Int = 0 # backtracking line search counter
     t::Int = 0 # restoration phase counter
+    ir::Int = 0 # iterative refinement counter
 
     start_time::Float64
 


### PR DESCRIPTION
As we're now printing inf_compl, the printing per iteration became a bit too heavy. In this PR, we revise the printing scheme used by default.

Specifically, the following changes are made:
* Use colors when introducing MadNLP
* Removed alpha, alpha_z, and ||d||, and instead print `ir` (the number of iterative refinement steps)
* The type of iteration (f,h, etc.) are shown at the very end
* We separately report initialization time (the time that can be excluded when solving the same problem with updated entries)
* Depending on the exit status, we show the exit message in different colors

Below is an example output
```julia
This is MadNLP version v0.8.12, running with cuDSS v0.6.0                                                                                                                                                                                                                                                   

Number of nonzeros in constraint Jacobian............:     5925                                                                                                                                                                                                                            
Number of nonzeros in Lagrangian Hessian.............:     8474                                                                                                                                                                                                                            
                                                                      
Total number of variables............................:     1088       
                     variables with only lower bounds:        0                                                                                                                                                                                                                            
                variables with lower and upper bounds:      970       
                     variables with only upper bounds:        0                                                                                                                                                                                                                            
Total number of equality constraints.................:      981       
Total number of inequality constraints...............:      558    
        inequality constraints with only lower bounds:        0    
   inequality constraints with lower and upper bounds:      186    
        inequality constraints with only upper bounds:      372    
                                                                                                                                             
iter    objective    inf_pr   inf_du inf_compl lg(mu) lg(rg) ir ls    
   0  4.7812282e+02 2.76e+00 1.00e+02 5.21e+03  -1.0     -    0  0                                                                           
   1  4.7814725e+02 2.76e+00 1.96e+00 7.58e+01  -1.0     -    1  1h   
   2  7.8025285e+02 2.75e+00 1.41e-02 4.80e-01  -1.0     -   10  1h
   3  9.5082142e+03 2.42e+00 1.26e-02 4.76e-01  -1.0   -4.0   2  2h                                                                          
   4  2.2755464e+04 1.95e+00 9.68e-03 3.82e-01  -1.0   -4.5   1  1h
   5  3.2336469e+04 1.67e+00 7.83e-03 3.16e-01  -1.0   -5.0   1  1h
   6  5.0419605e+04 1.22e+00 5.13e-03 2.16e-01  -1.0   -5.4   1  1h
   7  6.4965378e+04 1.23e+00 2.65e-03 1.11e-01  -1.0   -5.9   1  1h                                                                          
   8  7.5947380e+04 1.56e+00 6.25e-04 1.84e-02  -1.0   -6.4   2  1h   
   9  8.5081325e+04 1.63e+00 4.52e-04 1.45e-02  -1.0   -6.9   2  1h                                                                          
iter    objective    inf_pr   inf_du inf_compl lg(mu) lg(rg) ir ls                                                                           
  10  9.2751699e+04 1.01e+00 2.09e-04 6.98e-03  -1.0   -7.3   2  1h
  11  9.4160144e+04 8.65e-01 3.80e-04 3.60e-03  -1.0   -7.8   2  1h                                                                          
  12  9.6370677e+04 1.89e+00 3.30e-04 2.34e-03  -1.7   -8.3   1  1h
  13  9.7076549e+04 1.05e+00 2.11e-04 1.00e-03  -1.7   -8.8   1  1h   
  14  9.7349356e+04 1.06e-01 5.02e-05 1.29e-05  -1.7   -9.2   1  1h
  15  9.7275680e+04 4.53e-02 8.71e-04 1.06e-05  -2.5   -9.7   2  1h                                                                          
  16  9.7229885e+04 8.53e-02 7.33e-05 5.97e-06  -2.5     -   10  1h
  17  9.7233091e+04 1.48e-03 2.00e-06 4.89e-06  -2.5   -2.1  10  1h
  18  9.7219402e+04 1.07e-02 2.40e-03 9.88e-06  -5.7     -   10  1h
  19  9.7215895e+04 4.92e-03 7.76e-03 1.58e-05  -5.7     -    4  1h   
iter    objective    inf_pr   inf_du inf_compl lg(mu) lg(rg) ir ls                                                                                                                                                                                                                         
  20  9.7214217e+04 1.56e-03 1.00e-01 7.57e-05  -5.7     -    4  1h   
  21  9.7213617e+04 1.27e-04 5.87e-03 3.93e-05  -5.7     -    2  1h                                                                                                                                                                                                                        
  22  9.7213615e+04 1.71e-05 1.72e-05 1.07e-05  -5.7     -    2  1h   
  23  9.7213600e+04 5.11e-06 6.29e-04 2.99e-06  -8.6     -    2  1h
  24  9.7213582e+04 1.07e-06 5.76e-04 9.27e-07  -8.6     -    2  1h                                                                          
  25  9.7213577e+04 2.28e-07 2.48e-04 2.63e-07  -8.6     -    2  1h
  26  9.7213576e+04 5.99e-08 8.97e-06 5.79e-08  -8.6     -    3  1h   
  27  9.7213576e+04 9.22e-09 9.15e-09 7.66e-09  -8.6     -    3  1h                                                                          
                                                                      
Number of Iterations....: 27                                                                                                                 
                                                                      
                               (scaled)             (unscaled) 
Objective...............:   7.80320725958e+02    9.72135764614e+04                                                                           
Dual infeasibility......:   9.15481313781e-09    1.14052093884e-06
Constraint violation....:   9.22316845120e-09    9.22316845120e-09
Complementarity.........:   6.14562657742e-11    7.65631770775e-09
Overall NLP error.......:   9.22316845120e-09    9.22316845120e-09

Number of objective function evaluations              = 31
Number of objective gradient evaluations              = 28
Number of constraint evaluations                      = 31
Number of constraint Jacobian evaluations             = 28
Number of Lagrangian Hessian evaluations              = 27

Total wall secs in initializtion                      =  0.039                 
Total wall secs in linear solver                      =  0.292                 
Total wall secs in NLP function evaluations           =  0.057                 
Total wall secs in solver (w/o init./fun./lin. alg.)  =  0.143                 
Total wall secs                                       =  0.532                 

EXIT: Optimal Solution Found (tol = 1.0e-08).                                  
```