### PR TITLE
Precompile fix

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -85,6 +85,7 @@
     end
 
     nlp = HS15Model()
+    __init__()
     
     @compile_workload begin
         madnlp(nlp; print_level=MadNLP.ERROR)


### PR DESCRIPTION
This resolves https://github.com/MadNLP/MadNLP.jl/actions/runs/18313761816/job/52148472438#step:5:261
```
┌ MadNLP
│  Error: no BLAS/LAPACK library loaded for dtrsm_()
│  Error: no BLAS/LAPACK library loaded for dtrsm_()
│  Error: no BLAS/LAPACK library loaded for dtrsm_()
│  Error: no BLAS/LAPACK library loaded for dtrsm_()
│  Error: no BLAS/LAPACK library loaded for dtrsm_()
│  Error: no BLAS/LAPACK library loaded for dtrsm_()
│  Error: no BLAS/LAPACK library loaded for dtrsm_()
```
Following the approach in https://github.com/jump-dev/Ipopt.jl/blob/v1.9.0/src/Ipopt.jl#L41 @odow 