### PR TITLE
[WIP] extract code in `regular!`. `robust!`, and `restore!` into functions for more consise extensibility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ benchmark/Project.toml
 benchmark/Manifest.toml
 benchmark/*.csv
 benchmark/*.pdf
+
+# Emacs Autosaves
+*~

--- a/src/IPM/IPM.jl
+++ b/src/IPM/IPM.jl
@@ -4,6 +4,7 @@
 abstract type AbstractMadNLPSolver{T} end
 
 include("types.jl")
+include("options.jl")
 
 mutable struct MadNLPSolver{
     T,
@@ -79,6 +80,7 @@ mutable struct MadNLPSolver{
     inf_pr::T
     inf_du::T
     inf_compl::T
+    inf_compl_mu::T
 
     theta_min::T
     theta_max::T
@@ -105,7 +107,6 @@ include("api.jl")
 include("restoration.jl")
 include("inertiacorrector.jl")
 include("barrier.jl")
-include("options.jl")
 
 
 """
@@ -231,7 +232,7 @@ function MadNLPSolver(nlp::AbstractNLPModel{T,VT}; kwargs...) where {T, VT}
         ind_cons.ind_ineq, ind_cons.ind_fixed, ind_cons.ind_llb, ind_cons.ind_uub,
         x_lr, x_ur, xl_r, xu_r, zl_r, zu_r, dx_lr, dx_ur, x_trial_lr, x_trial_ur,
         iterator,
-        zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T),
+        zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T),
         " ",
         zero(T), zero(T), zero(T),
         Tuple{T, T}[],

--- a/src/IPM/IPM.jl
+++ b/src/IPM/IPM.jl
@@ -3,6 +3,7 @@
 
 abstract type AbstractMadNLPSolver{T} end
 
+include("api.jl")
 include("restoration.jl")
 include("inertiacorrector.jl")
 include("barrier.jl")

--- a/src/IPM/IPM.jl
+++ b/src/IPM/IPM.jl
@@ -3,11 +3,7 @@
 
 abstract type AbstractMadNLPSolver{T} end
 
-include("api.jl")
-include("restoration.jl")
-include("inertiacorrector.jl")
-include("barrier.jl")
-include("options.jl")
+include("types.jl")
 
 mutable struct MadNLPSolver{
     T,
@@ -104,6 +100,13 @@ mutable struct MadNLPSolver{
     status::Status
     output::Dict
 end
+
+include("api.jl")
+include("restoration.jl")
+include("inertiacorrector.jl")
+include("barrier.jl")
+include("options.jl")
+
 
 """
     MadNLPSolver(nlp::AbstractNLPModel{T, VT}; options...) where {T, VT}

--- a/src/IPM/IPM.jl
+++ b/src/IPM/IPM.jl
@@ -77,6 +77,9 @@ mutable struct MadNLPSolver{
 
     iterator::Iterator
 
+    sc::T
+    sd::T
+    
     inf_pr::T
     inf_du::T
     inf_compl::T

--- a/src/IPM/IPM.jl
+++ b/src/IPM/IPM.jl
@@ -235,7 +235,7 @@ function MadNLPSolver(nlp::AbstractNLPModel{T,VT}; kwargs...) where {T, VT}
         ind_cons.ind_ineq, ind_cons.ind_fixed, ind_cons.ind_llb, ind_cons.ind_uub,
         x_lr, x_ur, xl_r, xu_r, zl_r, zu_r, dx_lr, dx_ur, x_trial_lr, x_trial_ur,
         iterator,
-        zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T),
+        zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T),
         " ",
         zero(T), zero(T), zero(T),
         Tuple{T, T}[],

--- a/src/IPM/api.jl
+++ b/src/IPM/api.jl
@@ -26,6 +26,7 @@ set_obj_val_trial!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.o
 set_inf_pr!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_pr = rhs
 set_inf_du!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_du = rhs
 set_inf_compl!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_compl = rhs
+set_inf_compl_mu!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_compl_mu = rhs
 set_theta_min!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.theta_min = rhs
 set_theta_max!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.theta_max = rhs
 set_tau!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.tau = rhs
@@ -42,4 +43,5 @@ get_theta(solver::AbstractMadNLPSolver) = get_theta(get_c(solver))
 get_varphi(solver::AbstractMadNLPSolver) = get_varphi(get_obj_val(solver), get_x_lr(solver), get_xl_r(solver), get_xu_r(solver), get_x_ur(solver), get_mu(solver))
 get_kkt_error(solver::AbstractMadNLPSolver) = max(get_inf_pr(solver), get_inf_du(solver), get_inf_compl(solver))
 get_inf_compl(solver::AbstractMadNLPSolver{T}, sc::T; mu=get_mu(solver)) where {T} = get_inf_compl(get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver), mu, sc)
+get_inf_barrier(solver::AbstractMadNLPSolver) = max(get_inf_pr(solver),get_inf_du(solver),get_inf_compl_mu(solver))
 get_inf_total(solver::AbstractMadNLPSolver) = max(get_inf_pr(solver),get_inf_du(solver),get_inf_compl(solver))

--- a/src/IPM/api.jl
+++ b/src/IPM/api.jl
@@ -5,7 +5,7 @@
 
 # getters for all fields
 for (k, attribute) in enumerate(fieldnames(MadNLPSolver))
-    fname = "_$(attribute)"
+    fname = "get_$(attribute)"
     @eval begin
         @inline function $(Symbol(fname))(solver::MadNLPSolver)
             return getfield(solver, $k)
@@ -38,8 +38,8 @@ set_del_c!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_c = r
 
 # Computed quantities
 # TODO(@anton) I now think these would be useful to have, but which quantities are wrapped this way is a good question
-_theta(solver::AbstractMadNLPSolver) = get_theta(_c(solver))
-_varphi(solver::AbstractMadNLPSolver) = get_varphi(_obj_val(solver), _x_lr(solver), _xl_r(solver), _xu_r(solver), _x_ur(solver), _mu(solver))
-_kkt_error(solver::AbstractMadNLPSolver) = max(_inf_pr(solver), _inf_du(solver), _inf_compl(solver))
-_inf_compl(solver::AbstractMadNLPSolver{T}, sc::T; mu=_mu(solver)) where {T} = get_inf_compl(_x_lr(solver),_xl_r(solver),_zl_r(solver),_xu_r(solver),_x_ur(solver),_zu_r(solver), mu, sc)
-_inf_total(solver::AbstractMadNLPSolver) = max(_inf_pr(solver),_inf_du(solver),_inf_compl(solver))
+get_theta(solver::AbstractMadNLPSolver) = get_theta(get_c(solver))
+get_varphi(solver::AbstractMadNLPSolver) = get_varphi(get_obj_val(solver), get_x_lr(solver), get_xl_r(solver), get_xu_r(solver), get_x_ur(solver), get_mu(solver))
+get_kkt_error(solver::AbstractMadNLPSolver) = max(get_inf_pr(solver), get_inf_du(solver), get_inf_compl(solver))
+get_inf_compl(solver::AbstractMadNLPSolver{T}, sc::T; mu=get_mu(solver)) where {T} = get_inf_compl(get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver), mu, sc)
+get_inf_total(solver::AbstractMadNLPSolver) = max(get_inf_pr(solver),get_inf_du(solver),get_inf_compl(solver))

--- a/src/IPM/api.jl
+++ b/src/IPM/api.jl
@@ -2,7 +2,7 @@
 # The idea here is that a subtype of AbstractMadNLPSolver may specialize
 # some or all of these and the core functionality of the IPM in MadNLP
 # should function as normal.
-# TODO(@anton) We could in principle write a macro to define this "automatically"
+# TODO(@anton) We could in principle write a macro to define this "automagically"
 
 # Solver data
 _kkt(solver::AbstractMadNLPSolver) = solver.kkt

--- a/src/IPM/api.jl
+++ b/src/IPM/api.jl
@@ -12,6 +12,7 @@ _cnt(solver::AbstractMadNLPSolver) = solver.cnt
 _logger(solver::AbstractMadNLPSolver) = solver.logger
 _iterator(solver::AbstractMadNLPSolver) = solver.iterator
 _RR(solver::AbstractMadNLPSolver) = solver.RR
+_RR!(solver::AbstractMadNLPSolver, rhs) = solver.RR = rhs
 _output(solver::AbstractMadNLPSolver) = solver.output
 _inertia_corrector(solver::AbstractMadNLPSolver) = solver.inertia_corrector
 

--- a/src/IPM/api.jl
+++ b/src/IPM/api.jl
@@ -14,27 +14,27 @@ for (k, attribute) in enumerate(fieldnames(MadNLPSolver))
 end
 
 # Necessary Mutators
-_RR!(solver::AbstractMadNLPSolver, rhs) = solver.RR = rhs
-_n!(solver::AbstractMadNLPSolver, rhs::Int) = solver.n = rhs
-_m!(solver::AbstractMadNLPSolver, rhs::Int) = solver.m = rhs
-_nlb!(solver::AbstractMadNLPSolver, rhs::Int) = solver.nlb = rhs
-_nub!(solver::AbstractMadNLPSolver, rhs::Int) = solver.nub = rhs
-_status!(solver::AbstractMadNLPSolver, rhs::Status) = solver.status = rhs
-_mu!(solver::AbstractMadNLPSolver{T}, rhs::T) where{T} = solver.mu = rhs
-_obj_val!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.obj_val = rhs
-_obj_val_trial!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.obj_val_trial = rhs
-_inf_pr!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_pr = rhs
-_inf_du!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_du = rhs
-_inf_compl!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_compl = rhs
-_theta_min!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.theta_min = rhs
-_theta_max!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.theta_max = rhs
-_tau!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.tau = rhs
-_alpha!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.alpha = rhs
-_alpha_z!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.alpha_z = rhs
-_ftype!(solver::AbstractMadNLPSolver, rhs::String) = solver.ftype = rhs
-_del_w!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_w = rhs
-_del_w_last!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_w_last = rhs
-_del_c!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_c = rhs
+set_RR!(solver::AbstractMadNLPSolver, rhs) = solver.RR = rhs
+set_n!(solver::AbstractMadNLPSolver, rhs::Int) = solver.n = rhs
+set_m!(solver::AbstractMadNLPSolver, rhs::Int) = solver.m = rhs
+set_nlb!(solver::AbstractMadNLPSolver, rhs::Int) = solver.nlb = rhs
+set_nub!(solver::AbstractMadNLPSolver, rhs::Int) = solver.nub = rhs
+set_status!(solver::AbstractMadNLPSolver, rhs::Status) = solver.status = rhs
+set_mu!(solver::AbstractMadNLPSolver{T}, rhs::T) where{T} = solver.mu = rhs
+set_obj_val!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.obj_val = rhs
+set_obj_val_trial!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.obj_val_trial = rhs
+set_inf_pr!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_pr = rhs
+set_inf_du!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_du = rhs
+set_inf_compl!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_compl = rhs
+set_theta_min!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.theta_min = rhs
+set_theta_max!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.theta_max = rhs
+set_tau!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.tau = rhs
+set_alpha!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.alpha = rhs
+set_alpha_z!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.alpha_z = rhs
+set_ftype!(solver::AbstractMadNLPSolver, rhs::String) = solver.ftype = rhs
+set_del_w!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_w = rhs
+set_del_w_last!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_w_last = rhs
+set_del_c!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_c = rhs
 
 # Computed quantities
 # TODO(@anton) I now think these would be useful to have, but which quantities are wrapped this way is a good question

--- a/src/IPM/api.jl
+++ b/src/IPM/api.jl
@@ -14,28 +14,50 @@ for (k, attribute) in enumerate(fieldnames(MadNLPSolver))
 end
 
 # Necessary Mutators
-set_RR!(solver::AbstractMadNLPSolver, rhs) = solver.RR = rhs
-set_n!(solver::AbstractMadNLPSolver, rhs::Int) = solver.n = rhs
-set_m!(solver::AbstractMadNLPSolver, rhs::Int) = solver.m = rhs
-set_nlb!(solver::AbstractMadNLPSolver, rhs::Int) = solver.nlb = rhs
-set_nub!(solver::AbstractMadNLPSolver, rhs::Int) = solver.nub = rhs
-set_status!(solver::AbstractMadNLPSolver, rhs::Status) = solver.status = rhs
-set_mu!(solver::AbstractMadNLPSolver{T}, rhs::T) where{T} = solver.mu = rhs
-set_obj_val!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.obj_val = rhs
-set_obj_val_trial!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.obj_val_trial = rhs
-set_inf_pr!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_pr = rhs
-set_inf_du!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_du = rhs
-set_inf_compl!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_compl = rhs
-set_inf_compl_mu!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_compl_mu = rhs
-set_theta_min!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.theta_min = rhs
-set_theta_max!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.theta_max = rhs
-set_tau!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.tau = rhs
-set_alpha!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.alpha = rhs
-set_alpha_z!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.alpha_z = rhs
-set_ftype!(solver::AbstractMadNLPSolver, rhs::String) = solver.ftype = rhs
-set_del_w!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_w = rhs
-set_del_w_last!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_w_last = rhs
-set_del_c!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_c = rhs
+for (k, (attribute, type)) in enumerate(zip(fieldnames(MadNLPSolver), fieldtypes(MadNLPSolver)))
+    # These types shouldn't ever be set by value so we ignore them.
+    if type <: Union{AbstractVector,
+                     PrimalVector,
+                     AbstractKKTVector,
+                     MadNLPOptions,
+                     MadNLPCounters,
+                     MadNLPLogger,
+                     AbstractKKTSystem,
+                     AbstractNLPModel,
+                     AbstractCallback,
+                     AbstractIterator,
+                     AbstractInertiaCorrector}
+      continue
+    end
+    fname = "set_$(attribute)!"
+    @eval begin
+        @inline function $(Symbol(fname))(solver::MadNLPSolver, rhs)
+            return setfield!(solver, $k, rhs)
+        end
+    end
+end
+# set_RR!(solver::AbstractMadNLPSolver, rhs) = solver.RR = rhs
+# set_n!(solver::AbstractMadNLPSolver, rhs::Int) = solver.n = rhs
+# set_m!(solver::AbstractMadNLPSolver, rhs::Int) = solver.m = rhs
+# set_nlb!(solver::AbstractMadNLPSolver, rhs::Int) = solver.nlb = rhs
+# set_nub!(solver::AbstractMadNLPSolver, rhs::Int) = solver.nub = rhs
+# set_status!(solver::AbstractMadNLPSolver, rhs::Status) = solver.status = rhs
+# set_mu!(solver::AbstractMadNLPSolver{T}, rhs::T) where{T} = solver.mu = rhs
+# set_obj_val!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.obj_val = rhs
+# set_obj_val_trial!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.obj_val_trial = rhs
+# set_inf_pr!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_pr = rhs
+# set_inf_du!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_du = rhs
+# set_inf_compl!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_compl = rhs
+# set_inf_compl_mu!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_compl_mu = rhs
+# set_theta_min!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.theta_min = rhs
+# set_theta_max!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.theta_max = rhs
+# set_tau!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.tau = rhs
+# set_alpha!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.alpha = rhs
+# set_alpha_z!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.alpha_z = rhs
+# set_ftype!(solver::AbstractMadNLPSolver, rhs::String) = solver.ftype = rhs
+# set_del_w!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_w = rhs
+# set_del_w_last!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_w_last = rhs
+# set_del_c!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_c = rhs
 
 # Computed quantities
 # TODO(@anton) I now think these would be useful to have, but which quantities are wrapped this way is a good question

--- a/src/IPM/api.jl
+++ b/src/IPM/api.jl
@@ -107,3 +107,5 @@ _del_c!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_c = rhs
 _theta(solver::AbstractMadNLPSolver) = get_theta(_c(solver))
 _varphi(solver::AbstractMadNLPSolver) = get_varphi(_obj_val(solver), _x_lr(solver), _xl_r(solver), _xu_r(solver), _x_ur(solver), _mu(solver))
 _kkt_error(solver::AbstractMadNLPSolver) = max(_inf_pr(solver), _inf_du(solver), _inf_compl(solver))
+_inf_compl(solver::AbstractMadNLPSolver{T}, sc::T; mu=_mu(solver)) where {T} = get_inf_compl(_x_lr(solver),_xl_r(solver),_zl_r(solver),_xu_r(solver),_x_ur(solver),_zu_r(solver), mu, sc)
+_inf_total(solver::AbstractMadNLPSolver) = max(_inf_pr(solver),_inf_du(solver),_inf_compl(solver))

--- a/src/IPM/api.jl
+++ b/src/IPM/api.jl
@@ -36,28 +36,6 @@ for (k, (attribute, type)) in enumerate(zip(fieldnames(MadNLPSolver), fieldtypes
         end
     end
 end
-# set_RR!(solver::AbstractMadNLPSolver, rhs) = solver.RR = rhs
-# set_n!(solver::AbstractMadNLPSolver, rhs::Int) = solver.n = rhs
-# set_m!(solver::AbstractMadNLPSolver, rhs::Int) = solver.m = rhs
-# set_nlb!(solver::AbstractMadNLPSolver, rhs::Int) = solver.nlb = rhs
-# set_nub!(solver::AbstractMadNLPSolver, rhs::Int) = solver.nub = rhs
-# set_status!(solver::AbstractMadNLPSolver, rhs::Status) = solver.status = rhs
-# set_mu!(solver::AbstractMadNLPSolver{T}, rhs::T) where{T} = solver.mu = rhs
-# set_obj_val!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.obj_val = rhs
-# set_obj_val_trial!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.obj_val_trial = rhs
-# set_inf_pr!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_pr = rhs
-# set_inf_du!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_du = rhs
-# set_inf_compl!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_compl = rhs
-# set_inf_compl_mu!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_compl_mu = rhs
-# set_theta_min!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.theta_min = rhs
-# set_theta_max!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.theta_max = rhs
-# set_tau!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.tau = rhs
-# set_alpha!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.alpha = rhs
-# set_alpha_z!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.alpha_z = rhs
-# set_ftype!(solver::AbstractMadNLPSolver, rhs::String) = solver.ftype = rhs
-# set_del_w!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_w = rhs
-# set_del_w_last!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_w_last = rhs
-# set_del_c!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_c = rhs
 
 # Computed quantities
 # TODO(@anton) I now think these would be useful to have, but which quantities are wrapped this way is a good question

--- a/src/IPM/api.jl
+++ b/src/IPM/api.jl
@@ -2,90 +2,23 @@
 # The idea here is that a subtype of AbstractMadNLPSolver may specialize
 # some or all of these and the core functionality of the IPM in MadNLP
 # should function as normal.
-# TODO(@anton) We could in principle write a macro to define this "automagically"
 
-# Solver data
-_kkt(solver::AbstractMadNLPSolver) = solver.kkt
-_nlp(solver::AbstractMadNLPSolver) = solver.nlp
-_cb(solver::AbstractMadNLPSolver) = solver.cb
-_cnt(solver::AbstractMadNLPSolver) = solver.cnt
-_logger(solver::AbstractMadNLPSolver) = solver.logger
-_iterator(solver::AbstractMadNLPSolver) = solver.iterator
-_RR(solver::AbstractMadNLPSolver) = solver.RR
+# getters for all fields
+for (k, attribute) in enumerate(fieldnames(MadNLPSolver))
+    fname = "_$(attribute)"
+    @eval begin
+        @inline function $(Symbol(fname))(solver::MadNLPSolver)
+            return getfield(solver, $k)
+        end
+    end
+end
+
+# Necessary Mutators
 _RR!(solver::AbstractMadNLPSolver, rhs) = solver.RR = rhs
-_output(solver::AbstractMadNLPSolver) = solver.output
-_inertia_corrector(solver::AbstractMadNLPSolver) = solver.inertia_corrector
-
-# Solver sizes
-_n(solver::AbstractMadNLPSolver) = solver.n
-_m(solver::AbstractMadNLPSolver) = solver.m
-_nlb(solver::AbstractMadNLPSolver) = solver.nlb
-_nub(solver::AbstractMadNLPSolver) = solver.nub
-
-# Solver size mutators
 _n!(solver::AbstractMadNLPSolver, rhs::Int) = solver.n = rhs
 _m!(solver::AbstractMadNLPSolver, rhs::Int) = solver.m = rhs
 _nlb!(solver::AbstractMadNLPSolver, rhs::Int) = solver.nlb = rhs
 _nub!(solver::AbstractMadNLPSolver, rhs::Int) = solver.nub = rhs
-
-# Vectors
-_x(solver::AbstractMadNLPSolver) = solver.x
-_y(solver::AbstractMadNLPSolver) = solver.y
-_zl(solver::AbstractMadNLPSolver) = solver.zl
-_xl(solver::AbstractMadNLPSolver) = solver.xl
-_zu(solver::AbstractMadNLPSolver) = solver.zu
-_xu(solver::AbstractMadNLPSolver) = solver.xu
-_f(solver::AbstractMadNLPSolver) = solver.f
-_c(solver::AbstractMadNLPSolver) = solver.c
-_jacl(solver::AbstractMadNLPSolver) = solver.jacl
-_d(solver::AbstractMadNLPSolver) = solver.d
-_p(solver::AbstractMadNLPSolver) = solver.p
-__w1(solver::AbstractMadNLPSolver) = solver._w1
-__w2(solver::AbstractMadNLPSolver) = solver._w2
-__w3(solver::AbstractMadNLPSolver) = solver._w3
-__w4(solver::AbstractMadNLPSolver) = solver._w4
-_x_trial(solver::AbstractMadNLPSolver) = solver.x_trial
-_c_trial(solver::AbstractMadNLPSolver) = solver.c_trial
-_c_slk(solver::AbstractMadNLPSolver) = solver.c_slk
-_rhs(solver::AbstractMadNLPSolver) = solver.rhs
-_ind_ineq(solver::AbstractMadNLPSolver) = solver.ind_ineq
-_ind_fixed(solver::AbstractMadNLPSolver) = solver.ind_fixed
-_ind_llb(solver::AbstractMadNLPSolver) = solver.ind_llb
-_ind_uub(solver::AbstractMadNLPSolver) = solver.ind_uub
-_x_lr(solver::AbstractMadNLPSolver) = solver.x_lr
-_x_ur(solver::AbstractMadNLPSolver) = solver.x_ur
-_xl_r(solver::AbstractMadNLPSolver) = solver.xl_r
-_xu_r(solver::AbstractMadNLPSolver) = solver.xu_r
-_zl_r(solver::AbstractMadNLPSolver) = solver.zl_r
-_zu_r(solver::AbstractMadNLPSolver) = solver.zu_r
-_dx_lr(solver::AbstractMadNLPSolver) = solver.dx_lr
-_dx_ur(solver::AbstractMadNLPSolver) = solver.dx_ur
-_x_trial_lr(solver::AbstractMadNLPSolver) = solver.x_trial_lr
-_x_trial_ur(solver::AbstractMadNLPSolver) = solver.x_trial_ur
-
-# Options
-_opt(solver::AbstractMadNLPSolver) = solver.opt
-
-# Solver state
-_status(solver::AbstractMadNLPSolver) = solver.status
-_mu(solver::AbstractMadNLPSolver) = solver.mu
-_filter(solver::AbstractMadNLPSolver) = solver.filter
-_obj_val(solver::AbstractMadNLPSolver) = solver.obj_val
-_obj_val_trial(solver::AbstractMadNLPSolver) = solver.obj_val_trial
-_inf_pr(solver::AbstractMadNLPSolver) = solver.inf_pr
-_inf_du(solver::AbstractMadNLPSolver) = solver.inf_du
-_inf_compl(solver::AbstractMadNLPSolver) = solver.inf_compl
-_theta_min(solver::AbstractMadNLPSolver) = solver.theta_min
-_theta_max(solver::AbstractMadNLPSolver) = solver.theta_max
-_tau(solver::AbstractMadNLPSolver) = solver.tau
-_alpha(solver::AbstractMadNLPSolver) = solver.alpha
-_alpha_z(solver::AbstractMadNLPSolver) = solver.alpha_z
-_ftype(solver::AbstractMadNLPSolver) = solver.ftype
-_del_w(solver::AbstractMadNLPSolver) = solver.del_w
-_del_w_last(solver::AbstractMadNLPSolver) = solver.del_w_last
-_del_c(solver::AbstractMadNLPSolver) = solver.del_c
-
-# Solver state mutators
 _status!(solver::AbstractMadNLPSolver, rhs::Status) = solver.status = rhs
 _mu!(solver::AbstractMadNLPSolver{T}, rhs::T) where{T} = solver.mu = rhs
 _obj_val!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.obj_val = rhs

--- a/src/IPM/api.jl
+++ b/src/IPM/api.jl
@@ -1,0 +1,109 @@
+# API for getting internal members of IPM
+# The idea here is that a subtype of AbstractMadNLPSolver may specialize
+# some or all of these and the core functionality of the IPM in MadNLP
+# should function as normal.
+# TODO(@anton) We could in principle write a macro to define this "automatically"
+
+# Solver data
+_kkt(solver::AbstractMadNLPSolver) = solver.kkt
+_nlp(solver::AbstractMadNLPSolver) = solver.nlp
+_cb(solver::AbstractMadNLPSolver) = solver.cb
+_cnt(solver::AbstractMadNLPSolver) = solver.cnt
+_logger(solver::AbstractMadNLPSolver) = solver.logger
+_iterator(solver::AbstractMadNLPSolver) = solver.iterator
+_RR(solver::AbstractMadNLPSolver) = solver.RR
+_output(solver::AbstractMadNLPSolver) = solver.output
+_inertia_corrector(solver::AbstractMadNLPSolver) = solver.inertia_corrector
+
+# Solver sizes
+_n(solver::AbstractMadNLPSolver) = solver.n
+_m(solver::AbstractMadNLPSolver) = solver.m
+_nlb(solver::AbstractMadNLPSolver) = solver.nlb
+_nub(solver::AbstractMadNLPSolver) = solver.nub
+
+# Solver size mutators
+_n!(solver::AbstractMadNLPSolver, rhs::Int) = solver.n = rhs
+_m!(solver::AbstractMadNLPSolver, rhs::Int) = solver.m = rhs
+_nlb!(solver::AbstractMadNLPSolver, rhs::Int) = solver.nlb = rhs
+_nub!(solver::AbstractMadNLPSolver, rhs::Int) = solver.nub = rhs
+
+# Vectors
+_x(solver::AbstractMadNLPSolver) = solver.x
+_y(solver::AbstractMadNLPSolver) = solver.y
+_zl(solver::AbstractMadNLPSolver) = solver.zl
+_xl(solver::AbstractMadNLPSolver) = solver.xl
+_zu(solver::AbstractMadNLPSolver) = solver.zu
+_xu(solver::AbstractMadNLPSolver) = solver.xu
+_f(solver::AbstractMadNLPSolver) = solver.f
+_c(solver::AbstractMadNLPSolver) = solver.c
+_jacl(solver::AbstractMadNLPSolver) = solver.jacl
+_d(solver::AbstractMadNLPSolver) = solver.d
+_p(solver::AbstractMadNLPSolver) = solver.p
+__w1(solver::AbstractMadNLPSolver) = solver._w1
+__w2(solver::AbstractMadNLPSolver) = solver._w2
+__w3(solver::AbstractMadNLPSolver) = solver._w3
+__w4(solver::AbstractMadNLPSolver) = solver._w4
+_x_trial(solver::AbstractMadNLPSolver) = solver.x_trial
+_c_trial(solver::AbstractMadNLPSolver) = solver.c_trial
+_c_slk(solver::AbstractMadNLPSolver) = solver.c_slk
+_rhs(solver::AbstractMadNLPSolver) = solver.rhs
+_ind_ineq(solver::AbstractMadNLPSolver) = solver.ind_ineq
+_ind_fixed(solver::AbstractMadNLPSolver) = solver.ind_fixed
+_ind_llb(solver::AbstractMadNLPSolver) = solver.ind_llb
+_ind_uub(solver::AbstractMadNLPSolver) = solver.ind_uub
+_x_lr(solver::AbstractMadNLPSolver) = solver.x_lr
+_x_ur(solver::AbstractMadNLPSolver) = solver.x_ur
+_xl_r(solver::AbstractMadNLPSolver) = solver.xl_r
+_xu_r(solver::AbstractMadNLPSolver) = solver.xu_r
+_zl_r(solver::AbstractMadNLPSolver) = solver.zl_r
+_zu_r(solver::AbstractMadNLPSolver) = solver.zu_r
+_dx_lr(solver::AbstractMadNLPSolver) = solver.dx_lr
+_dx_ur(solver::AbstractMadNLPSolver) = solver.dx_ur
+_x_trial_lr(solver::AbstractMadNLPSolver) = solver.x_trial_lr
+_x_trial_ur(solver::AbstractMadNLPSolver) = solver.x_trial_ur
+
+# Options
+_opt(solver::AbstractMadNLPSolver) = solver.opt
+
+# Solver state
+_status(solver::AbstractMadNLPSolver) = solver.status
+_mu(solver::AbstractMadNLPSolver) = solver.mu
+_filter(solver::AbstractMadNLPSolver) = solver.filter
+_obj_val(solver::AbstractMadNLPSolver) = solver.obj_val
+_obj_val_trial(solver::AbstractMadNLPSolver) = solver.obj_val_trial
+_inf_pr(solver::AbstractMadNLPSolver) = solver.inf_pr
+_inf_du(solver::AbstractMadNLPSolver) = solver.inf_du
+_inf_compl(solver::AbstractMadNLPSolver) = solver.inf_compl
+_theta_min(solver::AbstractMadNLPSolver) = solver.theta_min
+_theta_max(solver::AbstractMadNLPSolver) = solver.theta_max
+_tau(solver::AbstractMadNLPSolver) = solver.tau
+_alpha(solver::AbstractMadNLPSolver) = solver.alpha
+_alpha_z(solver::AbstractMadNLPSolver) = solver.alpha_z
+_ftype(solver::AbstractMadNLPSolver) = solver.ftype
+_del_w(solver::AbstractMadNLPSolver) = solver.del_w
+_del_w_last(solver::AbstractMadNLPSolver) = solver.del_w_last
+_del_c(solver::AbstractMadNLPSolver) = solver.del_c
+
+# Solver state mutators
+_status!(solver::AbstractMadNLPSolver, rhs::Status) = solver.status = rhs
+_mu!(solver::AbstractMadNLPSolver{T}, rhs::T) where{T} = solver.mu = rhs
+_obj_val!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.obj_val = rhs
+_obj_val_trial!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.obj_val_trial = rhs
+_inf_pr!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_pr = rhs
+_inf_du!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_du = rhs
+_inf_compl!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.inf_compl = rhs
+_theta_min!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.theta_min = rhs
+_theta_max!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.theta_max = rhs
+_tau!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.tau = rhs
+_alpha!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.alpha = rhs
+_alpha_z!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.alpha_z = rhs
+_ftype!(solver::AbstractMadNLPSolver, rhs::String) = solver.ftype = rhs
+_del_w!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_w = rhs
+_del_w_last!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_w_last = rhs
+_del_c!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_c = rhs
+
+# Computed quantities
+# TODO(@anton) this is probably not necessary
+_theta(solver::AbstractMadNLPSolver) = get_theta(solver.c)
+_varphi(solver::AbstractMadNLPSolver) = get_varphi(solver.obj_val, solver.x_lr, solver.xl_r, solver.xu_r, solver.x_ur, solver.mu)
+_kkt_error(solver::AbstractMadNLPSolver) = max(solver.inf_pr, solver.inf_du, solver.inf_compl)

--- a/src/IPM/api.jl
+++ b/src/IPM/api.jl
@@ -103,7 +103,7 @@ _del_w_last!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_w_l
 _del_c!(solver::AbstractMadNLPSolver{T}, rhs::T) where {T} = solver.del_c = rhs
 
 # Computed quantities
-# TODO(@anton) this is probably not necessary
-_theta(solver::AbstractMadNLPSolver) = get_theta(solver.c)
-_varphi(solver::AbstractMadNLPSolver) = get_varphi(solver.obj_val, solver.x_lr, solver.xl_r, solver.xu_r, solver.x_ur, solver.mu)
-_kkt_error(solver::AbstractMadNLPSolver) = max(solver.inf_pr, solver.inf_du, solver.inf_compl)
+# TODO(@anton) I now think these would be useful to have, but which quantities are wrapped this way is a good question
+_theta(solver::AbstractMadNLPSolver) = get_theta(_c(solver))
+_varphi(solver::AbstractMadNLPSolver) = get_varphi(_obj_val(solver), _x_lr(solver), _xl_r(solver), _xu_r(solver), _x_ur(solver), _mu(solver))
+_kkt_error(solver::AbstractMadNLPSolver) = max(_inf_pr(solver), _inf_du(solver), _inf_compl(solver))

--- a/src/IPM/barrier.jl
+++ b/src/IPM/barrier.jl
@@ -1,14 +1,5 @@
 
 """
-    AbstractBarrierUpdate{T}
-
-Abstraction used to implement the different rules to update the barrier parameter.
-The barrier is updated using either a monotone rule or an adaptive rule.
-
-"""
-abstract type AbstractBarrierUpdate{T} end
-
-"""
     update_barrier!(barrier::AbstractBarrierUpdate{T}, solver::AbstractMadNLPSolver{T}, sc::T) where T
 
 Update barrier using the rule in `barrier`. Store the results in `solver.mu`.
@@ -23,39 +14,21 @@ function _update_monotone!(
     solver::AbstractMadNLPSolver{T},
     sc::T
 ) where T
-    inf_compl_mu = get_inf_compl(
-        solver.x_lr,
-        solver.xl_r,
-        solver.zl_r,
-        solver.xu_r,
-        solver.x_ur,
-        solver.zu_r,
-        solver.mu,
-        sc,
-    )
-    while (solver.mu > max(barrier.mu_min, solver.opt.tol/10)) &&
-        (max(solver.inf_pr, solver.inf_du, inf_compl_mu) <= solver.opt.barrier_tol_factor*solver.mu)
+    set_inf_compl_mu!(solver, get_inf_compl(solver, sc))
+    while (get_mu(solver) > max(barrier.mu_min, get_opt(solver).tol/10)) &&
+        (get_inf_barrier(solver) <= get_opt(solver).barrier_tol_factor*get_mu(solver))
         mu_new = get_mu(
-            solver.mu,
+            get_mu(solver),
             barrier.mu_min,
             barrier.mu_linear_decrease_factor,
             barrier.mu_superlinear_decrease_power,
-            solver.opt.tol,
+            get_opt(solver).tol,
         )
-        inf_compl_mu = get_inf_compl(
-            solver.x_lr,
-            solver.xl_r,
-            solver.zl_r,
-            solver.xu_r,
-            solver.x_ur,
-            solver.zu_r,
-            solver.mu,
-            sc,
-        )
-        solver.tau = get_tau(solver.mu, solver.opt.tau_min)
-        solver.mu = mu_new
-        empty!(solver.filter)
-        push!(solver.filter, (solver.theta_max, -Inf))
+        set_inf_compl_mu!(solver, get_inf_compl(solver, sc))
+        set_tau!(solver, get_tau(get_mu(solver), get_opt(solver).tau_min))
+        set_mu!(solver, mu_new)
+        empty!(get_filter(solver))
+        push!(get_filter(solver), (get_theta_max(solver), -Inf))
     end
     return
 end
@@ -68,14 +41,14 @@ function _update_monotone_RR!(
     solver::AbstractMadNLPSolver{T},
     sc::T
 ) where T
-    RR = solver.RR
+    RR = get_RR(solver)
     inf_compl_mu_R = get_inf_compl_R(
-        solver.x_lr,
-        solver.xl_r,
-        solver.zl_r,
-        solver.xu_r,
-        solver.x_ur,
-        solver.zu_r,
+        get_x_lr(solver),
+        get_xl_r(solver),
+        get_zl_r(solver),
+        get_xu_r(solver),
+        get_x_ur(solver),
+        get_zu_r(solver),
         RR.pp,
         RR.zp,
         RR.nn,
@@ -84,21 +57,21 @@ function _update_monotone_RR!(
         sc,
     )
     while RR.mu_R >= barrier.mu_min &&
-        max(RR.inf_pr_R,RR.inf_du_R,inf_compl_mu_R) <= solver.opt.barrier_tol_factor*RR.mu_R
+        max(RR.inf_pr_R,RR.inf_du_R,inf_compl_mu_R) <= get_opt(solver).barrier_tol_factor*RR.mu_R
         RR.mu_R = get_mu(
             RR.mu_R,
             barrier.mu_min,
             barrier.mu_linear_decrease_factor,
             barrier.mu_superlinear_decrease_power,
-            solver.opt.tol,
+            get_opt(solver).tol,
         )
         inf_compl_mu_R = get_inf_compl_R(
-            solver.x_lr,
-            solver.xl_r,
-            solver.zl_r,
-            solver.xu_r,
-            solver.x_ur,
-            solver.zu_r,
+            get_x_lr(solver),
+            get_xl_r(solver),
+            get_zl_r(solver),
+            get_xu_r(solver),
+            get_x_ur(solver),
+            get_zu_r(solver),
             RR.pp,
             RR.zp,
             RR.nn,
@@ -106,28 +79,12 @@ function _update_monotone_RR!(
             RR.mu_R,
             sc,
         )
-        RR.tau_R= max(solver.opt.tau_min,1-RR.mu_R)
+        RR.tau_R= max(get_opt(solver).tau_min,1-RR.mu_R)
         RR.zeta = sqrt(RR.mu_R)
         empty!(RR.filter)
-        push!(RR.filter,(solver.theta_max,-Inf))
+        push!(RR.filter,(get_theta_max(solver),-Inf))
     end
     return
-end
-
-"""
-    MonotoneUpdate{T} <: AbstractBarrierUpdate{T}
-
-Update the barrier parameter using the classical Fiacco-McCormick monotone rule.
-
-"""
-@kwdef mutable struct MonotoneUpdate{T} <: AbstractBarrierUpdate{T}
-    mu_init::T = 1e-1
-    mu_min::T = 1e-11
-    mu_superlinear_decrease_power::T = 1.5
-    mu_linear_decrease_factor::T = .2
-end
-function MonotoneUpdate(tol::T, barrier_tol_factor) where T
-    return MonotoneUpdate{T}(; mu_min=min(1e-4, tol ) / (barrier_tol_factor + 1))
 end
 
 function update_barrier!(barrier::MonotoneUpdate{T}, solver::AbstractMadNLPSolver{T}, sc::T) where T
@@ -137,19 +94,6 @@ end
 #=
     Adaptive updates
 =#
-
-"""
-    AbstractAdaptiveUpdate{T} <: AbstractBarrierUpdate{T}
-
-Abstraction used to implement the adaptive barrier updates described in [Nocedal2009].
-
-## References
-[Nocedal2009] Nocedal, J., Wächter, A., & Waltz, R. A. (2009).
-Adaptive barrier update strategies for nonlinear interior methods.
-SIAM Journal on Optimization, 19(4), 1674-1693.
-
-"""
-abstract type AbstractAdaptiveUpdate{T} <: AbstractBarrierUpdate{T} end
 
 # Initial barrier parameter used when we fallback to the monotone barrier update.
 function get_fixed_mu(solver::AbstractMadNLPSolver{T}, barrier::AbstractAdaptiveUpdate{T}) where T
@@ -164,98 +108,66 @@ function _check_progress(barrier::AbstractAdaptiveUpdate{T}, solver::AbstractMad
     kappa_1 = T(1e-5) # filter margin width
     kappa_2 = T(1.0)  # filter margin maximum width
     # Check current progress using filter line search
-    theta = get_theta(solver.c)
-    varphi = get_varphi(solver.obj_val, solver.x_lr, solver.xl_r, solver.xu_r, solver.x_ur, solver.mu)
-    kkt_error = max(solver.inf_pr, solver.inf_du, solver.inf_compl)
+    theta = get_theta(get_c(solver))
+    varphi = get_varphi(get_obj_val(solver), get_x_lr(solver), get_xl_r(solver), get_xu_r(solver), get_x_ur(solver), get_mu(solver))
+    kkt_error = max(get_inf_pr(solver), get_inf_du(solver), get_inf_compl(solver))
     delta = kappa_1 * min(kappa_2, kkt_error)
-    return is_filter_acceptable(solver.filter, theta + delta, varphi + delta)
+    return is_filter_acceptable(get_filter(solver), theta + delta, varphi + delta)
 end
 
 function update_barrier!(barrier::AbstractAdaptiveUpdate{T}, solver::AbstractMadNLPSolver{T}, sc::T) where T
-    old_mu = solver.mu
+    old_mu = get_mu(solver)
     progress = _check_progress(barrier, solver)
     # Update state of barrier algorithm
     if !barrier.free_mode
         if progress
-            @trace(solver.logger, "Moving adaptive barrier back to free mode.")
+            @trace(get_logger(solver), "Moving adaptive barrier back to free mode.")
             barrier.free_mode = true
         else
             _update_monotone!(barrier, solver, sc)
         end
     else
         if !progress
-            @trace(solver.logger, "Moving adaptive barrier to monotone mode.")
+            @trace(get_logger(solver), "Moving adaptive barrier to monotone mode.")
             barrier.free_mode = false
             # Reset barrier parameter using current average complementarity
-            solver.mu = get_fixed_mu(solver, barrier)
+            set_mu!(solver, get_fixed_mu(solver, barrier))
         else
-            @trace(solver.logger, "Keeping adaptive barrier in free mode.")
+            @trace(get_logger(solver), "Keeping adaptive barrier in free mode.")
         end
     end
     if barrier.free_mode
-        solver.mu = get_adaptive_mu(solver, barrier)
+        set_mu!(solver, get_adaptive_mu(solver, barrier))
     end
     # Update tau and reset filter is barrier has been updated
-    if solver.mu != old_mu
-        solver.tau = get_tau(solver.mu, solver.opt.tau_min)
-        empty!(solver.filter)
-        push!(solver.filter, (solver.theta_max, -Inf))
+    if get_mu(solver) != old_mu
+        set_tau!(solver, get_tau(get_mu(solver), get_opt(solver).tau_min))
+        empty!(get_filter(solver))
+        push!(get_filter(solver), (get_theta_max(solver), -Inf))
     end
     return
 end
 
-"""
-    QualityFunctionUpdate{T} <: AbstractAdaptiveUpdate{T}
-
-Find the barrier parameter using a quality function encoding the ℓ1-norm of the KKT violations.
-At each IPM iteration, the minimum of the quality function is found using a Golden search algorithm.
-
-If no sufficient progress is made, the barrier fallbacks to a monotone rule.
-
-## References
-The algorithm is described in [Nocedal2009, Section 4].
-
-"""
-@kwdef mutable struct QualityFunctionUpdate{T} <: AbstractAdaptiveUpdate{T}
-    mu_init::T = 1e-1
-    mu_min::T = 1e-11
-    mu_max::T = 1e5
-    sigma_min::T = 1e-6
-    sigma_max::T = 1e2
-    sigma_tol::T = 1e-2
-    gamma::T = 1.0
-    max_gs_iter::Int = 8
-    # For non-free mode
-    mu_superlinear_decrease_power::T = 1.5
-    mu_linear_decrease_factor::T = .2
-    free_mode::Bool = true
-    globalization::Bool = true
-    n_update::Int = 0
-end
-function QualityFunctionUpdate(tol::T, barrier_tol_factor) where T
-    return QualityFunctionUpdate{T}(; mu_min=min(1e-4, tol ) / (barrier_tol_factor + 1))
-end
-
 # Evaluate the linear quality function described in [Nocedal2009, Eq. (4.2)]
 function _evaluate_quality_function(solver, sigma, step_aff, step_cen, res_dual, res_primal)
-    n, m = solver.n, solver.m
-    nlb, nub = solver.nlb, solver.nub
-    tau = solver.tau
-    d = solver.d # Load buffer
+    n, m = get_n(solver), get_m(solver)
+    nlb, nub = get_nlb(solver), get_nub(solver)
+    tau = get_tau(solver)
+    d = get_d(solver) # Load buffer
     # Δ(σ) = Δ_aff + σ Δ_cen
     full(d) .= full(step_aff) .+ sigma .* full(step_cen)
     # Primal step
     alpha_pr = get_alpha_max(
-        primal(solver.x),
-        primal(solver.xl),
-        primal(solver.xu),
+        primal(get_x(solver)),
+        primal(get_xl(solver)),
+        primal(get_xu(solver)),
         primal(d),
         tau,
     )
     # Dual step
     alpha_du = get_alpha_z(
-        solver.zl_r,
-        solver.zu_r,
+        get_zl_r(solver),
+        get_zu_r(solver),
         dual_lb(d),
         dual_ub(d),
         tau,
@@ -264,7 +176,7 @@ function _evaluate_quality_function(solver, sigma, step_aff, step_cen, res_dual,
     inf_compl_lb = mapreduce(
         (x, xl, dx, z, dz) -> ((x + alpha_pr * dx - xl) * (z + alpha_du * dz))^2,
         +,
-        solver.x_lr, solver.xl_r, solver.dx_lr, solver.zl_r, dual_lb(d);
+        get_x_lr(solver), get_xl_r(solver), get_dx_lr(solver), get_zl_r(solver), dual_lb(d);
         init=0.0,
     )
 
@@ -272,7 +184,7 @@ function _evaluate_quality_function(solver, sigma, step_aff, step_cen, res_dual,
     inf_compl_ub = mapreduce(
         (x, xu, dx, z, dz) -> ((xu - x - alpha_pr * dx) * (z + alpha_du * dz))^2,
         +,
-        solver.x_ur, solver.xu_r, solver.dx_ur, solver.zu_r, dual_ub(d);
+        get_x_ur(solver), get_xu_r(solver), get_dx_ur(solver), get_zu_r(solver), dual_ub(d);
         init=0.0,
     )
     # Primal infeasibility
@@ -282,7 +194,7 @@ function _evaluate_quality_function(solver, sigma, step_aff, step_cen, res_dual,
     # Complementarity infeasibility
     inf_compl = (inf_compl_lb + inf_compl_ub ) / (nlb + nub)
 
-    @debug(solver.logger, @sprintf("sigma=%4.1e inf_pr=%4.2e inf_du=%4.2e inf_cc=%4.2e a_pr=%4.2e a_du=%4.2e", sigma, inf_pr, inf_du, inf_compl, alpha_pr, alpha_du))
+    @debug(get_logger(solver), @sprintf("sigma=%4.1e inf_pr=%4.2e inf_du=%4.2e inf_cc=%4.2e a_pr=%4.2e a_du=%4.2e", sigma, inf_pr, inf_du, inf_compl, alpha_pr, alpha_du))
 
     # Return quality function qL defined in Eq. (4.2)
     return inf_du + inf_pr + inf_compl
@@ -334,10 +246,10 @@ function _run_golden_search!(solver, barrier, sigma_lb, sigma_ub, step_aff, step
 end
 
 function set_centering_aug_rhs!(solver::AbstractMadNLPSolver, kkt::AbstractKKTSystem, mu)
-    px = primal(solver.p)
-    py = dual(solver.p)
-    pzl = dual_lb(solver.p)
-    pzu = dual_ub(solver.p)
+    px = primal(get_p(solver))
+    py = dual(get_p(solver))
+    pzl = dual_lb(get_p(solver))
+    pzu = dual_ub(get_p(solver))
     px .= 0
     py .= 0
     pzl .= mu
@@ -347,28 +259,28 @@ end
 
 function get_adaptive_mu(solver::AbstractMadNLPSolver{T}, barrier::QualityFunctionUpdate{T}) where T
     # No inequality constraint: early return as barrier update is useless
-    if solver.nlb + solver.nub == 0
+    if get_nlb(solver) + get_nub(solver) == 0
         return barrier.mu_min
     end
-    step_aff = solver._w3 # buffer 1
-    step_cen = solver._w4 # buffer 2
+    step_aff = get__w3(solver) # buffer 1
+    step_cen = get__w4(solver) # buffer 2
     # Affine step
-    set_aug_rhs!(solver, solver.kkt, solver.c, zero(T))
+    set_aug_rhs!(solver, get_kkt(solver), get_c(solver), zero(T))
     # Get primal and dual infeasibility directly from the values in RHS p
-    res_primal = norm(dual(solver.p))
-    res_dual = norm(primal(solver.p))
+    res_primal = norm(dual(get_p(solver)))
+    res_dual = norm(primal(get_p(solver)))
     # Get approximate solution without iterative refinement
-    copyto!(full(step_aff), full(solver.p))
-    solve!(solver.kkt, step_aff)
+    copyto!(full(step_aff), full(get_p(solver)))
+    solve!(get_kkt(solver), step_aff)
     # Get average complementarity
     mu = get_average_complementarity(solver)
     # Centering step
-    set_centering_aug_rhs!(solver, solver.kkt, mu)
+    set_centering_aug_rhs!(solver, get_kkt(solver), mu)
     # NOTE(@anton) Ipopt also applies the dual infeasibility perturbation for some reason???
-    dual_inf_perturbation!(primal(solver.p),solver.ind_llb,solver.ind_uub,mu,solver.opt.kappa_d)
+    dual_inf_perturbation!(primal(get_p(solver)),get_ind_llb(solver),get_ind_uub(solver),mu,get_opt(solver).kappa_d)
     # Get (again) approximate solution without iterative refinement
-    copyto!(full(step_cen), full(solver.p))
-    solve!(solver.kkt, step_cen)
+    copyto!(full(step_cen), full(get_p(solver)))
+    solve!(get_kkt(solver), step_cen)
     # Refine the search interval using Ipopt's heuristics
     # First, check if sigma is greater than 1.
     phi1 = _evaluate_quality_function(solver, one(T), step_aff, step_cen, res_primal, res_dual)
@@ -389,40 +301,13 @@ function get_adaptive_mu(solver::AbstractMadNLPSolver{T}, barrier::QualityFuncti
     return clamp(sigma_opt * mu, barrier.mu_min, barrier.mu_max)
 end
 
-"""
-    LOQOUpdate{T} <: AbstractAdaptiveUpdate{T}
-
-Find the barrier parameter using the rule used in the LOQO solver.
-The rule is explicited in [Nocedal2009, Eq (3.6)].
-
-If no sufficient progress is made, the barrier fallbacks to a monotone rule.
-
-## References
-The algorithm is described in [Nocedal2009, Section 3].
-
-"""
-@kwdef mutable struct LOQOUpdate{T} <: AbstractAdaptiveUpdate{T}
-    mu_init::T = 1e-1
-    mu_min::T = 1e-11
-    mu_max::T = 1e5
-    gamma::T = 0.1 # scale factor
-    r::T = .95 # Steplength param
-    mu_superlinear_decrease_power::T = 1.5
-    mu_linear_decrease_factor::T = .2
-    free_mode::Bool = true
-    globalization::Bool = true
-end
-function LOQOUpdate(tol::T, barrier_tol_factor) where T
-    return LOQOUpdate{T}(; mu_min=min(1e-4, tol ) / (barrier_tol_factor + 1))
-end
-
 function get_adaptive_mu(solver::AbstractMadNLPSolver{T}, barrier::LOQOUpdate{T}) where T
     # No inequality constraint: early return as barrier update is useless
-    if solver.nlb + solver.nub == 0
+    if get_nlb(solver) + get_nub(solver) == 0
         return barrier.mu_min
     end
     mu = get_average_complementarity(solver) # get average complementarity.
-    ncc = solver.nlb + solver.nub
+    ncc = get_nlb(solver) + get_nub(solver)
     min_cc = get_min_complementarity(solver)
     xi = min_cc/mu
     sigma = barrier.gamma*min((1-barrier.r)*((1-xi)/xi),2)^3

--- a/src/IPM/callbacks.jl
+++ b/src/IPM/callbacks.jl
@@ -1,4 +1,4 @@
-function eval_f_wrapper(solver::AbstractMadNLPSolver, x::PrimalVector{T}) where T
+function eval_f_wrapper(solver::AbstractMadNLPSolver{T}, x::PrimalVector{T}) where T
     nlp = _nlp(solver)
     cnt = _cnt(solver)
     @trace(_logger(solver),"Evaluating objective.")

--- a/src/IPM/callbacks.jl
+++ b/src/IPM/callbacks.jl
@@ -1,10 +1,10 @@
 function eval_f_wrapper(solver::AbstractMadNLPSolver{T}, x::PrimalVector{T}) where T
-    nlp = _nlp(solver)
-    cnt = _cnt(solver)
-    @trace(_logger(solver),"Evaluating objective.")
+    nlp = get_nlp(solver)
+    cnt = get_cnt(solver)
+    @trace(get_logger(solver),"Evaluating objective.")
     cnt.eval_function_time += @elapsed begin
         sense = (get_minimize(nlp) ? one(T) : -one(T))
-        obj_val = sense * _eval_f_wrapper(_cb(solver), variable(x))
+        obj_val = sense * _eval_f_wrapper(get_cb(solver), variable(x))
     end
     cnt.obj_cnt += 1
     if cnt.obj_cnt == 1 && !is_valid(obj_val)
@@ -14,11 +14,11 @@ function eval_f_wrapper(solver::AbstractMadNLPSolver{T}, x::PrimalVector{T}) whe
 end
 
 function eval_grad_f_wrapper!(solver::AbstractMadNLPSolver, f::PrimalVector{T}, x::PrimalVector{T}) where T
-    nlp = _nlp(solver)
-    cnt = _cnt(solver)
-    @trace(_logger(solver),"Evaluating objective gradient.")
+    nlp = get_nlp(solver)
+    cnt = get_cnt(solver)
+    @trace(get_logger(solver),"Evaluating objective gradient.")
     cnt.eval_function_time += @elapsed _eval_grad_f_wrapper!(
-        _cb(solver),
+        get_cb(solver),
         variable(x),
         variable(f),
     )
@@ -34,16 +34,16 @@ function eval_grad_f_wrapper!(solver::AbstractMadNLPSolver, f::PrimalVector{T}, 
 end
 
 function eval_cons_wrapper!(solver::AbstractMadNLPSolver, c::AbstractVector{T}, x::PrimalVector{T}) where T
-    nlp = _nlp(solver)
-    cnt = _cnt(solver)
-    @trace(_logger(solver), "Evaluating constraints.")
+    nlp = get_nlp(solver)
+    cnt = get_cnt(solver)
+    @trace(get_logger(solver), "Evaluating constraints.")
     cnt.eval_function_time += @elapsed _eval_cons_wrapper!(
-        _cb(solver),
+        get_cb(solver),
         variable(x),
         c,
     )
-    view(c,_ind_ineq(solver)) .-= slack(x)
-    c .-= _rhs(solver)
+    view(c,get_ind_ineq(solver)) .-= slack(x)
+    c .-= get_rhs(solver)
     cnt.con_cnt+=1
     if cnt.con_cnt == 1 && !is_valid(c)
         throw(InvalidNumberException(:cons))
@@ -52,13 +52,13 @@ function eval_cons_wrapper!(solver::AbstractMadNLPSolver, c::AbstractVector{T}, 
 end
 
 function eval_jac_wrapper!(solver::AbstractMadNLPSolver, kkt::AbstractKKTSystem, x::PrimalVector{T}) where T
-    nlp = _nlp(solver)
-    cnt = _cnt(solver)
-    ns = length(_ind_ineq(solver))
-    @trace(_logger(solver), "Evaluating constraint Jacobian.")
+    nlp = get_nlp(solver)
+    cnt = get_cnt(solver)
+    ns = length(get_ind_ineq(solver))
+    @trace(get_logger(solver), "Evaluating constraint Jacobian.")
     jac = get_jacobian(kkt)
     cnt.eval_function_time += @elapsed _eval_jac_wrapper!(
-        _cb(solver),
+        get_cb(solver),
         variable(x),
         jac,
         )
@@ -67,18 +67,18 @@ function eval_jac_wrapper!(solver::AbstractMadNLPSolver, kkt::AbstractKKTSystem,
     if cnt.con_jac_cnt == 1 && !is_valid(jac)
         throw(InvalidNumberException(:jac))
     end
-    @trace(_logger(solver),"Constraint jacobian evaluation started.")
+    @trace(get_logger(solver),"Constraint jacobian evaluation started.")
     return jac
 end
 
 function eval_lag_hess_wrapper!(solver::AbstractMadNLPSolver, kkt::AbstractKKTSystem, x::PrimalVector{T},l::AbstractVector{T};is_resto=false) where T
-    nlp = _nlp(solver)
-    cnt = _cnt(solver)
-    @trace(_logger(solver),"Evaluating Lagrangian Hessian.")
+    nlp = get_nlp(solver)
+    cnt = get_cnt(solver)
+    @trace(get_logger(solver),"Evaluating Lagrangian Hessian.")
     hess = get_hessian(kkt)
     scale = (get_minimize(nlp) ? one(T) : -one(T)) * (is_resto ? zero(T) : one(T))
     cnt.eval_function_time += @elapsed _eval_lag_hess_wrapper!(
-        _cb(solver),
+        get_cb(solver),
         variable(x),
         l,
         hess;
@@ -93,13 +93,13 @@ function eval_lag_hess_wrapper!(solver::AbstractMadNLPSolver, kkt::AbstractKKTSy
 end
 
 function eval_jac_wrapper!(solver::AbstractMadNLPSolver, kkt::AbstractDenseKKTSystem, x::PrimalVector{T}) where T
-    nlp = _nlp(solver)
-    cnt = _cnt(solver)
-    ns = length(_ind_ineq(solver))
-    @trace(_logger(solver), "Evaluating constraint Jacobian.")
+    nlp = get_nlp(solver)
+    cnt = get_cnt(solver)
+    ns = length(get_ind_ineq(solver))
+    @trace(get_logger(solver), "Evaluating constraint Jacobian.")
     jac = get_jacobian(kkt)
     cnt.eval_function_time += @elapsed _eval_jac_wrapper!(
-        _cb(solver),
+        get_cb(solver),
         variable(x),
         jac,
     )
@@ -108,7 +108,7 @@ function eval_jac_wrapper!(solver::AbstractMadNLPSolver, kkt::AbstractDenseKKTSy
     if cnt.con_jac_cnt == 1 && !is_valid(jac)
         throw(InvalidNumberException(:jac))
     end
-    @trace(_logger(solver),"Constraint jacobian evaluation started.")
+    @trace(get_logger(solver),"Constraint jacobian evaluation started.")
     return jac
 end
 
@@ -119,13 +119,13 @@ function eval_lag_hess_wrapper!(
     l::AbstractVector{T};
     is_resto=false,
 ) where {T, VT, MT, QN<:ExactHessian}
-    nlp = _nlp(solver)
-    cnt = _cnt(solver)
-    @trace(_logger(solver),"Evaluating Lagrangian Hessian.")
+    nlp = get_nlp(solver)
+    cnt = get_cnt(solver)
+    @trace(get_logger(solver),"Evaluating Lagrangian Hessian.")
     hess = get_hessian(kkt)
     scale = is_resto ? zero(T) : get_minimize(nlp) ? one(T) : -one(T)
     cnt.eval_function_time += @elapsed _eval_lag_hess_wrapper!(
-        _cb(solver),
+        get_cb(solver),
         variable(x),
         l,
         hess;
@@ -146,9 +146,9 @@ function eval_lag_hess_wrapper!(
     l::AbstractVector{T};
     is_resto=false,
 ) where {T, VT, MT<:AbstractMatrix{T}, QN<:AbstractQuasiNewton{T, VT}}
-    cb = _cb(solver)
-    cnt = _cnt(solver)
-    @trace(_logger(solver), "Update BFGS matrices.")
+    cb = get_cb(solver)
+    cnt = get_cnt(solver)
+    @trace(get_logger(solver), "Update BFGS matrices.")
 
     qn = kkt.quasi_newton
     Bk = kkt.hess
@@ -158,14 +158,14 @@ function eval_lag_hess_wrapper!(
 
     if cnt.obj_grad_cnt >= 2
         # Build sk = x+ - x
-        copyto!(sk, 1, variable(_x(solver)), 1, n)   # sₖ = x₊
+        copyto!(sk, 1, variable(get_x(solver)), 1, n)   # sₖ = x₊
         axpy!(-one(T), qn.last_x, sk)              # sₖ = x₊ - x
         # Build yk = ∇L+ - ∇L
-        copyto!(yk, 1, variable(_f(solver)), 1, n)   # yₖ = ∇f₊
+        copyto!(yk, 1, variable(get_f(solver)), 1, n)   # yₖ = ∇f₊
         axpy!(-one(T), qn.last_g, yk)              # yₖ = ∇f₊ - ∇f
         if m > 0
-            jtprod!(_jacl(solver), kkt, l)
-            yk .+= @view(_jacl(solver)[1:n])         # yₖ += J₊ᵀ l₊
+            jtprod!(get_jacl(solver), kkt, l)
+            yk .+= @view(get_jacl(solver)[1:n])         # yₖ += J₊ᵀ l₊
             _eval_jtprod_wrapper!(cb, qn.last_x, l, qn.last_jv)
             axpy!(-one(T), qn.last_jv, yk)         # yₖ += J₊ᵀ l₊ - Jᵀ l₊
         end
@@ -173,14 +173,14 @@ function eval_lag_hess_wrapper!(
         update!(qn, Bk, sk, yk)
     else
         # Init quasi-Newton approximation
-        g0 = variable(_f(solver))
-        f0 = _obj_val(solver)
+        g0 = variable(get_f(solver))
+        f0 = get_obj_val(solver)
         init!(qn, Bk, g0, f0)
     end
 
     # Backup data for next step
-    copyto!(qn.last_x, 1, variable(_x(solver)), 1, n)
-    copyto!(qn.last_g, 1, variable(_f(solver)), 1, n)
+    copyto!(qn.last_x, 1, variable(get_x(solver)), 1, n)
+    copyto!(qn.last_g, 1, variable(get_f(solver)), 1, n)
 
     compress_hessian!(kkt)
     return get_hessian(kkt)

--- a/src/IPM/callbacks.jl
+++ b/src/IPM/callbacks.jl
@@ -1,10 +1,10 @@
 function eval_f_wrapper(solver::AbstractMadNLPSolver, x::PrimalVector{T}) where T
-    nlp = solver.nlp
-    cnt = solver.cnt
-    @trace(solver.logger,"Evaluating objective.")
+    nlp = _nlp(solver)
+    cnt = _cnt(solver)
+    @trace(_logger(solver),"Evaluating objective.")
     cnt.eval_function_time += @elapsed begin
         sense = (get_minimize(nlp) ? one(T) : -one(T))
-        obj_val = sense * _eval_f_wrapper(solver.cb, variable(x))
+        obj_val = sense * _eval_f_wrapper(_cb(solver), variable(x))
     end
     cnt.obj_cnt += 1
     if cnt.obj_cnt == 1 && !is_valid(obj_val)
@@ -14,11 +14,11 @@ function eval_f_wrapper(solver::AbstractMadNLPSolver, x::PrimalVector{T}) where 
 end
 
 function eval_grad_f_wrapper!(solver::AbstractMadNLPSolver, f::PrimalVector{T}, x::PrimalVector{T}) where T
-    nlp = solver.nlp
-    cnt = solver.cnt
-    @trace(solver.logger,"Evaluating objective gradient.")
+    nlp = _nlp(solver)
+    cnt = _cnt(solver)
+    @trace(_logger(solver),"Evaluating objective gradient.")
     cnt.eval_function_time += @elapsed _eval_grad_f_wrapper!(
-        solver.cb,
+        _cb(solver),
         variable(x),
         variable(f),
     )
@@ -34,16 +34,16 @@ function eval_grad_f_wrapper!(solver::AbstractMadNLPSolver, f::PrimalVector{T}, 
 end
 
 function eval_cons_wrapper!(solver::AbstractMadNLPSolver, c::AbstractVector{T}, x::PrimalVector{T}) where T
-    nlp = solver.nlp
-    cnt = solver.cnt
-    @trace(solver.logger, "Evaluating constraints.")
+    nlp = _nlp(solver)
+    cnt = _cnt(solver)
+    @trace(_logger(solver), "Evaluating constraints.")
     cnt.eval_function_time += @elapsed _eval_cons_wrapper!(
-        solver.cb,
+        _cb(solver),
         variable(x),
         c,
     )
-    view(c,solver.ind_ineq) .-= slack(x)
-    c .-= solver.rhs
+    view(c,_ind_ineq(solver)) .-= slack(x)
+    c .-= _rhs(solver)
     cnt.con_cnt+=1
     if cnt.con_cnt == 1 && !is_valid(c)
         throw(InvalidNumberException(:cons))
@@ -52,13 +52,13 @@ function eval_cons_wrapper!(solver::AbstractMadNLPSolver, c::AbstractVector{T}, 
 end
 
 function eval_jac_wrapper!(solver::AbstractMadNLPSolver, kkt::AbstractKKTSystem, x::PrimalVector{T}) where T
-    nlp = solver.nlp
-    cnt = solver.cnt
-    ns = length(solver.ind_ineq)
-    @trace(solver.logger, "Evaluating constraint Jacobian.")
+    nlp = _nlp(solver)
+    cnt = _cnt(solver)
+    ns = length(_ind_ineq(solver))
+    @trace(_logger(solver), "Evaluating constraint Jacobian.")
     jac = get_jacobian(kkt)
     cnt.eval_function_time += @elapsed _eval_jac_wrapper!(
-        solver.cb,
+        _cb(solver),
         variable(x),
         jac,
         )
@@ -67,18 +67,18 @@ function eval_jac_wrapper!(solver::AbstractMadNLPSolver, kkt::AbstractKKTSystem,
     if cnt.con_jac_cnt == 1 && !is_valid(jac)
         throw(InvalidNumberException(:jac))
     end
-    @trace(solver.logger,"Constraint jacobian evaluation started.")
+    @trace(_logger(solver),"Constraint jacobian evaluation started.")
     return jac
 end
 
 function eval_lag_hess_wrapper!(solver::AbstractMadNLPSolver, kkt::AbstractKKTSystem, x::PrimalVector{T},l::AbstractVector{T};is_resto=false) where T
-    nlp = solver.nlp
-    cnt = solver.cnt
-    @trace(solver.logger,"Evaluating Lagrangian Hessian.")
+    nlp = _nlp(solver)
+    cnt = _cnt(solver)
+    @trace(_logger(solver),"Evaluating Lagrangian Hessian.")
     hess = get_hessian(kkt)
     scale = (get_minimize(nlp) ? one(T) : -one(T)) * (is_resto ? zero(T) : one(T))
     cnt.eval_function_time += @elapsed _eval_lag_hess_wrapper!(
-        solver.cb,
+        _cb(solver),
         variable(x),
         l,
         hess;
@@ -93,13 +93,13 @@ function eval_lag_hess_wrapper!(solver::AbstractMadNLPSolver, kkt::AbstractKKTSy
 end
 
 function eval_jac_wrapper!(solver::AbstractMadNLPSolver, kkt::AbstractDenseKKTSystem, x::PrimalVector{T}) where T
-    nlp = solver.nlp
-    cnt = solver.cnt
-    ns = length(solver.ind_ineq)
-    @trace(solver.logger, "Evaluating constraint Jacobian.")
+    nlp = _nlp(solver)
+    cnt = _cnt(solver)
+    ns = length(_ind_ineq(solver))
+    @trace(_logger(solver), "Evaluating constraint Jacobian.")
     jac = get_jacobian(kkt)
     cnt.eval_function_time += @elapsed _eval_jac_wrapper!(
-        solver.cb,
+        _cb(solver),
         variable(x),
         jac,
     )
@@ -108,7 +108,7 @@ function eval_jac_wrapper!(solver::AbstractMadNLPSolver, kkt::AbstractDenseKKTSy
     if cnt.con_jac_cnt == 1 && !is_valid(jac)
         throw(InvalidNumberException(:jac))
     end
-    @trace(solver.logger,"Constraint jacobian evaluation started.")
+    @trace(_logger(solver),"Constraint jacobian evaluation started.")
     return jac
 end
 
@@ -119,13 +119,13 @@ function eval_lag_hess_wrapper!(
     l::AbstractVector{T};
     is_resto=false,
 ) where {T, VT, MT, QN<:ExactHessian}
-    nlp = solver.nlp
-    cnt = solver.cnt
-    @trace(solver.logger,"Evaluating Lagrangian Hessian.")
+    nlp = _nlp(solver)
+    cnt = _cnt(solver)
+    @trace(_logger(solver),"Evaluating Lagrangian Hessian.")
     hess = get_hessian(kkt)
     scale = is_resto ? zero(T) : get_minimize(nlp) ? one(T) : -one(T)
     cnt.eval_function_time += @elapsed _eval_lag_hess_wrapper!(
-        solver.cb,
+        _cb(solver),
         variable(x),
         l,
         hess;
@@ -146,9 +146,9 @@ function eval_lag_hess_wrapper!(
     l::AbstractVector{T};
     is_resto=false,
 ) where {T, VT, MT<:AbstractMatrix{T}, QN<:AbstractQuasiNewton{T, VT}}
-    cb = solver.cb
-    cnt = solver.cnt
-    @trace(solver.logger, "Update BFGS matrices.")
+    cb = _cb(solver)
+    cnt = _cnt(solver)
+    @trace(_logger(solver), "Update BFGS matrices.")
 
     qn = kkt.quasi_newton
     Bk = kkt.hess
@@ -158,14 +158,14 @@ function eval_lag_hess_wrapper!(
 
     if cnt.obj_grad_cnt >= 2
         # Build sk = x+ - x
-        copyto!(sk, 1, variable(solver.x), 1, n)   # sₖ = x₊
+        copyto!(sk, 1, variable(_x(solver)), 1, n)   # sₖ = x₊
         axpy!(-one(T), qn.last_x, sk)              # sₖ = x₊ - x
         # Build yk = ∇L+ - ∇L
-        copyto!(yk, 1, variable(solver.f), 1, n)   # yₖ = ∇f₊
+        copyto!(yk, 1, variable(_f(solver)), 1, n)   # yₖ = ∇f₊
         axpy!(-one(T), qn.last_g, yk)              # yₖ = ∇f₊ - ∇f
         if m > 0
-            jtprod!(solver.jacl, kkt, l)
-            yk .+= @view(solver.jacl[1:n])         # yₖ += J₊ᵀ l₊
+            jtprod!(_jacl(solver), kkt, l)
+            yk .+= @view(_jacl(solver)[1:n])         # yₖ += J₊ᵀ l₊
             _eval_jtprod_wrapper!(cb, qn.last_x, l, qn.last_jv)
             axpy!(-one(T), qn.last_jv, yk)         # yₖ += J₊ᵀ l₊ - Jᵀ l₊
         end
@@ -173,14 +173,14 @@ function eval_lag_hess_wrapper!(
         update!(qn, Bk, sk, yk)
     else
         # Init quasi-Newton approximation
-        g0 = variable(solver.f)
-        f0 = solver.obj_val
+        g0 = variable(_f(solver))
+        f0 = _obj_val(solver)
         init!(qn, Bk, g0, f0)
     end
 
     # Backup data for next step
-    copyto!(qn.last_x, 1, variable(solver.x), 1, n)
-    copyto!(qn.last_g, 1, variable(solver.f), 1, n)
+    copyto!(qn.last_x, 1, variable(_x(solver)), 1, n)
+    copyto!(qn.last_g, 1, variable(_f(solver)), 1, n)
 
     compress_hessian!(kkt)
     return get_hessian(kkt)

--- a/src/IPM/factorization.jl
+++ b/src/IPM/factorization.jl
@@ -1,12 +1,12 @@
 function solve_refine_wrapper!(d, solver, p, w)
     result = false
 
-    solver.cnt.linear_solver_time += @elapsed begin
-        if solve_refine!(d, solver.iterator, p, w)
+    _cnt(solver).linear_solver_time += @elapsed begin
+        if solve_refine!(d, _iterator(solver), p, w)
             result = true
         else
-            if improve!(solver.kkt.linear_solver)
-                if solve_refine!(d, solver.iterator, p, w)
+            if improve!(_kkt(solver).linear_solver)
+                if solve_refine!(d, _iterator(solver), p, w)
                     result = true
                 end
             end
@@ -17,9 +17,9 @@ function solve_refine_wrapper!(d, solver, p, w)
 end
 
 function factorize_wrapper!(solver::AbstractMadNLPSolver)
-    @trace(solver.logger,"Factorization started.")
-    build_kkt!(solver.kkt)
-    solver.cnt.linear_solver_time += @elapsed factorize!(solver.kkt.linear_solver)
+    @trace(_logger(solver),"Factorization started.")
+    build_kkt!(_kkt(solver))
+    _cnt(solver).linear_solver_time += @elapsed factorize!(_kkt(solver).linear_solver)
 end
 
 function solve!(kkt::SparseUnreducedKKTSystem, w::AbstractKKTVector)

--- a/src/IPM/factorization.jl
+++ b/src/IPM/factorization.jl
@@ -1,12 +1,12 @@
 function solve_refine_wrapper!(d, solver, p, w)
     result = false
 
-    _cnt(solver).linear_solver_time += @elapsed begin
-        if solve_refine!(d, _iterator(solver), p, w)
+    get_cnt(solver).linear_solver_time += @elapsed begin
+        if solve_refine!(d, get_iterator(solver), p, w)
             result = true
         else
-            if improve!(_kkt(solver).linear_solver)
-                if solve_refine!(d, _iterator(solver), p, w)
+            if improve!(get_kkt(solver).linear_solver)
+                if solve_refine!(d, get_iterator(solver), p, w)
                     result = true
                 end
             end
@@ -17,9 +17,9 @@ function solve_refine_wrapper!(d, solver, p, w)
 end
 
 function factorize_wrapper!(solver::AbstractMadNLPSolver)
-    @trace(_logger(solver),"Factorization started.")
-    build_kkt!(_kkt(solver))
-    _cnt(solver).linear_solver_time += @elapsed factorize!(_kkt(solver).linear_solver)
+    @trace(get_logger(solver),"Factorization started.")
+    build_kkt!(get_kkt(solver))
+    get_cnt(solver).linear_solver_time += @elapsed factorize!(get_kkt(solver).linear_solver)
 end
 
 function solve!(kkt::SparseUnreducedKKTSystem, w::AbstractKKTVector)

--- a/src/IPM/inertiacorrector.jl
+++ b/src/IPM/inertiacorrector.jl
@@ -1,19 +1,3 @@
-abstract type AbstractInertiaCorrector end
-struct InertiaAuto <: AbstractInertiaCorrector end
-struct InertiaBased <: AbstractInertiaCorrector end
-struct InertiaIgnore <: AbstractInertiaCorrector end
-struct InertiaFree{
-    T,
-    VT <: AbstractVector{T},
-    KKTVec <: AbstractKKTVector{T, VT}
-} <: AbstractInertiaCorrector 
-    p0::KKTVec
-    d0::KKTVec
-    t::VT
-    wx::VT
-    g::VT
-end
-
 function build_inertia_corrector(::Type{InertiaBased}, ::Type{VT}, n, m, nlb, nub, ind_lb, ind_ub) where VT
     return InertiaBased()
 end

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -940,9 +940,9 @@ function eval_for_next_iter!(solver::AbstractMadNLPSolver)
         full(get_zl(solver)),
         full(get_zu(solver)),
         get_jacl(solver),
-        _sd(solver),
+        get_sd(solver),
     ))
-    set_inf_compl!(solver, get_inf_compl(solver, sc; mu=zero(T)))
+    set_inf_compl!(solver, get_inf_compl(solver, get_sc(solver); mu=zero(T)))
     set_inf_compl_mu!(get_inf_compl(solver))
 end
 
@@ -1035,15 +1035,15 @@ function eval_for_next_iter_RR!(solver::AbstractMadNLPSolver)
         get_jacl(solver),
         sd,
     ))
-    set_inf_compl!(solver, get_inf_compl(get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),zero(T),sc))
+    set_inf_compl!(solver, get_inf_compl(get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),zero(T),get_sc(solver)))
 
     # Robust restoration phase error
     RR.inf_pr_R = get_inf_pr_R(get_c(solver),RR.pp,RR.nn)
-    RR.inf_du_R = get_inf_du_R(RR.f_R,get_y(solver),primal(get_zl(solver)),primal(get_zu(solver)),get_jacl(solver),RR.zp,RR.zn,get_opt(solver).rho,sd)
+    RR.inf_du_R = get_inf_du_R(RR.f_R,get_y(solver),primal(get_zl(solver)),primal(get_zu(solver)),get_jacl(solver),RR.zp,RR.zn,get_opt(solver).rho,get_sd(solver))
     RR.inf_compl_R = get_inf_compl_R(
-        get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),RR.pp,RR.zp,RR.nn,RR.zn,zero(T),sc)
+        get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),RR.pp,RR.zp,RR.nn,RR.zn,zero(T),get_sc(solver))
     RR.inf_compl_mu_R = get_inf_compl_R(
-        get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),RR.pp,RR.zp,RR.nn,RR.zn,RR.mu_R,sc)
+        get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),RR.pp,RR.zp,RR.nn,RR.zn,RR.mu_R,get_sc(solver))
 end
 
 function evaluate_termination_criteria_RR!(solver::AbstractMadNLPSolver)
@@ -1140,7 +1140,7 @@ function check_restoration_successful!(solver::AbstractMadNLPSolver)
     end
 end
 
-function return_from_restoration!(solver::AbstractMadNLPSolver)
+function return_from_restoration!(solver::AbstractMadNLPSolver) where {T}
     RR = get_RR(solver)
     @trace(get_logger(solver),"Going back to the regular phase.")
     set_initial_rhs!(solver, get_kkt(solver))

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -1123,7 +1123,6 @@ function update_variables_RR!(solver::AbstractMadNLPSolver)
     adjust_boundary!(get_x_lr(solver),get_xl_r(solver),get_x_ur(solver),get_xu_r(solver),get_mu(solver))
 end
 
-
 function check_restoration_successful!(solver::AbstractMadNLPSolver)
     RR = get_RR(solver)
     @trace(get_logger(solver),"Checking if going back to regular phase.")
@@ -1155,4 +1154,15 @@ function return_from_restoration!(solver::AbstractMadNLPSolver) where {T}
     else
         copyto!(get_y(solver), dual(get_d(solver)))
     end
+end
+
+# Sections of `restore!` heuristic.
+function initialize_restore!(solver::AbstractMadNLPSolver{T}) where T
+    set_del_w!(solver, zero(T))
+    # Backup the previous primal iterate
+    copyto!(primal(get__w1(solver)), full(get_x(solver)))
+    copyto!(dual(get__w1(solver)), get_y(solver))
+    copyto!(dual(get__w2(solver)), get_c(solver))
+    set_alpha_z!(solver, zero(T))
+    set_ftype!(solver, "R")
 end

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -2,18 +2,18 @@
 # KKT system updates -------------------------------------------------------
 # Set diagonal
 function set_aug_diagonal!(kkt::AbstractKKTSystem{T}, solver::AbstractMadNLPSolver{T}) where T
-    x = full(_x(solver))
-    xl = full(_xl(solver))
-    xu = full(_xu(solver))
-    zl = full(_zl(solver))
-    zu = full(_zu(solver))
+    x = full(get_x(solver))
+    xl = full(get_xl(solver))
+    xu = full(get_xu(solver))
+    zl = full(get_zl(solver))
+    zu = full(get_zu(solver))
 
     fill!(kkt.reg, zero(T))
     fill!(kkt.du_diag, zero(T))
-    kkt.l_diag .= _xl_r(solver) .- _x_lr(solver)   # (Xˡ - X)
-    kkt.u_diag .= _x_ur(solver) .- _xu_r(solver)   # (X - Xᵘ)
-    copyto!(kkt.l_lower, _zl_r(solver))
-    copyto!(kkt.u_lower, _zu_r(solver))
+    kkt.l_diag .= get_xl_r(solver) .- get_x_lr(solver)   # (Xˡ - X)
+    kkt.u_diag .= get_x_ur(solver) .- get_xu_r(solver)   # (X - Xᵘ)
+    copyto!(kkt.l_lower, get_zl_r(solver))
+    copyto!(kkt.u_lower, get_zu_r(solver))
 
     _set_aug_diagonal!(kkt)
     return
@@ -37,10 +37,10 @@ function set_aug_diagonal!(kkt::ScaledSparseKKTSystem{T}, solver::AbstractMadNLP
     fill!(kkt.reg, zero(T))
     fill!(kkt.du_diag, zero(T))
     # Ensure l_diag and u_diag have only non negative entries
-    kkt.l_diag .= _x_lr(solver) .- _xl_r(solver)   # (X - Xˡ)
-    kkt.u_diag .= _xu_r(solver) .- _x_ur(solver)   # (Xᵘ - X)
-    copyto!(kkt.l_lower, _zl_r(solver))
-    copyto!(kkt.u_lower, _zu_r(solver))
+    kkt.l_diag .= get_x_lr(solver) .- get_xl_r(solver)   # (X - Xˡ)
+    kkt.u_diag .= get_xu_r(solver) .- get_x_ur(solver)   # (Xᵘ - X)
+    copyto!(kkt.l_lower, get_zl_r(solver))
+    copyto!(kkt.u_lower, get_zu_r(solver))
     _set_aug_diagonal!(kkt)
 end
 
@@ -70,62 +70,62 @@ end
 
 # Robust restoration
 function set_aug_RR!(kkt::AbstractKKTSystem, solver::AbstractMadNLPSolver, RR::RobustRestorer)
-    x = full(_x(solver))
-    xl = full(_xl(solver))
-    xu = full(_xu(solver))
-    zl = full(_zl(solver))
-    zu = full(_zu(solver))
+    x = full(get_x(solver))
+    xl = full(get_xl(solver))
+    xu = full(get_xu(solver))
+    zl = full(get_zl(solver))
+    zu = full(get_zu(solver))
     kkt.reg .= RR.zeta .* RR.D_R .^ 2
     kkt.du_diag .= .- RR.pp ./ RR.zp .- RR.nn ./ RR.zn
-    copyto!(kkt.l_lower, _zl_r(solver))
-    copyto!(kkt.u_lower, _zu_r(solver))
-    kkt.l_diag .= _xl_r(solver) .- _x_lr(solver)
-    kkt.u_diag .= _x_ur(solver) .- _xu_r(solver)
+    copyto!(kkt.l_lower, get_zl_r(solver))
+    copyto!(kkt.u_lower, get_zu_r(solver))
+    kkt.l_diag .= get_xl_r(solver) .- get_x_lr(solver)
+    kkt.u_diag .= get_x_ur(solver) .- get_xu_r(solver)
 
     _set_aug_diagonal!(kkt)
     return
 end
 
 function set_aug_RR!(kkt::ScaledSparseKKTSystem, solver::AbstractMadNLPSolver, RR::RobustRestorer)
-    x = full(_x(solver))
-    xl = full(_xl(solver))
-    xu = full(_xu(solver))
-    zl = full(_zl(solver))
-    zu = full(_zu(solver))
+    x = full(get_x(solver))
+    xl = full(get_xl(solver))
+    xu = full(get_xu(solver))
+    zl = full(get_zl(solver))
+    zu = full(get_zu(solver))
     kkt.reg .= RR.zeta .* RR.D_R .^ 2
     kkt.du_diag .= .- RR.pp ./ RR.zp .- RR.nn ./ RR.zn
-    copyto!(kkt.l_lower, _zl_r(solver))
-    copyto!(kkt.u_lower, _zu_r(solver))
-    kkt.l_diag .= _x_lr(solver) .- _xl_r(solver)
-    kkt.u_diag .= _xu_r(solver) .- _x_ur(solver)
+    copyto!(kkt.l_lower, get_zl_r(solver))
+    copyto!(kkt.u_lower, get_zu_r(solver))
+    kkt.l_diag .= get_x_lr(solver) .- get_xl_r(solver)
+    kkt.u_diag .= get_xu_r(solver) .- get_x_ur(solver)
 
     _set_aug_diagonal!(kkt)
     return
 end
 
 function set_f_RR!(solver::AbstractMadNLPSolver, RR::RobustRestorer)
-    x = full(_x(solver))
+    x = full(get_x(solver))
     RR.f_R .= RR.zeta .* RR.D_R .^ 2 .* (x .- RR.x_ref)
     return
 end
 
 # Set RHS
 function set_aug_rhs!(solver::AbstractMadNLPSolver, kkt::AbstractKKTSystem, c::AbstractVector, mu)
-    px = primal(_p(solver))
-    x = primal(_x(solver))
-    f = primal(_f(solver))
-    xl = primal(_xl(solver))
-    xu = primal(_xu(solver))
-    zl = full(_zl(solver))
-    zu = full(_zu(solver))
-    py = dual(_p(solver))
-    pzl = dual_lb(_p(solver))
-    pzu = dual_ub(_p(solver))
+    px = primal(get_p(solver))
+    x = primal(get_x(solver))
+    f = primal(get_f(solver))
+    xl = primal(get_xl(solver))
+    xu = primal(get_xu(solver))
+    zl = full(get_zl(solver))
+    zu = full(get_zu(solver))
+    py = dual(get_p(solver))
+    pzl = dual_lb(get_p(solver))
+    pzu = dual_ub(get_p(solver))
 
-    px .= .-f .+ zl .- zu .- _jacl(solver)
+    px .= .-f .+ zl .- zu .- get_jacl(solver)
     py .= .-c
-    pzl .= (_xl_r(solver) .- _x_lr(solver)) .* _zl_r(solver) .+ mu
-    pzu .= (_xu_r(solver) .- _x_ur(solver)) .* _zu_r(solver) .- mu
+    pzl .= (get_xl_r(solver) .- get_x_lr(solver)) .* get_zl_r(solver) .+ mu
+    pzu .= (get_xu_r(solver) .- get_x_ur(solver)) .* get_zu_r(solver) .- mu
     return
 end
 
@@ -133,26 +133,26 @@ end
 function set_aug_rhs_RR!(
     solver::AbstractMadNLPSolver, kkt::AbstractKKTSystem, RR::RobustRestorer, rho,
 )
-    x = full(_x(solver))
-    xl = full(_xl(solver))
-    xu = full(_xu(solver))
-    zl = full(_zl(solver))
-    zu = full(_zu(solver))
+    x = full(get_x(solver))
+    xl = full(get_xl(solver))
+    xu = full(get_xu(solver))
+    zl = full(get_zl(solver))
+    zu = full(get_zu(solver))
 
-    px = primal(_p(solver))
-    py = dual(_p(solver))
-    pzl = dual_lb(_p(solver))
-    pzu = dual_ub(_p(solver))
+    px = primal(get_p(solver))
+    py = dual(get_p(solver))
+    pzl = dual_lb(get_p(solver))
+    pzu = dual_ub(get_p(solver))
 
     mu = RR.mu_R
 
-    px .= .- RR.f_R .+ zl .- zu .- _jacl(solver)
-    py .= .- _c(solver) .+ RR.pp .- RR.nn .+
-        (mu .- (rho .- _y(solver)) .* RR.pp) ./ RR.zp .-
-        (mu .- (rho .+ _y(solver)) .* RR.nn) ./ RR.zn
+    px .= .- RR.f_R .+ zl .- zu .- get_jacl(solver)
+    py .= .- get_c(solver) .+ RR.pp .- RR.nn .+
+        (mu .- (rho .- get_y(solver)) .* RR.pp) ./ RR.zp .-
+        (mu .- (rho .+ get_y(solver)) .* RR.nn) ./ RR.zn
 
-    pzl .= (_xl_r(solver) .- _x_lr(solver)) .* _zl_r(solver) .+ mu
-    pzu .= (_xu_r(solver) .- _x_ur(solver)) .* _zu_r(solver) .- mu
+    pzl .= (get_xl_r(solver) .- get_x_lr(solver)) .* get_zl_r(solver) .+ mu
+    pzu .= (get_xu_r(solver) .- get_x_ur(solver)) .* get_zu_r(solver) .- mu
 
     return
 end
@@ -218,14 +218,14 @@ function set_initial_bounds!(xl::AbstractVector{T}, xu::AbstractVector{T}, tol) 
 end
 
 function set_initial_rhs!(solver::AbstractMadNLPSolver{T}, kkt::AbstractKKTSystem) where T
-    f = primal(_f(solver))
-    zl = primal(_zl(solver))
-    zu = primal(_zu(solver))
-    px = primal(_p(solver))
+    f = primal(get_f(solver))
+    zl = primal(get_zl(solver))
+    zu = primal(get_zu(solver))
+    px = primal(get_p(solver))
     px .= .-f .+ zl .- zu
-    fill!(dual(_p(solver)), zero(T))
-    fill!(dual_lb(_p(solver)), zero(T))
-    fill!(dual_ub(_p(solver)), zero(T))
+    fill!(dual(get_p(solver)), zero(T))
+    fill!(dual_lb(get_p(solver)), zero(T))
+    fill!(dual_ub(get_p(solver)), zero(T))
     return
 end
 
@@ -235,16 +235,16 @@ function set_aug_rhs_ifr!(solver::AbstractMadNLPSolver{T}, kkt::AbstractKKTSyste
     fill!(dual_lb(p0), zero(T))
     fill!(dual_ub(p0), zero(T))
     wy = dual(p0)
-    wy .= .- _c(solver)
+    wy .= .- get_c(solver)
     return
 end
 
 function set_g_ifr!(solver::AbstractMadNLPSolver, g::AbstractArray)
-    f = full(_f(solver))
-    x = full(_x(solver))
-    xl = full(_xl(solver))
-    xu = full(_xu(solver))
-    g .= f .- _mu(solver) ./ (x .- xl) .+ _mu(solver) ./ (xu .- x) .+ _jacl(solver)
+    f = full(get_f(solver))
+    x = full(get_x(solver))
+    xl = full(get_xl(solver))
+    xu = full(get_xu(solver))
+    g .= f .- get_mu(solver) ./ (x .- xl) .+ get_mu(solver) ./ (xu .- x) .+ get_jacl(solver)
 end
 
 # Finish RR

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -1234,11 +1234,11 @@ function evaluate_for_next_iter_restore!(solver::AbstractMadNLPSolver{T}) where 
         primal(get_zl(solver)),
         primal(get_zu(solver)),
         get_jacl(solver),
-        sd,
+        get_sd(solver),
     ))
 
-    set_inf_compl!(solver, get_inf_compl(get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),zero(T),sc))
-    set_inf_compl_mu!(solver, get_inf_compl(get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),get_mu(solver),sc))
+    set_inf_compl!(solver, get_inf_compl(get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),zero(T),get_sc(solver)))
+    set_inf_compl_mu!(solver, get_inf_compl(get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),get_mu(solver),get_sc(solver)))
 
     return nothing
 end

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -2,18 +2,18 @@
 # KKT system updates -------------------------------------------------------
 # Set diagonal
 function set_aug_diagonal!(kkt::AbstractKKTSystem{T}, solver::AbstractMadNLPSolver{T}) where T
-    x = full(solver.x)
-    xl = full(solver.xl)
-    xu = full(solver.xu)
-    zl = full(solver.zl)
-    zu = full(solver.zu)
+    x = full(_x(solver))
+    xl = full(_xl(solver))
+    xu = full(_xu(solver))
+    zl = full(_zl(solver))
+    zu = full(_zu(solver))
 
     fill!(kkt.reg, zero(T))
     fill!(kkt.du_diag, zero(T))
-    kkt.l_diag .= solver.xl_r .- solver.x_lr   # (Xˡ - X)
-    kkt.u_diag .= solver.x_ur .- solver.xu_r   # (X - Xᵘ)
-    copyto!(kkt.l_lower, solver.zl_r)
-    copyto!(kkt.u_lower, solver.zu_r)
+    kkt.l_diag .= _xl_r(solver) .- _x_lr(solver)   # (Xˡ - X)
+    kkt.u_diag .= _x_ur(solver) .- _xu_r(solver)   # (X - Xᵘ)
+    copyto!(kkt.l_lower, _zl_r(solver))
+    copyto!(kkt.u_lower, _zu_r(solver))
 
     _set_aug_diagonal!(kkt)
     return
@@ -37,10 +37,10 @@ function set_aug_diagonal!(kkt::ScaledSparseKKTSystem{T}, solver::AbstractMadNLP
     fill!(kkt.reg, zero(T))
     fill!(kkt.du_diag, zero(T))
     # Ensure l_diag and u_diag have only non negative entries
-    kkt.l_diag .= solver.x_lr .- solver.xl_r   # (X - Xˡ)
-    kkt.u_diag .= solver.xu_r .- solver.x_ur   # (Xᵘ - X)
-    copyto!(kkt.l_lower, solver.zl_r)
-    copyto!(kkt.u_lower, solver.zu_r)
+    kkt.l_diag .= _x_lr(solver) .- _xl_r(solver)   # (X - Xˡ)
+    kkt.u_diag .= _xu_r(solver) .- _x_ur(solver)   # (Xᵘ - X)
+    copyto!(kkt.l_lower, _zl_r(solver))
+    copyto!(kkt.u_lower, _zu_r(solver))
     _set_aug_diagonal!(kkt)
 end
 
@@ -70,62 +70,62 @@ end
 
 # Robust restoration
 function set_aug_RR!(kkt::AbstractKKTSystem, solver::AbstractMadNLPSolver, RR::RobustRestorer)
-    x = full(solver.x)
-    xl = full(solver.xl)
-    xu = full(solver.xu)
-    zl = full(solver.zl)
-    zu = full(solver.zu)
+    x = full(_x(solver))
+    xl = full(_xl(solver))
+    xu = full(_xu(solver))
+    zl = full(_zl(solver))
+    zu = full(_zu(solver))
     kkt.reg .= RR.zeta .* RR.D_R .^ 2
     kkt.du_diag .= .- RR.pp ./ RR.zp .- RR.nn ./ RR.zn
-    copyto!(kkt.l_lower, solver.zl_r)
-    copyto!(kkt.u_lower, solver.zu_r)
-    kkt.l_diag .= solver.xl_r .- solver.x_lr
-    kkt.u_diag .= solver.x_ur .- solver.xu_r
+    copyto!(kkt.l_lower, _zl_r(solver))
+    copyto!(kkt.u_lower, _zu_r(solver))
+    kkt.l_diag .= _xl_r(solver) .- _x_lr(solver)
+    kkt.u_diag .= _x_ur(solver) .- _xu_r(solver)
 
     _set_aug_diagonal!(kkt)
     return
 end
 
 function set_aug_RR!(kkt::ScaledSparseKKTSystem, solver::AbstractMadNLPSolver, RR::RobustRestorer)
-    x = full(solver.x)
-    xl = full(solver.xl)
-    xu = full(solver.xu)
-    zl = full(solver.zl)
-    zu = full(solver.zu)
+    x = full(_x(solver))
+    xl = full(_xl(solver))
+    xu = full(_xu(solver))
+    zl = full(_zl(solver))
+    zu = full(_zu(solver))
     kkt.reg .= RR.zeta .* RR.D_R .^ 2
     kkt.du_diag .= .- RR.pp ./ RR.zp .- RR.nn ./ RR.zn
-    copyto!(kkt.l_lower, solver.zl_r)
-    copyto!(kkt.u_lower, solver.zu_r)
-    kkt.l_diag .= solver.x_lr .- solver.xl_r
-    kkt.u_diag .= solver.xu_r .- solver.x_ur
+    copyto!(kkt.l_lower, _zl_r(solver))
+    copyto!(kkt.u_lower, _zu_r(solver))
+    kkt.l_diag .= _x_lr(solver) .- _xl_r(solver)
+    kkt.u_diag .= _xu_r(solver) .- _x_ur(solver)
 
     _set_aug_diagonal!(kkt)
     return
 end
 
 function set_f_RR!(solver::AbstractMadNLPSolver, RR::RobustRestorer)
-    x = full(solver.x)
+    x = full(_x(solver))
     RR.f_R .= RR.zeta .* RR.D_R .^ 2 .* (x .- RR.x_ref)
     return
 end
 
 # Set RHS
 function set_aug_rhs!(solver::AbstractMadNLPSolver, kkt::AbstractKKTSystem, c::AbstractVector, mu)
-    px = primal(solver.p)
-    x = primal(solver.x)
-    f = primal(solver.f)
-    xl = primal(solver.xl)
-    xu = primal(solver.xu)
-    zl = full(solver.zl)
-    zu = full(solver.zu)
-    py = dual(solver.p)
-    pzl = dual_lb(solver.p)
-    pzu = dual_ub(solver.p)
+    px = primal(_p(solver))
+    x = primal(_x(solver))
+    f = primal(_f(solver))
+    xl = primal(_xl(solver))
+    xu = primal(_xu(solver))
+    zl = full(_zl(solver))
+    zu = full(_zu(solver))
+    py = dual(_p(solver))
+    pzl = dual_lb(_p(solver))
+    pzu = dual_ub(_p(solver))
 
-    px .= .-f .+ zl .- zu .- solver.jacl
+    px .= .-f .+ zl .- zu .- _jacl(solver)
     py .= .-c
-    pzl .= (solver.xl_r .- solver.x_lr) .* solver.zl_r .+ mu
-    pzu .= (solver.xu_r .- solver.x_ur) .* solver.zu_r .- mu
+    pzl .= (_xl_r(solver) .- _x_lr(solver)) .* _zl_r(solver) .+ mu
+    pzu .= (_xu_r(solver) .- _x_ur(solver)) .* _zu_r(solver) .- mu
     return
 end
 
@@ -133,26 +133,26 @@ end
 function set_aug_rhs_RR!(
     solver::AbstractMadNLPSolver, kkt::AbstractKKTSystem, RR::RobustRestorer, rho,
 )
-    x = full(solver.x)
-    xl = full(solver.xl)
-    xu = full(solver.xu)
-    zl = full(solver.zl)
-    zu = full(solver.zu)
+    x = full(_x(solver))
+    xl = full(_xl(solver))
+    xu = full(_xu(solver))
+    zl = full(_zl(solver))
+    zu = full(_zu(solver))
 
-    px = primal(solver.p)
-    py = dual(solver.p)
-    pzl = dual_lb(solver.p)
-    pzu = dual_ub(solver.p)
+    px = primal(_p(solver))
+    py = dual(_p(solver))
+    pzl = dual_lb(_p(solver))
+    pzu = dual_ub(_p(solver))
 
     mu = RR.mu_R
 
-    px .= .- RR.f_R .+ zl .- zu .- solver.jacl
-    py .= .- solver.c .+ RR.pp .- RR.nn .+
-        (mu .- (rho .- solver.y) .* RR.pp) ./ RR.zp .-
-        (mu .- (rho .+ solver.y) .* RR.nn) ./ RR.zn
+    px .= .- RR.f_R .+ zl .- zu .- _jacl(solver)
+    py .= .- _c(solver) .+ RR.pp .- RR.nn .+
+        (mu .- (rho .- _y(solver)) .* RR.pp) ./ RR.zp .-
+        (mu .- (rho .+ _y(solver)) .* RR.nn) ./ RR.zn
 
-    pzl .= (solver.xl_r .- solver.x_lr) .* solver.zl_r .+ mu
-    pzu .= (solver.xu_r .- solver.x_ur) .* solver.zu_r .- mu
+    pzl .= (_xl_r(solver) .- _x_lr(solver)) .* _zl_r(solver) .+ mu
+    pzu .= (_xu_r(solver) .- _x_ur(solver)) .* _zu_r(solver) .- mu
 
     return
 end
@@ -218,14 +218,14 @@ function set_initial_bounds!(xl::AbstractVector{T}, xu::AbstractVector{T}, tol) 
 end
 
 function set_initial_rhs!(solver::AbstractMadNLPSolver{T}, kkt::AbstractKKTSystem) where T
-    f = primal(solver.f)
-    zl = primal(solver.zl)
-    zu = primal(solver.zu)
-    px = primal(solver.p)
+    f = primal(_f(solver))
+    zl = primal(_zl(solver))
+    zu = primal(_zu(solver))
+    px = primal(_p(solver))
     px .= .-f .+ zl .- zu
-    fill!(dual(solver.p), zero(T))
-    fill!(dual_lb(solver.p), zero(T))
-    fill!(dual_ub(solver.p), zero(T))
+    fill!(dual(_p(solver)), zero(T))
+    fill!(dual_lb(_p(solver)), zero(T))
+    fill!(dual_ub(_p(solver)), zero(T))
     return
 end
 
@@ -235,16 +235,16 @@ function set_aug_rhs_ifr!(solver::AbstractMadNLPSolver{T}, kkt::AbstractKKTSyste
     fill!(dual_lb(p0), zero(T))
     fill!(dual_ub(p0), zero(T))
     wy = dual(p0)
-    wy .= .- solver.c
+    wy .= .- _c(solver)
     return
 end
 
 function set_g_ifr!(solver::AbstractMadNLPSolver, g::AbstractArray)
-    f = full(solver.f)
-    x = full(solver.x)
-    xl = full(solver.xl)
-    xu = full(solver.xu)
-    g .= f .- solver.mu ./ (x .- xl) .+ solver.mu ./ (xu .- x) .+ solver.jacl
+    f = full(_f(solver))
+    x = full(_x(solver))
+    xl = full(_xl(solver))
+    xu = full(_xu(solver))
+    g .= f .- _mu(solver) ./ (x .- xl) .+ _mu(solver) ./ (xu .- x) .+ _jacl(solver)
 end
 
 # Finish RR

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -784,14 +784,14 @@ function get_sc(zl_r, zu_r, s_max)
 end
 
 function get_mu(
-    mu,
+    mu::T,
     mu_min,
     mu_linear_decrease_factor,
     mu_superlinear_decrease_power,
     tol,
-)
+) where {T}
     # Warning: `a * tol` should be strictly less than 100 * mu_min, see issue #242
-    a = min(99.0 * mu_min / tol, 0.01)
+    a = min(T(99.0) * mu_min / tol, T(0.01))
     return max(
         mu_min,
         a * tol,
@@ -857,8 +857,8 @@ function is_filter_acceptable(filter, theta, varphi)
     return true
 end
 
-function is_barr_obj_rapid_increase(varphi, varphi_trial, obj_max_inc)
-    return (varphi_trial >= varphi) && (log10(varphi_trial-varphi) > obj_max_inc + max(1.0, log10(abs(varphi))))
+function is_barr_obj_rapid_increase(varphi::T, varphi_trial, obj_max_inc) where T
+    return (varphi_trial >= varphi) && (log10(varphi_trial-varphi) > obj_max_inc + max(one(T), log10(abs(varphi))))
 end
 
 function reset_bound_dual!(

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -1048,9 +1048,9 @@ end
 
 function evaluate_termination_criteria_RR!(solver::AbstractMadNLPSolver)
     RR = get_RR(solver)
-    max(RR.inf_pr_R,RR.inf_du_R,RR.inf_compl_R) <= get_opt(solver).tol && return INFEASIBLE_PROBLEM_DETECTED
-    get_cnt(solver).k>=get_opt(solver).max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
-    time()-get_cnt(solver).start_time>=get_opt(solver).max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
+    (max(RR.inf_pr_R,RR.inf_du_R,RR.inf_compl_R) <= get_opt(solver).tol) && return INFEASIBLE_PROBLEM_DETECTED
+    (get_cnt(solver).k>=get_opt(solver).max_iter) && return MAXIMUM_ITERATIONS_EXCEEDED
+    (time()-get_cnt(solver).start_time>=get_opt(solver).max_wall_time) && return MAXIMUM_WALLTIME_EXCEEDED
 
     return ROBUST
 end

--- a/src/IPM/line_search.jl
+++ b/src/IPM/line_search.jl
@@ -4,60 +4,60 @@
 =#
 
 function filter_line_search!(solver::AbstractMadNLPSolver{T}) where T
-    theta = get_theta(_c(solver))
-    varphi= get_varphi(_obj_val(solver),_x_lr(solver),_xl_r(solver),_xu_r(solver),_x_ur(solver),_mu(solver))
+    theta = get_theta(get_c(solver))
+    varphi= get_varphi(get_obj_val(solver),get_x_lr(solver),get_xl_r(solver),get_xu_r(solver),get_x_ur(solver),get_mu(solver))
     varphi_d = get_varphi_d(
-        primal(_f(solver)),
-        primal(_x(solver)),
-        primal(_xl(solver)),
-        primal(_xu(solver)),
-        primal(_d(solver)),
-        _mu(solver),
+        primal(get_f(solver)),
+        primal(get_x(solver)),
+        primal(get_xl(solver)),
+        primal(get_xu(solver)),
+        primal(get_d(solver)),
+        get_mu(solver),
     )
 
     alpha_max = get_alpha_max(
-        primal(_x(solver)),
-        primal(_xl(solver)),
-        primal(_xu(solver)),
-        primal(_d(solver)),
-        _tau(solver),
+        primal(get_x(solver)),
+        primal(get_xl(solver)),
+        primal(get_xu(solver)),
+        primal(get_d(solver)),
+        get_tau(solver),
     )
-    set_alpha_z!(solver, get_alpha_z(_zl_r(solver),_zu_r(solver),dual_lb(_d(solver)),dual_ub(_d(solver)),_tau(solver)))
-    alpha_min = get_alpha_min(theta,varphi_d,_theta_min(solver),_opt(solver).gamma_theta,_opt(solver).gamma_phi,
-                                _opt(solver).alpha_min_frac,_opt(solver).delta,_opt(solver).s_theta,_opt(solver).s_phi)
-    _cnt(solver).l = 1
+    set_alpha_z!(solver, get_alpha_z(get_zl_r(solver),get_zu_r(solver),dual_lb(get_d(solver)),dual_ub(get_d(solver)),get_tau(solver)))
+    alpha_min = get_alpha_min(theta,varphi_d,get_theta_min(solver),get_opt(solver).gamma_theta,get_opt(solver).gamma_phi,
+                                get_opt(solver).alpha_min_frac,get_opt(solver).delta,get_opt(solver).s_theta,get_opt(solver).s_phi)
+    get_cnt(solver).l = 1
     set_alpha!(solver, alpha_max)
     varphi_trial= zero(T)
     theta_trial = zero(T)
-    small_search_norm = get_rel_search_norm(primal(_x(solver)), primal(_d(solver))) < 10*eps(T)
-    switching_condition = is_switching(varphi_d,_alpha(solver),_opt(solver).s_phi,_opt(solver).delta,2.,_opt(solver).s_theta)
+    small_search_norm = get_rel_search_norm(primal(get_x(solver)), primal(get_d(solver))) < 10*eps(T)
+    switching_condition = is_switching(varphi_d,get_alpha(solver),get_opt(solver).s_phi,get_opt(solver).delta,2.,get_opt(solver).s_theta)
     armijo_condition = false
     unsuccessful_iterate = false
 
     while true
 
-        copyto!(full(_x_trial(solver)), full(_x(solver)))
-        axpy!(_alpha(solver), primal(_d(solver)), primal(_x_trial(solver)))
-        set_obj_val_trial!(solver, eval_f_wrapper(solver, _x_trial(solver)))
-        eval_cons_wrapper!(solver, _c_trial(solver), _x_trial(solver))
+        copyto!(full(get_x_trial(solver)), full(get_x(solver)))
+        axpy!(get_alpha(solver), primal(get_d(solver)), primal(get_x_trial(solver)))
+        set_obj_val_trial!(solver, eval_f_wrapper(solver, get_x_trial(solver)))
+        eval_cons_wrapper!(solver, get_c_trial(solver), get_x_trial(solver))
 
-        theta_trial = get_theta(_c_trial(solver))
-        varphi_trial= get_varphi(_obj_val_trial(solver),_x_trial_lr(solver),_xl_r(solver),_xu_r(solver),_x_trial_ur(solver),_mu(solver))
-        armijo_condition = is_armijo(varphi_trial,varphi,_opt(solver).eta_phi,_alpha(solver),varphi_d)
+        theta_trial = get_theta(get_c_trial(solver))
+        varphi_trial= get_varphi(get_obj_val_trial(solver),get_x_trial_lr(solver),get_xl_r(solver),get_xu_r(solver),get_x_trial_ur(solver),get_mu(solver))
+        armijo_condition = is_armijo(varphi_trial,varphi,get_opt(solver).eta_phi,get_alpha(solver),varphi_d)
 
         small_search_norm && break
 
         set_ftype!(solver, get_ftype(
-            _filter(solver),theta,theta_trial,varphi,varphi_trial,switching_condition,armijo_condition,
-            _theta_min(solver),_opt(solver).obj_max_inc,_opt(solver).gamma_theta,_opt(solver).gamma_phi,
+            get_filter(solver),theta,theta_trial,varphi,varphi_trial,switching_condition,armijo_condition,
+            get_theta_min(solver),get_opt(solver).obj_max_inc,get_opt(solver).gamma_theta,get_opt(solver).gamma_phi,
             has_constraints(solver))
                 )
-        if _ftype(solver) in ["f","h"]
-            @trace(_logger(solver),"Step accepted with type $(_ftype(solver))")
+        if get_ftype(solver) in ["f","h"]
+            @trace(get_logger(solver),"Step accepted with type $(get_ftype(solver))")
             break
         end
 
-        if _cnt(solver).l==1 && theta_trial>=theta
+        if get_cnt(solver).l==1 && theta_trial>=theta
             if second_order_correction(
                 solver,alpha_max,theta,varphi,theta_trial,varphi_d,switching_condition
             )
@@ -66,30 +66,30 @@ function filter_line_search!(solver::AbstractMadNLPSolver{T}) where T
         end
 
         unsuccessful_iterate = true
-        set_alpha!(solver, _alpha(solver)/2)
-        _cnt(solver).l += 1
-        if _alpha(solver) < alpha_min
-            @debug(_logger(solver),
-                    "Cannot find an acceptable step at iteration $(_cnt(solver).k). Switching to restoration phase.")
-            _cnt(solver).k+=1
+        set_alpha!(solver, get_alpha(solver)/2)
+        get_cnt(solver).l += 1
+        if get_alpha(solver) < alpha_min
+            @debug(get_logger(solver),
+                    "Cannot find an acceptable step at iteration $(get_cnt(solver).k). Switching to restoration phase.")
+            get_cnt(solver).k+=1
             return RESTORE
         else
-            @trace(_logger(solver),"Step rejected; proceed with the next trial step.")
-            if _alpha(solver) * norm(primal(_d(solver))) < eps(T)*10
-                if (_cnt(solver).restoration_fail_count += 1) >= 4
-                    return _cnt(solver).acceptable_cnt >0 ?
+            @trace(get_logger(solver),"Step rejected; proceed with the next trial step.")
+            if get_alpha(solver) * norm(primal(get_d(solver))) < eps(T)*10
+                if (get_cnt(solver).restoration_fail_count += 1) >= 4
+                    return get_cnt(solver).acceptable_cnt >0 ?
                         SOLVED_TO_ACCEPTABLE_LEVEL : SEARCH_DIRECTION_BECOMES_TOO_SMALL
                 else
                     # (experimental) while giving up directly
                     # we give MadNLP.jl second chance to explore
                     # some possibility at the current iterate
 
-                    fill!(_y(solver), zero(T))
-                    fill!(_zl_r(solver), one(T))
-                    fill!(_zu_r(solver), one(T))
-                    empty!(_filter(solver))
-                    push!(_filter(solver),(_theta_max(solver),-Inf))
-                    _cnt(solver).k+=1
+                    fill!(get_y(solver), zero(T))
+                    fill!(get_zl_r(solver), one(T))
+                    fill!(get_zu_r(solver), one(T))
+                    empty!(get_filter(solver))
+                    push!(get_filter(solver),(get_theta_max(solver),-Inf))
+                    get_cnt(solver).k+=1
 
                     return REGULAR
                 end
@@ -100,22 +100,22 @@ function filter_line_search!(solver::AbstractMadNLPSolver{T}) where T
     # this implements the heuristics in Section 3.2 of Ipopt paper.
     # Case I is only implemented
     if unsuccessful_iterate
-        if (_cnt(solver).unsuccessful_iterate += 1) >= 4
-            if _theta_max(solver)/10 > theta_trial
-                @debug(_logger(solver), "restarting filter")
-                set_theta_max!(solver, _theta_max(solver)/10)
-                empty!(_filter(solver))
-                push!(_filter(solver),(_theta_max(solver),-Inf))
+        if (get_cnt(solver).unsuccessful_iterate += 1) >= 4
+            if get_theta_max(solver)/10 > theta_trial
+                @debug(get_logger(solver), "restarting filter")
+                set_theta_max!(solver, get_theta_max(solver)/10)
+                empty!(get_filter(solver))
+                push!(get_filter(solver),(get_theta_max(solver),-Inf))
             end
-            _cnt(solver).unsuccessful_iterate = 0
+            get_cnt(solver).unsuccessful_iterate = 0
         end
     else
-        _cnt(solver).unsuccessful_iterate = 0
+        get_cnt(solver).unsuccessful_iterate = 0
     end
 
     if !switching_condition || !armijo_condition
-        @trace(_logger(solver),"Augmenting filter.")
-        augment_filter!(_filter(solver),theta_trial,varphi_trial,_opt(solver).gamma_theta)
+        @trace(get_logger(solver),"Augmenting filter.")
+        augment_filter!(get_filter(solver),theta_trial,varphi_trial,get_opt(solver).gamma_theta)
     end
 
     return LINESEARCH_SUCCEEDED
@@ -126,95 +126,95 @@ end
 =#
 
 function filter_line_search_RR!(solver::AbstractMadNLPSolver{T}) where T
-    RR = _RR(solver)
-    theta_R = get_theta_R(_c(solver),RR.pp,RR.nn)
-    varphi_R = get_varphi_R(RR.obj_val_R,_x_lr(solver),_xl_r(solver),_xu_r(solver),_x_ur(solver),RR.pp,RR.nn,RR.mu_R)
+    RR = get_RR(solver)
+    theta_R = get_theta_R(get_c(solver),RR.pp,RR.nn)
+    varphi_R = get_varphi_R(RR.obj_val_R,get_x_lr(solver),get_xl_r(solver),get_xu_r(solver),get_x_ur(solver),RR.pp,RR.nn,RR.mu_R)
     varphi_d_R = get_varphi_d_R(
         RR.f_R,
-        primal(_x(solver)),
-        primal(_xl(solver)),
-        primal(_xu(solver)),
-        primal(_d(solver)),
-        RR.pp,RR.nn,RR.dpp,RR.dnn,RR.mu_R,_opt(solver).rho,
+        primal(get_x(solver)),
+        primal(get_xl(solver)),
+        primal(get_xu(solver)),
+        primal(get_d(solver)),
+        RR.pp,RR.nn,RR.dpp,RR.dnn,RR.mu_R,get_opt(solver).rho,
     )
 
     # set alpha_min
     alpha_max = get_alpha_max_R(
-        primal(_x(solver)),
-        primal(_xl(solver)),
-        primal(_xu(solver)),
-        primal(_d(solver)),
+        primal(get_x(solver)),
+        primal(get_xl(solver)),
+        primal(get_xu(solver)),
+        primal(get_d(solver)),
         RR.pp,RR.dpp,RR.nn,RR.dnn,RR.tau_R,
     )
-    set_alpha_z!(solver, get_alpha_z_R(_zl_r(solver),_zu_r(solver),dual_lb(_d(solver)),dual_ub(_d(solver)),RR.zp,RR.dzp,RR.zn,RR.dzn,RR.tau_R))
-    alpha_min = get_alpha_min(theta_R,varphi_d_R,_theta_min(solver),_opt(solver).gamma_theta,_opt(solver).gamma_phi,
-                                _opt(solver).alpha_min_frac,_opt(solver).delta,_opt(solver).s_theta,_opt(solver).s_phi)
+    set_alpha_z!(solver, get_alpha_z_R(get_zl_r(solver),get_zu_r(solver),dual_lb(get_d(solver)),dual_ub(get_d(solver)),RR.zp,RR.dzp,RR.zn,RR.dzn,RR.tau_R))
+    alpha_min = get_alpha_min(theta_R,varphi_d_R,get_theta_min(solver),get_opt(solver).gamma_theta,get_opt(solver).gamma_phi,
+                                get_opt(solver).alpha_min_frac,get_opt(solver).delta,get_opt(solver).s_theta,get_opt(solver).s_phi)
 
     set_alpha!(solver, alpha_max)
-    _cnt(solver).l = 1
+    get_cnt(solver).l = 1
     theta_R_trial = zero(T)
     varphi_R_trial = zero(T)
-    small_search_norm = get_rel_search_norm(primal(_x(solver)), primal(_d(solver))) < 10*eps(T)
-    switching_condition = is_switching(varphi_d_R,_alpha(solver),_opt(solver).s_phi,_opt(solver).delta,theta_R,_opt(solver).s_theta)
+    small_search_norm = get_rel_search_norm(primal(get_x(solver)), primal(get_d(solver))) < 10*eps(T)
+    switching_condition = is_switching(varphi_d_R,get_alpha(solver),get_opt(solver).s_phi,get_opt(solver).delta,theta_R,get_opt(solver).s_theta)
     armijo_condition = false
 
     while true
-        copyto!(full(_x_trial(solver)), full(_x(solver)))
+        copyto!(full(get_x_trial(solver)), full(get_x(solver)))
         copyto!(RR.pp_trial,RR.pp)
         copyto!(RR.nn_trial,RR.nn)
-        axpy!(_alpha(solver),primal(_d(solver)),primal(_x_trial(solver)))
-        axpy!(_alpha(solver),RR.dpp,RR.pp_trial)
-        axpy!(_alpha(solver),RR.dnn,RR.nn_trial)
+        axpy!(get_alpha(solver),primal(get_d(solver)),primal(get_x_trial(solver)))
+        axpy!(get_alpha(solver),RR.dpp,RR.pp_trial)
+        axpy!(get_alpha(solver),RR.dnn,RR.nn_trial)
 
         RR.obj_val_R_trial = get_obj_val_R(
-            RR.pp_trial,RR.nn_trial,RR.D_R,primal(_x_trial(solver)),RR.x_ref,_opt(solver).rho,RR.zeta)
-        eval_cons_wrapper!(solver, _c_trial(solver), _x_trial(solver))
-        theta_R_trial  = get_theta_R(_c_trial(solver),RR.pp_trial,RR.nn_trial)
+            RR.pp_trial,RR.nn_trial,RR.D_R,primal(get_x_trial(solver)),RR.x_ref,get_opt(solver).rho,RR.zeta)
+        eval_cons_wrapper!(solver, get_c_trial(solver), get_x_trial(solver))
+        theta_R_trial  = get_theta_R(get_c_trial(solver),RR.pp_trial,RR.nn_trial)
         varphi_R_trial = get_varphi_R(
-            RR.obj_val_R_trial,_x_trial_lr(solver),_xl_r(solver),_xu_r(solver),_x_trial_ur(solver),RR.pp_trial,RR.nn_trial,RR.mu_R)
+            RR.obj_val_R_trial,get_x_trial_lr(solver),get_xl_r(solver),get_xu_r(solver),get_x_trial_ur(solver),RR.pp_trial,RR.nn_trial,RR.mu_R)
 
-        armijo_condition = is_armijo(varphi_R_trial,varphi_R,_opt(solver).eta_phi,_alpha(solver),varphi_d_R)
+        armijo_condition = is_armijo(varphi_R_trial,varphi_R,get_opt(solver).eta_phi,get_alpha(solver),varphi_d_R)
 
         small_search_norm && break
         set_ftype!(solver, get_ftype(
             RR.filter,theta_R,theta_R_trial,varphi_R,varphi_R_trial,
             switching_condition,armijo_condition,
-            _theta_min(solver),_opt(solver).obj_max_inc,_opt(solver).gamma_theta,_opt(solver).gamma_phi,
+            get_theta_min(solver),get_opt(solver).obj_max_inc,get_opt(solver).gamma_theta,get_opt(solver).gamma_phi,
             has_constraints(solver))
                 )
-        _ftype(solver) in ["f","h"] && (@trace(_logger(solver),"Step accepted with type $(_ftype(solver))"); break)
+        get_ftype(solver) in ["f","h"] && (@trace(get_logger(solver),"Step accepted with type $(get_ftype(solver))"); break)
 
-        set_alpha!(solver, _alpha(solver)/2)
-        _cnt(solver).l += 1
-        if _alpha(solver) < alpha_min
-            @debug(_logger(solver),"Restoration phase cannot find an acceptable step at iteration $(_cnt(solver).k).")
-            if (_cnt(solver).restoration_fail_count += 1) >= 4
+        set_alpha!(solver, get_alpha(solver)/2)
+        get_cnt(solver).l += 1
+        if get_alpha(solver) < alpha_min
+            @debug(get_logger(solver),"Restoration phase cannot find an acceptable step at iteration $(get_cnt(solver).k).")
+            if (get_cnt(solver).restoration_fail_count += 1) >= 4
                 return RESTORATION_FAILED
             else
                 # (experimental) while giving up directly
                 # we give MadNLP.jl second chance to explore
                 # some possibility at the current iterate
 
-                fill!(_y(solver), zero(T))
-                fill!(_zl_r(solver), one(T))
-                fill!(_zu_r(solver), one(T))
-                empty!(_filter(solver))
-                push!(_filter(solver),(_theta_max(solver),-Inf))
+                fill!(get_y(solver), zero(T))
+                fill!(get_zl_r(solver), one(T))
+                fill!(get_zu_r(solver), one(T))
+                empty!(get_filter(solver))
+                push!(get_filter(solver),(get_theta_max(solver),-Inf))
 
-                _cnt(solver).k+=1
-                _cnt(solver).t+=1
+                get_cnt(solver).k+=1
+                get_cnt(solver).t+=1
                 return REGULAR
             end
         else
-            @trace(_logger(solver),"Step rejected; proceed with the next trial step.")
-            _alpha(solver) < eps(T)*10 && return _cnt(solver).acceptable_cnt >0 ?
+            @trace(get_logger(solver),"Step rejected; proceed with the next trial step.")
+            get_alpha(solver) < eps(T)*10 && return get_cnt(solver).acceptable_cnt >0 ?
                 SOLVED_TO_ACCEPTABLE_LEVEL : SEARCH_DIRECTION_BECOMES_TOO_SMALL
         end
     end
 
     if !switching_condition || !armijo_condition
-        @trace(_logger(solver),"Augmenting restoration phase filter.")
-        augment_filter!(RR.filter,theta_R_trial,varphi_R_trial,_opt(solver).gamma_theta)
+        @trace(get_logger(solver),"Augmenting restoration phase filter.")
+        augment_filter!(RR.filter,theta_R_trial,varphi_R_trial,get_opt(solver).gamma_theta)
     end
 
     return LINESEARCH_SUCCEEDED

--- a/src/IPM/line_search.jl
+++ b/src/IPM/line_search.jl
@@ -4,60 +4,60 @@
 =#
 
 function filter_line_search!(solver::AbstractMadNLPSolver{T}) where T
-    theta = get_theta(solver.c)
-    varphi= get_varphi(solver.obj_val,solver.x_lr,solver.xl_r,solver.xu_r,solver.x_ur,solver.mu)
+    theta = get_theta(_c(solver))
+    varphi= get_varphi(_obj_val(solver),_x_lr(solver),_xl_r(solver),_xu_r(solver),_x_ur(solver),_mu(solver))
     varphi_d = get_varphi_d(
-        primal(solver.f),
-        primal(solver.x),
-        primal(solver.xl),
-        primal(solver.xu),
-        primal(solver.d),
-        solver.mu,
+        primal(_f(solver)),
+        primal(_x(solver)),
+        primal(_xl(solver)),
+        primal(_xu(solver)),
+        primal(_d(solver)),
+        _mu(solver),
     )
 
     alpha_max = get_alpha_max(
-        primal(solver.x),
-        primal(solver.xl),
-        primal(solver.xu),
-        primal(solver.d),
-        solver.tau,
+        primal(_x(solver)),
+        primal(_xl(solver)),
+        primal(_xu(solver)),
+        primal(_d(solver)),
+        _tau(solver),
     )
-    solver.alpha_z = get_alpha_z(solver.zl_r,solver.zu_r,dual_lb(solver.d),dual_ub(solver.d),solver.tau)
-    alpha_min = get_alpha_min(theta,varphi_d,solver.theta_min,solver.opt.gamma_theta,solver.opt.gamma_phi,
-                                solver.opt.alpha_min_frac,solver.opt.delta,solver.opt.s_theta,solver.opt.s_phi)
-    solver.cnt.l = 1
-    solver.alpha = alpha_max
+    _alpha_z!(solver, get_alpha_z(_zl_r(solver),_zu_r(solver),dual_lb(_d(solver)),dual_ub(_d(solver)),_tau(solver)))
+    alpha_min = get_alpha_min(theta,varphi_d,_theta_min(solver),_opt(solver).gamma_theta,_opt(solver).gamma_phi,
+                                _opt(solver).alpha_min_frac,_opt(solver).delta,_opt(solver).s_theta,_opt(solver).s_phi)
+    _cnt(solver).l = 1
+    _alpha!(solver, alpha_max)
     varphi_trial= zero(T)
     theta_trial = zero(T)
-    small_search_norm = get_rel_search_norm(primal(solver.x), primal(solver.d)) < 10*eps(T)
-    switching_condition = is_switching(varphi_d,solver.alpha,solver.opt.s_phi,solver.opt.delta,2.,solver.opt.s_theta)
+    small_search_norm = get_rel_search_norm(primal(_x(solver)), primal(_d(solver))) < 10*eps(T)
+    switching_condition = is_switching(varphi_d,_alpha(solver),_opt(solver).s_phi,_opt(solver).delta,2.,_opt(solver).s_theta)
     armijo_condition = false
     unsuccessful_iterate = false
 
     while true
 
-        copyto!(full(solver.x_trial), full(solver.x))
-        axpy!(solver.alpha, primal(solver.d), primal(solver.x_trial))
-        solver.obj_val_trial = eval_f_wrapper(solver, solver.x_trial)
-        eval_cons_wrapper!(solver, solver.c_trial, solver.x_trial)
+        copyto!(full(_x_trial(solver)), full(_x(solver)))
+        axpy!(_alpha(solver), primal(_d(solver)), primal(_x_trial(solver)))
+        _obj_val_trial!(solver, eval_f_wrapper(solver, _x_trial(solver)))
+        eval_cons_wrapper!(solver, _c_trial(solver), _x_trial(solver))
 
-        theta_trial = get_theta(solver.c_trial)
-        varphi_trial= get_varphi(solver.obj_val_trial,solver.x_trial_lr,solver.xl_r,solver.xu_r,solver.x_trial_ur,solver.mu)
-        armijo_condition = is_armijo(varphi_trial,varphi,solver.opt.eta_phi,solver.alpha,varphi_d)
+        theta_trial = get_theta(_c_trial(solver))
+        varphi_trial= get_varphi(_obj_val_trial(solver),_x_trial_lr(solver),_xl_r(solver),_xu_r(solver),_x_trial_ur(solver),_mu(solver))
+        armijo_condition = is_armijo(varphi_trial,varphi,_opt(solver).eta_phi,_alpha(solver),varphi_d)
 
         small_search_norm && break
 
-        solver.ftype = get_ftype(
-            solver.filter,theta,theta_trial,varphi,varphi_trial,switching_condition,armijo_condition,
-            solver.theta_min,solver.opt.obj_max_inc,solver.opt.gamma_theta,solver.opt.gamma_phi,
+        _ftype!(solver, get_ftype(
+            _filter(solver),theta,theta_trial,varphi,varphi_trial,switching_condition,armijo_condition,
+            _theta_min(solver),_opt(solver).obj_max_inc,_opt(solver).gamma_theta,_opt(solver).gamma_phi,
             has_constraints(solver))
-
-        if solver.ftype in ["f","h"]
-            @trace(solver.logger,"Step accepted with type $(solver.ftype)")
+                )
+        if _ftype(solver) in ["f","h"]
+            @trace(_logger(solver),"Step accepted with type $(_ftype(solver))")
             break
         end
 
-        if solver.cnt.l==1 && theta_trial>=theta
+        if _cnt(solver).l==1 && theta_trial>=theta
             if second_order_correction(
                 solver,alpha_max,theta,varphi,theta_trial,varphi_d,switching_condition
             )
@@ -66,30 +66,30 @@ function filter_line_search!(solver::AbstractMadNLPSolver{T}) where T
         end
 
         unsuccessful_iterate = true
-        solver.alpha /= 2
-        solver.cnt.l += 1
-        if solver.alpha < alpha_min
-            @debug(solver.logger,
-                    "Cannot find an acceptable step at iteration $(solver.cnt.k). Switching to restoration phase.")
-            solver.cnt.k+=1
+        _alpha!(solver, _alpha(solver)/2)
+        _cnt(solver).l += 1
+        if _alpha(solver) < alpha_min
+            @debug(_logger(solver),
+                    "Cannot find an acceptable step at iteration $(_cnt(solver).k). Switching to restoration phase.")
+            _cnt(solver).k+=1
             return RESTORE
         else
-            @trace(solver.logger,"Step rejected; proceed with the next trial step.")
-            if solver.alpha * norm(primal(solver.d)) < eps(T)*10
-                if (solver.cnt.restoration_fail_count += 1) >= 4
-                    return solver.cnt.acceptable_cnt >0 ?
+            @trace(_logger(solver),"Step rejected; proceed with the next trial step.")
+            if _alpha(solver) * norm(primal(_d(solver))) < eps(T)*10
+                if (_cnt(solver).restoration_fail_count += 1) >= 4
+                    return _cnt(solver).acceptable_cnt >0 ?
                         SOLVED_TO_ACCEPTABLE_LEVEL : SEARCH_DIRECTION_BECOMES_TOO_SMALL
                 else
                     # (experimental) while giving up directly
                     # we give MadNLP.jl second chance to explore
                     # some possibility at the current iterate
 
-                    fill!(solver.y, zero(T))
-                    fill!(solver.zl_r, one(T))
-                    fill!(solver.zu_r, one(T))
-                    empty!(solver.filter)
-                    push!(solver.filter,(solver.theta_max,-Inf))
-                    solver.cnt.k+=1
+                    fill!(_y(solver), zero(T))
+                    fill!(_zl_r(solver), one(T))
+                    fill!(_zu_r(solver), one(T))
+                    empty!(_filter(solver))
+                    push!(_filter(solver),(_theta_max(solver),-Inf))
+                    _cnt(solver).k+=1
 
                     return REGULAR
                 end
@@ -100,22 +100,22 @@ function filter_line_search!(solver::AbstractMadNLPSolver{T}) where T
     # this implements the heuristics in Section 3.2 of Ipopt paper.
     # Case I is only implemented
     if unsuccessful_iterate
-        if (solver.cnt.unsuccessful_iterate += 1) >= 4
-            if solver.theta_max/10 > theta_trial
-                @debug(solver.logger, "restarting filter")
-                solver.theta_max /= 10
-                empty!(solver.filter)
-                push!(solver.filter,(solver.theta_max,-Inf))
+        if (_cnt(solver).unsuccessful_iterate += 1) >= 4
+            if _theta_max(solver)/10 > theta_trial
+                @debug(_logger(solver), "restarting filter")
+                _theta_max!(solver, _theta_max(solver)/10)
+                empty!(_filter(solver))
+                push!(_filter(solver),(_theta_max(solver),-Inf))
             end
-            solver.cnt.unsuccessful_iterate = 0
+            _cnt(solver).unsuccessful_iterate = 0
         end
     else
-        solver.cnt.unsuccessful_iterate = 0
+        _cnt(solver).unsuccessful_iterate = 0
     end
 
     if !switching_condition || !armijo_condition
-        @trace(solver.logger,"Augmenting filter.")
-        augment_filter!(solver.filter,theta_trial,varphi_trial,solver.opt.gamma_theta)
+        @trace(_logger(solver),"Augmenting filter.")
+        augment_filter!(_filter(solver),theta_trial,varphi_trial,_opt(solver).gamma_theta)
     end
 
     return LINESEARCH_SUCCEEDED
@@ -126,94 +126,95 @@ end
 =#
 
 function filter_line_search_RR!(solver::AbstractMadNLPSolver{T}) where T
-    RR = solver.RR
-    theta_R = get_theta_R(solver.c,RR.pp,RR.nn)
-    varphi_R = get_varphi_R(RR.obj_val_R,solver.x_lr,solver.xl_r,solver.xu_r,solver.x_ur,RR.pp,RR.nn,RR.mu_R)
+    RR = _RR(solver)
+    theta_R = get_theta_R(_c(solver),RR.pp,RR.nn)
+    varphi_R = get_varphi_R(RR.obj_val_R,_x_lr(solver),_xl_r(solver),_xu_r(solver),_x_ur(solver),RR.pp,RR.nn,RR.mu_R)
     varphi_d_R = get_varphi_d_R(
         RR.f_R,
-        primal(solver.x),
-        primal(solver.xl),
-        primal(solver.xu),
-        primal(solver.d),
-        RR.pp,RR.nn,RR.dpp,RR.dnn,RR.mu_R,solver.opt.rho,
+        primal(_x(solver)),
+        primal(_xl(solver)),
+        primal(_xu(solver)),
+        primal(_d(solver)),
+        RR.pp,RR.nn,RR.dpp,RR.dnn,RR.mu_R,_opt(solver).rho,
     )
 
     # set alpha_min
     alpha_max = get_alpha_max_R(
-        primal(solver.x),
-        primal(solver.xl),
-        primal(solver.xu),
-        primal(solver.d),
+        primal(_x(solver)),
+        primal(_xl(solver)),
+        primal(_xu(solver)),
+        primal(_d(solver)),
         RR.pp,RR.dpp,RR.nn,RR.dnn,RR.tau_R,
     )
-    solver.alpha_z = get_alpha_z_R(solver.zl_r,solver.zu_r,dual_lb(solver.d),dual_ub(solver.d),RR.zp,RR.dzp,RR.zn,RR.dzn,RR.tau_R)
-    alpha_min = get_alpha_min(theta_R,varphi_d_R,solver.theta_min,solver.opt.gamma_theta,solver.opt.gamma_phi,
-                                solver.opt.alpha_min_frac,solver.opt.delta,solver.opt.s_theta,solver.opt.s_phi)
+    _alpha_z!(solver, get_alpha_z_R(_zl_r(solver),_zu_r(solver),dual_lb(_d(solver)),dual_ub(_d(solver)),RR.zp,RR.dzp,RR.zn,RR.dzn,RR.tau_R))
+    alpha_min = get_alpha_min(theta_R,varphi_d_R,_theta_min(solver),_opt(solver).gamma_theta,_opt(solver).gamma_phi,
+                                _opt(solver).alpha_min_frac,_opt(solver).delta,_opt(solver).s_theta,_opt(solver).s_phi)
 
-    solver.alpha = alpha_max
-    solver.cnt.l = 1
+    _alpha!(solver, alpha_max)
+    _cnt(solver).l = 1
     theta_R_trial = zero(T)
     varphi_R_trial = zero(T)
-    small_search_norm = get_rel_search_norm(primal(solver.x), primal(solver.d)) < 10*eps(T)
-    switching_condition = is_switching(varphi_d_R,solver.alpha,solver.opt.s_phi,solver.opt.delta,theta_R,solver.opt.s_theta)
+    small_search_norm = get_rel_search_norm(primal(_x(solver)), primal(_d(solver))) < 10*eps(T)
+    switching_condition = is_switching(varphi_d_R,_alpha(solver),_opt(solver).s_phi,_opt(solver).delta,theta_R,_opt(solver).s_theta)
     armijo_condition = false
 
     while true
-        copyto!(full(solver.x_trial), full(solver.x))
+        copyto!(full(_x_trial(solver)), full(_x(solver)))
         copyto!(RR.pp_trial,RR.pp)
         copyto!(RR.nn_trial,RR.nn)
-        axpy!(solver.alpha,primal(solver.d),primal(solver.x_trial))
-        axpy!(solver.alpha,RR.dpp,RR.pp_trial)
-        axpy!(solver.alpha,RR.dnn,RR.nn_trial)
+        axpy!(_alpha(solver),primal(_d(solver)),primal(_x_trial(solver)))
+        axpy!(_alpha(solver),RR.dpp,RR.pp_trial)
+        axpy!(_alpha(solver),RR.dnn,RR.nn_trial)
 
         RR.obj_val_R_trial = get_obj_val_R(
-            RR.pp_trial,RR.nn_trial,RR.D_R,primal(solver.x_trial),RR.x_ref,solver.opt.rho,RR.zeta)
-        eval_cons_wrapper!(solver, solver.c_trial, solver.x_trial)
-        theta_R_trial  = get_theta_R(solver.c_trial,RR.pp_trial,RR.nn_trial)
+            RR.pp_trial,RR.nn_trial,RR.D_R,primal(_x_trial(solver)),RR.x_ref,_opt(solver).rho,RR.zeta)
+        eval_cons_wrapper!(solver, _c_trial(solver), _x_trial(solver))
+        theta_R_trial  = get_theta_R(_c_trial(solver),RR.pp_trial,RR.nn_trial)
         varphi_R_trial = get_varphi_R(
-            RR.obj_val_R_trial,solver.x_trial_lr,solver.xl_r,solver.xu_r,solver.x_trial_ur,RR.pp_trial,RR.nn_trial,RR.mu_R)
+            RR.obj_val_R_trial,_x_trial_lr(solver),_xl_r(solver),_xu_r(solver),_x_trial_ur(solver),RR.pp_trial,RR.nn_trial,RR.mu_R)
 
-        armijo_condition = is_armijo(varphi_R_trial,varphi_R,solver.opt.eta_phi,solver.alpha,varphi_d_R)
+        armijo_condition = is_armijo(varphi_R_trial,varphi_R,_opt(solver).eta_phi,_alpha(solver),varphi_d_R)
 
         small_search_norm && break
-        solver.ftype = get_ftype(
+        _ftype!(solver, get_ftype(
             RR.filter,theta_R,theta_R_trial,varphi_R,varphi_R_trial,
             switching_condition,armijo_condition,
-            solver.theta_min,solver.opt.obj_max_inc,solver.opt.gamma_theta,solver.opt.gamma_phi,
+            _theta_min(solver),_opt(solver).obj_max_inc,_opt(solver).gamma_theta,_opt(solver).gamma_phi,
             has_constraints(solver))
-        solver.ftype in ["f","h"] && (@trace(solver.logger,"Step accepted with type $(solver.ftype)"); break)
+                )
+        _ftype(solver) in ["f","h"] && (@trace(_logger(solver),"Step accepted with type $(_ftype(solver))"); break)
 
-        solver.alpha /= 2
-        solver.cnt.l += 1
-        if solver.alpha < alpha_min
-            @debug(solver.logger,"Restoration phase cannot find an acceptable step at iteration $(solver.cnt.k).")
-            if (solver.cnt.restoration_fail_count += 1) >= 4
+        _alpha!(solver, _alpha(solver)/2)
+        _cnt(solver).l += 1
+        if _alpha(solver) < alpha_min
+            @debug(_logger(solver),"Restoration phase cannot find an acceptable step at iteration $(_cnt(solver).k).")
+            if (_cnt(solver).restoration_fail_count += 1) >= 4
                 return RESTORATION_FAILED
             else
                 # (experimental) while giving up directly
                 # we give MadNLP.jl second chance to explore
                 # some possibility at the current iterate
 
-                fill!(solver.y, zero(T))
-                fill!(solver.zl_r, one(T))
-                fill!(solver.zu_r, one(T))
-                empty!(solver.filter)
-                push!(solver.filter,(solver.theta_max,-Inf))
+                fill!(_y(solver), zero(T))
+                fill!(_zl_r(solver), one(T))
+                fill!(_zu_r(solver), one(T))
+                empty!(_filter(solver))
+                push!(_filter(solver),(_theta_max(solver),-Inf))
 
-                solver.cnt.k+=1
-                solver.cnt.t+=1
+                _cnt(solver).k+=1
+                _cnt(solver).t+=1
                 return REGULAR
             end
         else
-            @trace(solver.logger,"Step rejected; proceed with the next trial step.")
-            solver.alpha < eps(T)*10 && return solver.cnt.acceptable_cnt >0 ?
+            @trace(_logger(solver),"Step rejected; proceed with the next trial step.")
+            _alpha(solver) < eps(T)*10 && return _cnt(solver).acceptable_cnt >0 ?
                 SOLVED_TO_ACCEPTABLE_LEVEL : SEARCH_DIRECTION_BECOMES_TOO_SMALL
         end
     end
 
     if !switching_condition || !armijo_condition
-        @trace(solver.logger,"Augmenting restoration phase filter.")
-        augment_filter!(RR.filter,theta_R_trial,varphi_R_trial,solver.opt.gamma_theta)
+        @trace(_logger(solver),"Augmenting restoration phase filter.")
+        augment_filter!(RR.filter,theta_R_trial,varphi_R_trial,_opt(solver).gamma_theta)
     end
 
     return LINESEARCH_SUCCEEDED

--- a/src/IPM/line_search.jl
+++ b/src/IPM/line_search.jl
@@ -22,11 +22,11 @@ function filter_line_search!(solver::AbstractMadNLPSolver{T}) where T
         primal(_d(solver)),
         _tau(solver),
     )
-    _alpha_z!(solver, get_alpha_z(_zl_r(solver),_zu_r(solver),dual_lb(_d(solver)),dual_ub(_d(solver)),_tau(solver)))
+    set_alpha_z!(solver, get_alpha_z(_zl_r(solver),_zu_r(solver),dual_lb(_d(solver)),dual_ub(_d(solver)),_tau(solver)))
     alpha_min = get_alpha_min(theta,varphi_d,_theta_min(solver),_opt(solver).gamma_theta,_opt(solver).gamma_phi,
                                 _opt(solver).alpha_min_frac,_opt(solver).delta,_opt(solver).s_theta,_opt(solver).s_phi)
     _cnt(solver).l = 1
-    _alpha!(solver, alpha_max)
+    set_alpha!(solver, alpha_max)
     varphi_trial= zero(T)
     theta_trial = zero(T)
     small_search_norm = get_rel_search_norm(primal(_x(solver)), primal(_d(solver))) < 10*eps(T)
@@ -38,7 +38,7 @@ function filter_line_search!(solver::AbstractMadNLPSolver{T}) where T
 
         copyto!(full(_x_trial(solver)), full(_x(solver)))
         axpy!(_alpha(solver), primal(_d(solver)), primal(_x_trial(solver)))
-        _obj_val_trial!(solver, eval_f_wrapper(solver, _x_trial(solver)))
+        set_obj_val_trial!(solver, eval_f_wrapper(solver, _x_trial(solver)))
         eval_cons_wrapper!(solver, _c_trial(solver), _x_trial(solver))
 
         theta_trial = get_theta(_c_trial(solver))
@@ -47,7 +47,7 @@ function filter_line_search!(solver::AbstractMadNLPSolver{T}) where T
 
         small_search_norm && break
 
-        _ftype!(solver, get_ftype(
+        set_ftype!(solver, get_ftype(
             _filter(solver),theta,theta_trial,varphi,varphi_trial,switching_condition,armijo_condition,
             _theta_min(solver),_opt(solver).obj_max_inc,_opt(solver).gamma_theta,_opt(solver).gamma_phi,
             has_constraints(solver))
@@ -66,7 +66,7 @@ function filter_line_search!(solver::AbstractMadNLPSolver{T}) where T
         end
 
         unsuccessful_iterate = true
-        _alpha!(solver, _alpha(solver)/2)
+        set_alpha!(solver, _alpha(solver)/2)
         _cnt(solver).l += 1
         if _alpha(solver) < alpha_min
             @debug(_logger(solver),
@@ -103,7 +103,7 @@ function filter_line_search!(solver::AbstractMadNLPSolver{T}) where T
         if (_cnt(solver).unsuccessful_iterate += 1) >= 4
             if _theta_max(solver)/10 > theta_trial
                 @debug(_logger(solver), "restarting filter")
-                _theta_max!(solver, _theta_max(solver)/10)
+                set_theta_max!(solver, _theta_max(solver)/10)
                 empty!(_filter(solver))
                 push!(_filter(solver),(_theta_max(solver),-Inf))
             end
@@ -146,11 +146,11 @@ function filter_line_search_RR!(solver::AbstractMadNLPSolver{T}) where T
         primal(_d(solver)),
         RR.pp,RR.dpp,RR.nn,RR.dnn,RR.tau_R,
     )
-    _alpha_z!(solver, get_alpha_z_R(_zl_r(solver),_zu_r(solver),dual_lb(_d(solver)),dual_ub(_d(solver)),RR.zp,RR.dzp,RR.zn,RR.dzn,RR.tau_R))
+    set_alpha_z!(solver, get_alpha_z_R(_zl_r(solver),_zu_r(solver),dual_lb(_d(solver)),dual_ub(_d(solver)),RR.zp,RR.dzp,RR.zn,RR.dzn,RR.tau_R))
     alpha_min = get_alpha_min(theta_R,varphi_d_R,_theta_min(solver),_opt(solver).gamma_theta,_opt(solver).gamma_phi,
                                 _opt(solver).alpha_min_frac,_opt(solver).delta,_opt(solver).s_theta,_opt(solver).s_phi)
 
-    _alpha!(solver, alpha_max)
+    set_alpha!(solver, alpha_max)
     _cnt(solver).l = 1
     theta_R_trial = zero(T)
     varphi_R_trial = zero(T)
@@ -176,7 +176,7 @@ function filter_line_search_RR!(solver::AbstractMadNLPSolver{T}) where T
         armijo_condition = is_armijo(varphi_R_trial,varphi_R,_opt(solver).eta_phi,_alpha(solver),varphi_d_R)
 
         small_search_norm && break
-        _ftype!(solver, get_ftype(
+        set_ftype!(solver, get_ftype(
             RR.filter,theta_R,theta_R_trial,varphi_R,varphi_R_trial,
             switching_condition,armijo_condition,
             _theta_min(solver),_opt(solver).obj_max_inc,_opt(solver).gamma_theta,_opt(solver).gamma_phi,
@@ -184,7 +184,7 @@ function filter_line_search_RR!(solver::AbstractMadNLPSolver{T}) where T
                 )
         _ftype(solver) in ["f","h"] && (@trace(_logger(solver),"Step accepted with type $(_ftype(solver))"); break)
 
-        _alpha!(solver, _alpha(solver)/2)
+        set_alpha!(solver, _alpha(solver)/2)
         _cnt(solver).l += 1
         if _alpha(solver) < alpha_min
             @debug(_logger(solver),"Restoration phase cannot find an acceptable step at iteration $(_cnt(solver).k).")

--- a/src/IPM/restoration.jl
+++ b/src/IPM/restoration.jl
@@ -38,7 +38,7 @@ end
 
 function initialize_robust_restorer!(solver::AbstractMadNLPSolver{T}) where T
     @trace(_logger(solver),"Initializing restoration phase variables.")
-    _RR(solver) == nothing && (_RR!(solver, RobustRestorer(solver)))
+    _RR(solver) == nothing && (set_RR!(solver, RobustRestorer(solver)))
     RR = _RR(solver)
 
     copyto!(RR.x_ref, full(_x(solver)))

--- a/src/IPM/restoration.jl
+++ b/src/IPM/restoration.jl
@@ -71,7 +71,7 @@ end
 
 function initialize_robust_restorer!(solver::AbstractMadNLPSolver{T}) where T
     @trace(_logger(solver),"Initializing restoration phase variables.")
-    _RR(solver) == nothing && (_RR(solver) = RobustRestorer(solver))
+    _RR(solver) == nothing && (_RR!(solver, RobustRestorer(solver)))
     RR = _RR(solver)
 
     copyto!(RR.x_ref, full(_x(solver)))
@@ -107,6 +107,6 @@ function initialize_robust_restorer!(solver::AbstractMadNLPSolver{T}) where T
     _cnt(solver).t = 0
 
     # misc
-    del_w!(solver, zero(T))
+    _del_w!(solver, zero(T))
 end
 

--- a/src/IPM/restoration.jl
+++ b/src/IPM/restoration.jl
@@ -1,36 +1,3 @@
-mutable struct RobustRestorer{T, VT}
-    obj_val_R::T
-    f_R::VT
-    x_ref::VT
-
-    theta_ref::T
-    D_R::VT
-    obj_val_R_trial::T
-
-    pp::VT
-    nn::VT
-    zp::VT
-    zn::VT
-
-    dpp::VT
-    dnn::VT
-    dzp::VT
-    dzn::VT
-
-    pp_trial::VT
-    nn_trial::VT
-
-    inf_pr_R::T
-    inf_du_R::T
-    inf_compl_R::T
-
-    mu_R::T
-    tau_R::T
-    zeta::T
-
-    filter::Vector{Tuple{T,T}}
-end
-
 function RobustRestorer(solver::AbstractMadNLPSolver{T}) where {T}
 
     f_R = similar(_y(solver), _n(solver))

--- a/src/IPM/restoration.jl
+++ b/src/IPM/restoration.jl
@@ -31,7 +31,7 @@ function RobustRestorer(solver::AbstractMadNLPSolver{T}) where {T}
         dpp, dnn, dzp, dzn, 
         pp_trial, 
         nn_trial, 
-        zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), 
+        zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T),
         Tuple{T, T}[], 
     )
 end

--- a/src/IPM/restoration.jl
+++ b/src/IPM/restoration.jl
@@ -74,6 +74,6 @@ function initialize_robust_restorer!(solver::AbstractMadNLPSolver{T}) where T
     _cnt(solver).t = 0
 
     # misc
-    _del_w!(solver, zero(T))
+    set_del_w!(solver, zero(T))
 end
 

--- a/src/IPM/restoration.jl
+++ b/src/IPM/restoration.jl
@@ -1,22 +1,22 @@
 function RobustRestorer(solver::AbstractMadNLPSolver{T}) where {T}
 
-    f_R = similar(_y(solver), _n(solver))
-    x_ref = similar(_y(solver), _n(solver))
-    D_R = similar(_y(solver), _n(solver))
-    pp = similar(_y(solver), _m(solver))
-    nn = similar(_y(solver), _m(solver))
-    pp_trial = similar(_y(solver), _m(solver))
-    nn_trial = similar(_y(solver), _m(solver))
+    f_R = similar(get_y(solver), get_n(solver))
+    x_ref = similar(get_y(solver), get_n(solver))
+    D_R = similar(get_y(solver), get_n(solver))
+    pp = similar(get_y(solver), get_m(solver))
+    nn = similar(get_y(solver), get_m(solver))
+    pp_trial = similar(get_y(solver), get_m(solver))
+    nn_trial = similar(get_y(solver), get_m(solver))
 
-    nn = similar(_y(solver), _m(solver))
-    zp = similar(_y(solver), _m(solver))
-    zn = similar(_y(solver), _m(solver))
-    dpp= similar(_y(solver), _m(solver))
-    dnn= similar(_y(solver), _m(solver))
-    dzp= similar(_y(solver), _m(solver))
-    dzn= similar(_y(solver), _m(solver))
-    pp_trial = similar(_y(solver), _m(solver))
-    nn_trial = similar(_y(solver), _m(solver))
+    nn = similar(get_y(solver), get_m(solver))
+    zp = similar(get_y(solver), get_m(solver))
+    zn = similar(get_y(solver), get_m(solver))
+    dpp= similar(get_y(solver), get_m(solver))
+    dnn= similar(get_y(solver), get_m(solver))
+    dzp= similar(get_y(solver), get_m(solver))
+    dzn= similar(get_y(solver), get_m(solver))
+    pp_trial = similar(get_y(solver), get_m(solver))
+    nn_trial = similar(get_y(solver), get_m(solver))
 
     return RobustRestorer(
         zero(T), 
@@ -37,41 +37,41 @@ function RobustRestorer(solver::AbstractMadNLPSolver{T}) where {T}
 end
 
 function initialize_robust_restorer!(solver::AbstractMadNLPSolver{T}) where T
-    @trace(_logger(solver),"Initializing restoration phase variables.")
-    _RR(solver) == nothing && (set_RR!(solver, RobustRestorer(solver)))
-    RR = _RR(solver)
+    @trace(get_logger(solver),"Initializing restoration phase variables.")
+    get_RR(solver) == nothing && (set_RR!(solver, RobustRestorer(solver)))
+    RR = get_RR(solver)
 
-    copyto!(RR.x_ref, full(_x(solver)))
-    RR.theta_ref = get_theta(_c(solver))
+    copyto!(RR.x_ref, full(get_x(solver)))
+    RR.theta_ref = get_theta(get_c(solver))
     RR.D_R .= min.(one(T), one(T) ./ abs.(RR.x_ref))
 
-    RR.mu_R = max(_mu(solver), norm(_c(solver), Inf))
-    RR.tau_R= max(_opt(solver).tau_min,1-RR.mu_R)
+    RR.mu_R = max(get_mu(solver), norm(get_c(solver), Inf))
+    RR.tau_R= max(get_opt(solver).tau_min,1-RR.mu_R)
     RR.zeta = sqrt(RR.mu_R)
 
-    rho = _opt(solver).rho
+    rho = get_opt(solver).rho
     mu = RR.mu_R
     RR.nn .=
-        (mu .- rho*_c(solver))./2 ./rho .+
+        (mu .- rho*get_c(solver))./2 ./rho .+
         sqrt.(
-            ((mu.-rho*_c(solver))./2 ./rho).^2 + mu.*_c(solver)./2 ./rho
+            ((mu.-rho*get_c(solver))./2 ./rho).^2 + mu.*get_c(solver)./2 ./rho
         )
-    RR.pp .= _c(solver) .+ RR.nn
+    RR.pp .= get_c(solver) .+ RR.nn
     RR.zp .= RR.mu_R ./ RR.pp
     RR.zn .= RR.mu_R ./ RR.nn
 
-    RR.obj_val_R = get_obj_val_R(RR.pp,RR.nn,RR.D_R,full(_x(solver)),RR.x_ref,_opt(solver).rho,RR.zeta)
+    RR.obj_val_R = get_obj_val_R(RR.pp,RR.nn,RR.D_R,full(get_x(solver)),RR.x_ref,get_opt(solver).rho,RR.zeta)
     fill!(RR.f_R, zero(T))
     empty!(RR.filter)
-    push!(RR.filter, (_theta_max(solver),-Inf))
+    push!(RR.filter, (get_theta_max(solver),-Inf))
 
-    fill!(_y(solver), zero(T))
-    _zl_r(solver) .= min.(_opt(solver).rho, _zl_r(solver))
-    _zu_r(solver) .= min.(_opt(solver).rho, _zu_r(solver))
-    # fill!(_zl_r(solver), one(T)) # Experimental
-    # fill!(_zu_r(solver), one(T)) # Experimental
+    fill!(get_y(solver), zero(T))
+    get_zl_r(solver) .= min.(get_opt(solver).rho, get_zl_r(solver))
+    get_zu_r(solver) .= min.(get_opt(solver).rho, get_zu_r(solver))
+    # fill!(get_zl_r(solver), one(T)) # Experimental
+    # fill!(get_zu_r(solver), one(T)) # Experimental
     
-    _cnt(solver).t = 0
+    get_cnt(solver).t = 0
 
     # misc
     set_del_w!(solver, zero(T))

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -15,71 +15,71 @@ solve!(nlp::AbstractNLPModel, solver::AbstractMadNLPSolver; kwargs...) = solve!(
     nlp, solver, MadNLPExecutionStats(solver);
     kwargs...)
 solve!(solver::AbstractMadNLPSolver; kwargs...) = solve!(
-    _nlp(solver), solver;
+    get_nlp(solver), solver;
     kwargs...)
 
 
 function initialize!(solver::AbstractMadNLPSolver{T}) where T
 
-    nlp = _nlp(solver)
-    opt = _opt(solver)
+    nlp = get_nlp(solver)
+    opt = get_opt(solver)
 
     # Initializing variables
-    @trace(_logger(solver),"Initializing variables.")
+    @trace(get_logger(solver),"Initializing variables.")
     initialize!(
-        _cb(solver),
-        _x(solver),
-        _xl(solver),
-        _xu(solver),
-        _y(solver),
-        _rhs(solver),
-        _ind_ineq(solver);
+        get_cb(solver),
+        get_x(solver),
+        get_xl(solver),
+        get_xu(solver),
+        get_y(solver),
+        get_rhs(solver),
+        get_ind_ineq(solver);
         tol=opt.bound_relax_factor,
         bound_push=opt.bound_push,
         bound_fac=opt.bound_fac,
     )
-    fill!(_jacl(solver), zero(T))
-    fill!(_zl_r(solver), one(T))
-    fill!(_zu_r(solver), one(T))
+    fill!(get_jacl(solver), zero(T))
+    fill!(get_zl_r(solver), one(T))
+    fill!(get_zu_r(solver), one(T))
 
     # Initializing scaling factors
     if opt.nlp_scaling
         set_scaling!(
-            _cb(solver),
-            _x(solver),
-            _xl(solver),
-            _xu(solver),
-            _y(solver),
-            _rhs(solver),
-            _ind_ineq(solver),
+            get_cb(solver),
+            get_x(solver),
+            get_xl(solver),
+            get_xu(solver),
+            get_y(solver),
+            get_rhs(solver),
+            get_ind_ineq(solver),
             opt.nlp_scaling_max_gradient
         )
     end
 
     # Initializing KKT system
-    initialize!(_kkt(solver))
+    initialize!(get_kkt(solver))
 
     # Initializing jacobian and gradient
-    eval_jac_wrapper!(solver, _kkt(solver), _x(solver))
-    eval_grad_f_wrapper!(solver, _f(solver),_x(solver))
+    eval_jac_wrapper!(solver, get_kkt(solver), get_x(solver))
+    eval_grad_f_wrapper!(solver, get_f(solver),get_x(solver))
 
 
-    @trace(_logger(solver),"Initializing constraint duals.")
-    if !_opt(solver).dual_initialized
+    @trace(get_logger(solver),"Initializing constraint duals.")
+    if !get_opt(solver).dual_initialized
         initialize_dual(solver, opt.dual_initialization_method)
     end
 
     # Initializing
-    set_obj_val!(solver, eval_f_wrapper(solver, _x(solver)))
-    eval_cons_wrapper!(solver, _c(solver), _x(solver))
-    eval_lag_hess_wrapper!(solver, _kkt(solver), _x(solver), _y(solver))
+    set_obj_val!(solver, eval_f_wrapper(solver, get_x(solver)))
+    eval_cons_wrapper!(solver, get_c(solver), get_x(solver))
+    eval_lag_hess_wrapper!(solver, get_kkt(solver), get_x(solver), get_y(solver))
 
-    theta = get_theta(_c(solver))
+    theta = get_theta(get_c(solver))
     set_theta_max!(solver, T(1e4)*max(one(T),theta))
     set_theta_min!(solver, T(1e-4)*max(one(T),theta))
-    set_mu!(solver, _opt(solver).barrier.mu_init)
-    set_tau!(solver, max(_opt(solver).tau_min,one(T)-_opt(solver).barrier.mu_init))
-    push!(_filter(solver), (_theta_max(solver),-T(Inf)))
+    set_mu!(solver, get_opt(solver).barrier.mu_init)
+    set_tau!(solver, max(get_opt(solver).tau_min,one(T)-get_opt(solver).barrier.mu_init))
+    push!(get_filter(solver), (get_theta_max(solver),-T(Inf)))
 
     return REGULAR
 end
@@ -89,37 +89,37 @@ struct DualInitializeSetZero <: DualInitializeOptions end
 struct DualInitializeLeastSquares <: DualInitializeOptions end
 
 function initialize_dual(solver::AbstractMadNLPSolver{T}, ::Type{DualInitializeSetZero}) where T
-    fill!(_y(solver), zero(T))
+    fill!(get_y(solver), zero(T))
 end
 function initialize_dual(solver::AbstractMadNLPSolver{T}, ::Type{DualInitializeLeastSquares}) where T
-    set_initial_rhs!(solver, _kkt(solver))
+    set_initial_rhs!(solver, get_kkt(solver))
     factorize_wrapper!(solver)
     is_solved = solve_refine_wrapper!(
-        _d(solver), solver, _p(solver), __w4(solver)
+        get_d(solver), solver, get_p(solver), get__w4(solver)
     )
-    if !is_solved || (norm(dual(_d(solver)), T(Inf)) > _opt(solver).constr_mult_init_max)
-        fill!(_y(solver), zero(T))
+    if !is_solved || (norm(dual(get_d(solver)), T(Inf)) > get_opt(solver).constr_mult_init_max)
+        fill!(get_y(solver), zero(T))
     else
-        copyto!(_y(solver), dual(_d(solver)))
+        copyto!(get_y(solver), dual(get_d(solver)))
     end
 end
 
 function reinitialize!(solver::AbstractMadNLPSolver)
-    variable(_x(solver)) .= get_x0(_nlp(solver))
+    variable(get_x(solver)) .= get_x0(get_nlp(solver))
 
-    set_obj_val!(solver, eval_f_wrapper(solver, _x(solver)))
-    eval_grad_f_wrapper!(solver, _f(solver), _x(solver))
-    eval_cons_wrapper!(solver, _c(solver), _x(solver))
-    eval_jac_wrapper!(solver, _kkt(solver), _x(solver))
-    eval_lag_hess_wrapper!(solver, _kkt(solver), _x(solver), _y(solver))
+    set_obj_val!(solver, eval_f_wrapper(solver, get_x(solver)))
+    eval_grad_f_wrapper!(solver, get_f(solver), get_x(solver))
+    eval_cons_wrapper!(solver, get_c(solver), get_x(solver))
+    eval_jac_wrapper!(solver, get_kkt(solver), get_x(solver))
+    eval_lag_hess_wrapper!(solver, get_kkt(solver), get_x(solver), get_y(solver))
 
-    theta = get_theta(_c(solver))
+    theta = get_theta(get_c(solver))
     set_theta_max!(solver, 1e4*max(1,theta))
     set_theta_min!(solver, 1e-4*max(1,theta))
-    set_mu!(solver, _opt(solver).barrier.mu_init)
-    set_tau!(solver, max(_opt(solver).tau_min,1-_opt(solver).barrier.mu_init))
-    empty!(_filter(solver))
-    push!(_filter(solver), (_theta_max(solver),-Inf))
+    set_mu!(solver, get_opt(solver).barrier.mu_init)
+    set_tau!(solver, max(get_opt(solver).tau_min,1-get_opt(solver).barrier.mu_init))
+    empty!(get_filter(solver))
+    push!(get_filter(solver), (get_theta_max(solver),-Inf))
 
     return REGULAR
 end
@@ -135,36 +135,36 @@ function solve!(
         )
 
     if x != nothing
-        full(_x(solver))[1:get_nvar(nlp)] .= x
+        full(get_x(solver))[1:get_nvar(nlp)] .= x
     end
     if y != nothing
-        _y(solver)[1:get_ncon(nlp)] .= y
+        get_y(solver)[1:get_ncon(nlp)] .= y
     end
     if zl != nothing
-        full(_zl(solver))[1:get_nvar(nlp)] .= zl
+        full(get_zl(solver))[1:get_nvar(nlp)] .= zl
     end
     if zu != nothing
-        full(_zu(solver))[1:get_nvar(nlp)] .= zu
+        full(get_zu(solver))[1:get_nvar(nlp)] .= zu
     end
 
     if !isempty(kwargs)
-        @warn(_logger(solver),"The options set during resolve may not have an effect")
-        set_options!(_opt(solver), kwargs)
+        @warn(get_logger(solver),"The options set during resolve may not have an effect")
+        set_options!(get_opt(solver), kwargs)
     end
 
     try
-        if _status(solver) == INITIAL
-            @notice(_logger(solver),"This is $(introduce()), running with $(introduce(_kkt(solver).linear_solver))\n")
+        if get_status(solver) == INITIAL
+            @notice(get_logger(solver),"This is $(introduce()), running with $(introduce(get_kkt(solver).linear_solver))\n")
             print_init(solver)
             set_status!(solver, initialize!(solver))
         else # resolving the problem
             set_status!(solver, reinitialize!(solver))
         end
 
-        while _status(solver) >= REGULAR
-            _status(solver) == REGULAR && (set_status!(solver, regular!(solver)))
-            _status(solver) == RESTORE && (set_status!(solver, restore!(solver)))
-            _status(solver) == ROBUST && (set_status!(solver, robust!(solver)))
+        while get_status(solver) >= REGULAR
+            get_status(solver) == REGULAR && (set_status!(solver, regular!(solver)))
+            get_status(solver) == RESTORE && (set_status!(solver, restore!(solver)))
+            get_status(solver) == ROBUST && (set_status!(solver, robust!(solver)))
         end
     catch e
         if e isa InvalidNumberException
@@ -185,23 +185,23 @@ function solve!(
             set_status!(solver, NOT_ENOUGH_DEGREES_OF_FREEDOM)
         elseif e isa LinearSolverException
             set_status!(solver, ERROR_IN_STEP_COMPUTATION;)
-            _opt(solver).rethrow_error && rethrow(e)
+            get_opt(solver).rethrow_error && rethrow(e)
         elseif e isa InterruptException
             set_status!(solver, USER_REQUESTED_STOP)
-            _opt(solver).rethrow_error && rethrow(e)
+            get_opt(solver).rethrow_error && rethrow(e)
         else
             set_status!(solver, INTERNAL_ERROR)
-            _opt(solver).rethrow_error && rethrow(e)
+            get_opt(solver).rethrow_error && rethrow(e)
         end
     finally
-        _cnt(solver).total_time = time() - _cnt(solver).start_time
-        if !(_status(solver) < SOLVE_SUCCEEDED)
+        get_cnt(solver).total_time = time() - get_cnt(solver).start_time
+        if !(get_status(solver) < SOLVE_SUCCEEDED)
             print_summary(solver)
         end
-        @notice(_logger(solver),"$(Base.text_colors[color_status(_status(solver))])EXIT: $(get_status_output(_status(solver), _opt(solver)))$(Base.text_colors[:normal])")
-        _opt(solver).disable_garbage_collector &&
-            (GC.enable(true); @warn(_logger(solver),"Julia garbage collector is turned back on"))
-        finalize(_logger(solver))
+        @notice(get_logger(solver),"$(Base.text_colors[color_status(get_status(solver))])EXIT: $(get_status_output(get_status(solver), get_opt(solver)))$(Base.text_colors[:normal])")
+        get_opt(solver).disable_garbage_collector &&
+            (GC.enable(true); @warn(get_logger(solver),"Julia garbage collector is turned back on"))
+        finalize(get_logger(solver))
 
         update!(stats,solver)
     end
@@ -217,34 +217,34 @@ color_status(status::Status) =
 
 function regular!(solver::AbstractMadNLPSolver{T}) where T
     while true
-        if (_cnt(solver).k!=0 && !_opt(solver).jacobian_constant)
-            eval_jac_wrapper!(solver, _kkt(solver), _x(solver))
+        if (get_cnt(solver).k!=0 && !get_opt(solver).jacobian_constant)
+            eval_jac_wrapper!(solver, get_kkt(solver), get_x(solver))
         end
 
-        jtprod!(_jacl(solver), _kkt(solver), _y(solver))
-        sd = get_sd(_y(solver),_zl_r(solver),_zu_r(solver),T(_opt(solver).s_max))
-        sc = get_sc(_zl_r(solver),_zu_r(solver),T(_opt(solver).s_max))
-        set_inf_pr!(solver, get_inf_pr(_c(solver)))
+        jtprod!(get_jacl(solver), get_kkt(solver), get_y(solver))
+        sd = get_sd(get_y(solver),get_zl_r(solver),get_zu_r(solver),T(get_opt(solver).s_max))
+        sc = get_sc(get_zl_r(solver),get_zu_r(solver),T(get_opt(solver).s_max))
+        set_inf_pr!(solver, get_inf_pr(get_c(solver)))
         set_inf_du!(solver, get_inf_du(
-            full(_f(solver)),
-            full(_zl(solver)),
-            full(_zu(solver)),
-            _jacl(solver),
+            full(get_f(solver)),
+            full(get_zl(solver)),
+            full(get_zu(solver)),
+            get_jacl(solver),
             sd,
         ))
-        set_inf_compl!(solver, _inf_compl(solver, sc; mu=zero(T)))
+        set_inf_compl!(solver, get_inf_compl(solver, sc; mu=zero(T)))
 
         print_iter(solver)
 
         # evaluate termination criteria
-        @trace(_logger(solver),"Evaluating termination criteria.")
-        _inf_total(solver) <= _opt(solver).tol && return SOLVE_SUCCEEDED
-        _inf_total(solver) <= _opt(solver).acceptable_tol ?
-            (_cnt(solver).acceptable_cnt < _opt(solver).acceptable_iter ?
-            _cnt(solver).acceptable_cnt+=1 : return SOLVED_TO_ACCEPTABLE_LEVEL) : (_cnt(solver).acceptable_cnt = 0)
-        _inf_total(solver) >= _opt(solver).diverging_iterates_tol && return DIVERGING_ITERATES
-        _cnt(solver).k>=_opt(solver).max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
-        time()-_cnt(solver).start_time>=_opt(solver).max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
+        @trace(get_logger(solver),"Evaluating termination criteria.")
+        get_inf_total(solver) <= get_opt(solver).tol && return SOLVE_SUCCEEDED
+        get_inf_total(solver) <= get_opt(solver).acceptable_tol ?
+            (get_cnt(solver).acceptable_cnt < get_opt(solver).acceptable_iter ?
+            get_cnt(solver).acceptable_cnt+=1 : return SOLVED_TO_ACCEPTABLE_LEVEL) : (get_cnt(solver).acceptable_cnt = 0)
+        get_inf_total(solver) >= get_opt(solver).diverging_iterates_tol && return DIVERGING_ITERATES
+        get_cnt(solver).k>=get_opt(solver).max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
+        time()-get_cnt(solver).start_time>=get_opt(solver).max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
 
         # evaluate Hessian
         if (solver.cnt.k!=0 && !solver.opt.hessian_constant)
@@ -262,39 +262,39 @@ function regular!(solver::AbstractMadNLPSolver{T}) where T
         dual_inf_perturbation!(primal(solver.p),solver.ind_llb,solver.ind_uub,solver.mu,solver.opt.kappa_d)
         inertia_correction!(solver.inertia_corrector, solver) || return ROBUST
 
-        @trace(_logger(solver),"Backtracking line search initiated.")
+        @trace(get_logger(solver),"Backtracking line search initiated.")
         status = filter_line_search!(solver)
         if status != LINESEARCH_SUCCEEDED
             return status
         end
 
-        @trace(_logger(solver),"Updating primal-dual variables.")
-        copyto!(full(_x(solver)), full(_x_trial(solver)))
-        copyto!(_c(solver), _c_trial(solver))
-        set_obj_val!(solver, _obj_val_trial(solver))
-        adjust_boundary!(_x_lr(solver),_xl_r(solver),_x_ur(solver),_xu_r(solver),_mu(solver))
+        @trace(get_logger(solver),"Updating primal-dual variables.")
+        copyto!(full(get_x(solver)), full(get_x_trial(solver)))
+        copyto!(get_c(solver), get_c_trial(solver))
+        set_obj_val!(solver, get_obj_val_trial(solver))
+        adjust_boundary!(get_x_lr(solver),get_xl_r(solver),get_x_ur(solver),get_xu_r(solver),get_mu(solver))
 
-        axpy!(_alpha(solver),dual(_d(solver)),_y(solver))
+        axpy!(get_alpha(solver),dual(get_d(solver)),get_y(solver))
 
-        _zl_r(solver) .+= _alpha_z(solver) .* dual_lb(_d(solver))
-        _zu_r(solver) .+= _alpha_z(solver) .* dual_ub(_d(solver))
+        get_zl_r(solver) .+= get_alpha_z(solver) .* dual_lb(get_d(solver))
+        get_zu_r(solver) .+= get_alpha_z(solver) .* dual_ub(get_d(solver))
         reset_bound_dual!(
-            primal(_zl(solver)),
-            primal(_x(solver)),
-            primal(_xl(solver)),
-            _mu(solver),_opt(solver).kappa_sigma,
+            primal(get_zl(solver)),
+            primal(get_x(solver)),
+            primal(get_xl(solver)),
+            get_mu(solver),get_opt(solver).kappa_sigma,
         )
         reset_bound_dual!(
-            primal(_zu(solver)),
-            primal(_xu(solver)),
-            primal(_x(solver)),
-            _mu(solver),_opt(solver).kappa_sigma,
+            primal(get_zu(solver)),
+            primal(get_xu(solver)),
+            primal(get_x(solver)),
+            get_mu(solver),get_opt(solver).kappa_sigma,
         )
 
-        eval_grad_f_wrapper!(solver, _f(solver),_x(solver))
+        eval_grad_f_wrapper!(solver, get_f(solver),get_x(solver))
 
-        _cnt(solver).k+=1
-        @trace(_logger(solver),"Proceeding to the next interior point iteration.")
+        get_cnt(solver).k+=1
+        @trace(get_logger(solver),"Proceeding to the next interior point iteration.")
     end
 end
 
@@ -302,109 +302,109 @@ end
 function restore!(solver::AbstractMadNLPSolver{T}) where T
     set_del_w!(solver, zero(T))
     # Backup the previous primal iterate
-    copyto!(primal(__w1(solver)), full(_x(solver)))
-    copyto!(dual(__w1(solver)), _y(solver))
-    copyto!(dual(__w2(solver)), _c(solver))
+    copyto!(primal(get__w1(solver)), full(get_x(solver)))
+    copyto!(dual(get__w1(solver)), get_y(solver))
+    copyto!(dual(get__w2(solver)), get_c(solver))
 
     F = get_F(
-        _c(solver),
-        primal(_f(solver)),
-        primal(_zl(solver)),
-        primal(_zu(solver)),
-        _jacl(solver),
-        _x_lr(solver),
-        _xl_r(solver),
-        _zl_r(solver),
-        _xu_r(solver),
-        _x_ur(solver),
-        _zu_r(solver),
-        _mu(solver),
+        get_c(solver),
+        primal(get_f(solver)),
+        primal(get_zl(solver)),
+        primal(get_zu(solver)),
+        get_jacl(solver),
+        get_x_lr(solver),
+        get_xl_r(solver),
+        get_zl_r(solver),
+        get_xu_r(solver),
+        get_x_ur(solver),
+        get_zu_r(solver),
+        get_mu(solver),
     )
     set_alpha_z!(solver, zero(T))
     set_ftype!(solver, "R")
     while true
         alpha_max = get_alpha_max(
-            primal(_x(solver)),
-            primal(_xl(solver)),
-            primal(_xu(solver)),
-            primal(_d(solver)),
-            _tau(solver),
+            primal(get_x(solver)),
+            primal(get_xl(solver)),
+            primal(get_xu(solver)),
+            primal(get_d(solver)),
+            get_tau(solver),
         )
         set_alpha!(solver,min(
             alpha_max,
-            get_alpha_z(_zl_r(solver),_zu_r(solver),dual_lb(_d(solver)),dual_ub(_d(solver)),_tau(solver)),
+            get_alpha_z(get_zl_r(solver),get_zu_r(solver),dual_lb(get_d(solver)),dual_ub(get_d(solver)),get_tau(solver)),
         ))
 
-        axpy!(_alpha(solver), primal(_d(solver)), full(_x(solver)))
-        axpy!(_alpha(solver), dual(_d(solver)), _y(solver))
-        _zl_r(solver) .+= _alpha(solver) .* dual_lb(_d(solver))
-        _zu_r(solver) .+= _alpha(solver) .* dual_ub(_d(solver))
+        axpy!(get_alpha(solver), primal(get_d(solver)), full(get_x(solver)))
+        axpy!(get_alpha(solver), dual(get_d(solver)), get_y(solver))
+        get_zl_r(solver) .+= get_alpha(solver) .* dual_lb(get_d(solver))
+        get_zu_r(solver) .+= get_alpha(solver) .* dual_ub(get_d(solver))
 
-        eval_cons_wrapper!(solver,_c(solver),_x(solver))
-        eval_grad_f_wrapper!(solver,_f(solver),_x(solver))
-        set_obj_val!(solver, eval_f_wrapper(solver,_x(solver)))
+        eval_cons_wrapper!(solver,get_c(solver),get_x(solver))
+        eval_grad_f_wrapper!(solver,get_f(solver),get_x(solver))
+        set_obj_val!(solver, eval_f_wrapper(solver,get_x(solver)))
 
-        !_opt(solver).jacobian_constant && eval_jac_wrapper!(solver,_kkt(solver),_x(solver))
-        jtprod!(_jacl(solver),_kkt(solver),_y(solver))
+        !get_opt(solver).jacobian_constant && eval_jac_wrapper!(solver,get_kkt(solver),get_x(solver))
+        jtprod!(get_jacl(solver),get_kkt(solver),get_y(solver))
 
         F_trial = get_F(
-            _c(solver),
-            primal(_f(solver)),
-            primal(_zl(solver)),
-            primal(_zu(solver)),
-            _jacl(solver),
-            _x_lr(solver),
-            _xl_r(solver),
-            _zl_r(solver),
-            _xu_r(solver),
-            _x_ur(solver),
-            _zu_r(solver),
-            _mu(solver),
+            get_c(solver),
+            primal(get_f(solver)),
+            primal(get_zl(solver)),
+            primal(get_zu(solver)),
+            get_jacl(solver),
+            get_x_lr(solver),
+            get_xl_r(solver),
+            get_zl_r(solver),
+            get_xu_r(solver),
+            get_x_ur(solver),
+            get_zu_r(solver),
+            get_mu(solver),
         )
-        if F_trial > _opt(solver).soft_resto_pderror_reduction_factor*F
-            copyto!(primal(_x(solver)), primal(__w1(solver)))
-            copyto!(_y(solver), dual(__w1(solver)))
-            copyto!(_c(solver), dual(__w2(solver))) # backup the previous primal iterate
+        if F_trial > get_opt(solver).soft_resto_pderror_reduction_factor*F
+            copyto!(primal(get_x(solver)), primal(get__w1(solver)))
+            copyto!(get_y(solver), dual(get__w1(solver)))
+            copyto!(get_c(solver), dual(get__w2(solver))) # backup the previous primal iterate
             return ROBUST
         end
 
-        adjust_boundary!(_x_lr(solver),_xl_r(solver),_x_ur(solver),_xu_r(solver),_mu(solver))
+        adjust_boundary!(get_x_lr(solver),get_xl_r(solver),get_x_ur(solver),get_xu_r(solver),get_mu(solver))
 
         F = F_trial
 
-        theta = get_theta(_c(solver))
-        varphi= get_varphi(_obj_val(solver),_x_lr(solver),_xl_r(solver),_xu_r(solver),_x_ur(solver),_mu(solver))
+        theta = get_theta(get_c(solver))
+        varphi= get_varphi(get_obj_val(solver),get_x_lr(solver),get_xl_r(solver),get_xu_r(solver),get_x_ur(solver),get_mu(solver))
 
-        _cnt(solver).k+=1
+        get_cnt(solver).k+=1
 
-        is_filter_acceptable(_filter(solver),theta,varphi) ? (return REGULAR) : (_cnt(solver).t+=1)
-        _cnt(solver).k>=_opt(solver).max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
-        time()-_cnt(solver).start_time>=_opt(solver).max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
+        is_filter_acceptable(get_filter(solver),theta,varphi) ? (return REGULAR) : (get_cnt(solver).t+=1)
+        get_cnt(solver).k>=get_opt(solver).max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
+        time()-get_cnt(solver).start_time>=get_opt(solver).max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
 
 
-        sd = get_sd(_y(solver),_zl_r(solver),_zu_r(solver),_opt(solver).s_max)
-        sc = get_sc(_zl_r(solver),_zu_r(solver),_opt(solver).s_max)
-        set_inf_pr!(solver, get_inf_pr(_c(solver)))
+        sd = get_sd(get_y(solver),get_zl_r(solver),get_zu_r(solver),get_opt(solver).s_max)
+        sc = get_sc(get_zl_r(solver),get_zu_r(solver),get_opt(solver).s_max)
+        set_inf_pr!(solver, get_inf_pr(get_c(solver)))
         set_inf_du!(solver, get_inf_du(
-            primal(_f(solver)),
-            primal(_zl(solver)),
-            primal(_zu(solver)),
-            _jacl(solver),
+            primal(get_f(solver)),
+            primal(get_zl(solver)),
+            primal(get_zu(solver)),
+            get_jacl(solver),
             sd,
         ))
 
-        set_inf_compl!(solver, get_inf_compl(_x_lr(solver),_xl_r(solver),_zl_r(solver),_xu_r(solver),_x_ur(solver),_zu_r(solver),zero(T),sc))
-        inf_compl_mu = get_inf_compl(_x_lr(solver),_xl_r(solver),_zl_r(solver),_xu_r(solver),_x_ur(solver),_zu_r(solver),_mu(solver),sc)
+        set_inf_compl!(solver, get_inf_compl(get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),zero(T),sc))
+        inf_compl_mu = get_inf_compl(get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),get_mu(solver),sc)
         print_iter(solver)
 
-        !_opt(solver).hessian_constant && eval_lag_hess_wrapper!(solver,_kkt(solver),_x(solver),_y(solver))
-        set_aug_diagonal!(_kkt(solver),solver)
-        set_aug_rhs!(solver, _kkt(solver), _c(solver), _mu(solver))
+        !get_opt(solver).hessian_constant && eval_lag_hess_wrapper!(solver,get_kkt(solver),get_x(solver),get_y(solver))
+        set_aug_diagonal!(get_kkt(solver),solver)
+        set_aug_rhs!(solver, get_kkt(solver), get_c(solver), get_mu(solver))
 
-        dual_inf_perturbation!(primal(_p(solver)),_ind_llb(solver),_ind_uub(solver),_mu(solver),_opt(solver).kappa_d)
+        dual_inf_perturbation!(primal(get_p(solver)),get_ind_llb(solver),get_ind_uub(solver),get_mu(solver),get_opt(solver).kappa_d)
         factorize_wrapper!(solver)
         solve_refine_wrapper!(
-            _d(solver), solver, _p(solver), __w4(solver)
+            get_d(solver), solver, get_p(solver), get__w4(solver)
         )
 
         set_ftype!(solver, "f")
@@ -413,38 +413,38 @@ end
 
 function robust!(solver::AbstractMadNLPSolver{T}) where T
     initialize_robust_restorer!(solver)
-    RR = _RR(solver)
+    RR = get_RR(solver)
     while true
-        if !_opt(solver).jacobian_constant
-            eval_jac_wrapper!(solver, _kkt(solver), _x(solver))
+        if !get_opt(solver).jacobian_constant
+            eval_jac_wrapper!(solver, get_kkt(solver), get_x(solver))
         end
-        jtprod!(_jacl(solver), _kkt(solver), _y(solver))
+        jtprod!(get_jacl(solver), get_kkt(solver), get_y(solver))
 
         # evaluate termination criteria
-        @trace(_logger(solver),"Evaluating restoration phase termination criteria.")
-        sd = get_sd(_y(solver),_zl_r(solver),_zu_r(solver),_opt(solver).s_max)
-        sc = get_sc(_zl_r(solver),_zu_r(solver),_opt(solver).s_max)
-        set_inf_pr!(solver, get_inf_pr(_c(solver)))
+        @trace(get_logger(solver),"Evaluating restoration phase termination criteria.")
+        sd = get_sd(get_y(solver),get_zl_r(solver),get_zu_r(solver),get_opt(solver).s_max)
+        sc = get_sc(get_zl_r(solver),get_zu_r(solver),get_opt(solver).s_max)
+        set_inf_pr!(solver, get_inf_pr(get_c(solver)))
         set_inf_du!(solver, get_inf_du(
-            primal(_f(solver)),
-            primal(_zl(solver)),
-            primal(_zu(solver)),
-            _jacl(solver),
+            primal(get_f(solver)),
+            primal(get_zl(solver)),
+            primal(get_zu(solver)),
+            get_jacl(solver),
             sd,
         ))
-        set_inf_compl!(solver, get_inf_compl(_x_lr(solver),_xl_r(solver),_zl_r(solver),_xu_r(solver),_x_ur(solver),_zu_r(solver),zero(T),sc))
+        set_inf_compl!(solver, get_inf_compl(get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),zero(T),sc))
 
         # Robust restoration phase error
-        RR.inf_pr_R = get_inf_pr_R(_c(solver),RR.pp,RR.nn)
-        RR.inf_du_R = get_inf_du_R(RR.f_R,_y(solver),primal(_zl(solver)),primal(_zu(solver)),_jacl(solver),RR.zp,RR.zn,_opt(solver).rho,sd)
+        RR.inf_pr_R = get_inf_pr_R(get_c(solver),RR.pp,RR.nn)
+        RR.inf_du_R = get_inf_du_R(RR.f_R,get_y(solver),primal(get_zl(solver)),primal(get_zu(solver)),get_jacl(solver),RR.zp,RR.zn,get_opt(solver).rho,sd)
         RR.inf_compl_R = get_inf_compl_R(
-            _x_lr(solver),_xl_r(solver),_zl_r(solver),_xu_r(solver),_x_ur(solver),_zu_r(solver),RR.pp,RR.zp,RR.nn,RR.zn,zero(T),sc)
+            get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),RR.pp,RR.zp,RR.nn,RR.zn,zero(T),sc)
 
         print_iter(solver;is_resto=true)
 
-        max(RR.inf_pr_R,RR.inf_du_R,RR.inf_compl_R) <= _opt(solver).tol && return INFEASIBLE_PROBLEM_DETECTED
-        _cnt(solver).k>=_opt(solver).max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
-        time()-_cnt(solver).start_time>=_opt(solver).max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
+        max(RR.inf_pr_R,RR.inf_du_R,RR.inf_compl_R) <= get_opt(solver).tol && return INFEASIBLE_PROBLEM_DETECTED
+        get_cnt(solver).k>=get_opt(solver).max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
+        time()-get_cnt(solver).start_time>=get_opt(solver).max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
 
         # update the barrier parameter
         @trace(solver.logger,"Updating restoration phase barrier parameter.")
@@ -460,148 +460,148 @@ function robust!(solver::AbstractMadNLPSolver{T}) where T
         set_aug_rhs_RR!(solver, solver.kkt, RR, solver.opt.rho)
         inertia_correction!(solver.inertia_corrector, solver) || return RESTORATION_FAILED
         finish_aug_solve_RR!(
-            RR.dpp,RR.dnn,RR.dzp,RR.dzn,_y(solver),dual(_d(solver)),
-            RR.pp,RR.nn,RR.zp,RR.zn,RR.mu_R,_opt(solver).rho
+            RR.dpp,RR.dnn,RR.dzp,RR.dzn,get_y(solver),dual(get_d(solver)),
+            RR.pp,RR.nn,RR.zp,RR.zn,RR.mu_R,get_opt(solver).rho
         )
 
         # filter start
-        @trace(_logger(solver),"Backtracking line search initiated.")
+        @trace(get_logger(solver),"Backtracking line search initiated.")
         status = filter_line_search_RR!(solver)
         if status != LINESEARCH_SUCCEEDED
             return status
         end
 
-        @trace(_logger(solver),"Updating primal-dual variables.")
-        copyto!(full(_x(solver)), full(_x_trial(solver)))
-        copyto!(_c(solver), _c_trial(solver))
+        @trace(get_logger(solver),"Updating primal-dual variables.")
+        copyto!(full(get_x(solver)), full(get_x_trial(solver)))
+        copyto!(get_c(solver), get_c_trial(solver))
         copyto!(RR.pp, RR.pp_trial)
         copyto!(RR.nn, RR.nn_trial)
 
         RR.obj_val_R=RR.obj_val_R_trial
         set_f_RR!(solver,RR)
 
-        axpy!(_alpha(solver), dual(_d(solver)), _y(solver))
-        axpy!(_alpha_z(solver), RR.dzp,RR.zp)
-        axpy!(_alpha_z(solver), RR.dzn,RR.zn)
+        axpy!(get_alpha(solver), dual(get_d(solver)), get_y(solver))
+        axpy!(get_alpha_z(solver), RR.dzp,RR.zp)
+        axpy!(get_alpha_z(solver), RR.dzn,RR.zn)
 
-        _zl_r(solver) .+= _alpha_z(solver) .* dual_lb(_d(solver))
-        _zu_r(solver) .+= _alpha_z(solver) .* dual_ub(_d(solver))
+        get_zl_r(solver) .+= get_alpha_z(solver) .* dual_lb(get_d(solver))
+        get_zu_r(solver) .+= get_alpha_z(solver) .* dual_ub(get_d(solver))
 
         reset_bound_dual!(
-            primal(_zl(solver)),
-            primal(_x(solver)),
-            primal(_xl(solver)),
-            RR.mu_R, _opt(solver).kappa_sigma,
+            primal(get_zl(solver)),
+            primal(get_x(solver)),
+            primal(get_xl(solver)),
+            RR.mu_R, get_opt(solver).kappa_sigma,
         )
         reset_bound_dual!(
-            primal(_zu(solver)),
-            primal(_xu(solver)),
-            primal(_x(solver)),
-            RR.mu_R, _opt(solver).kappa_sigma,
+            primal(get_zu(solver)),
+            primal(get_xu(solver)),
+            primal(get_x(solver)),
+            RR.mu_R, get_opt(solver).kappa_sigma,
         )
-        reset_bound_dual!(RR.zp,RR.pp,RR.mu_R,_opt(solver).kappa_sigma)
-        reset_bound_dual!(RR.zn,RR.nn,RR.mu_R,_opt(solver).kappa_sigma)
+        reset_bound_dual!(RR.zp,RR.pp,RR.mu_R,get_opt(solver).kappa_sigma)
+        reset_bound_dual!(RR.zn,RR.nn,RR.mu_R,get_opt(solver).kappa_sigma)
 
-        adjust_boundary!(_x_lr(solver),_xl_r(solver),_x_ur(solver),_xu_r(solver),_mu(solver))
+        adjust_boundary!(get_x_lr(solver),get_xl_r(solver),get_x_ur(solver),get_xu_r(solver),get_mu(solver))
 
         # check if going back to regular phase
-        @trace(_logger(solver),"Checking if going back to regular phase.")
-        set_obj_val!(solver, eval_f_wrapper(solver, _x(solver)))
-        eval_grad_f_wrapper!(solver, _f(solver), _x(solver))
-        theta = get_theta(_c(solver))
-        varphi= get_varphi(_obj_val(solver),_x_lr(solver),_xl_r(solver),_xu_r(solver),_x_ur(solver),_mu(solver))
+        @trace(get_logger(solver),"Checking if going back to regular phase.")
+        set_obj_val!(solver, eval_f_wrapper(solver, get_x(solver)))
+        eval_grad_f_wrapper!(solver, get_f(solver), get_x(solver))
+        theta = get_theta(get_c(solver))
+        varphi= get_varphi(get_obj_val(solver),get_x_lr(solver),get_xl_r(solver),get_xu_r(solver),get_x_ur(solver),get_mu(solver))
 
-        if is_filter_acceptable(_filter(solver),theta,varphi) &&
-            theta <= _opt(solver).required_infeasibility_reduction * RR.theta_ref
+        if is_filter_acceptable(get_filter(solver),theta,varphi) &&
+            theta <= get_opt(solver).required_infeasibility_reduction * RR.theta_ref
 
-            @trace(_logger(solver),"Going back to the regular phase.")
-            set_initial_rhs!(solver, _kkt(solver))
-            initialize!(_kkt(solver))
+            @trace(get_logger(solver),"Going back to the regular phase.")
+            set_initial_rhs!(solver, get_kkt(solver))
+            initialize!(get_kkt(solver))
 
             factorize_wrapper!(solver)
             solve_refine_wrapper!(
-                _d(solver), solver, _p(solver), __w4(solver)
+                get_d(solver), solver, get_p(solver), get__w4(solver)
             )
-            if norm(dual(_d(solver)), Inf)>_opt(solver).constr_mult_init_max
-                fill!(_y(solver), zero(T))
+            if norm(dual(get_d(solver)), Inf)>get_opt(solver).constr_mult_init_max
+                fill!(get_y(solver), zero(T))
             else
-                copyto!(_y(solver), dual(_d(solver)))
+                copyto!(get_y(solver), dual(get_d(solver)))
             end
 
-            _cnt(solver).k+=1
-            _cnt(solver).t+=1
+            get_cnt(solver).k+=1
+            get_cnt(solver).t+=1
 
             return REGULAR
         end
 
-        _cnt(solver).k>=_opt(solver).max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
-        time()-_cnt(solver).start_time>=_opt(solver).max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
+        get_cnt(solver).k>=get_opt(solver).max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
+        time()-get_cnt(solver).start_time>=get_opt(solver).max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
 
-        @trace(_logger(solver),"Proceeding to the next restoration phase iteration.")
-        _cnt(solver).k+=1
-        _cnt(solver).t+=1
+        @trace(get_logger(solver),"Proceeding to the next restoration phase iteration.")
+        get_cnt(solver).k+=1
+        get_cnt(solver).t+=1
     end
 end
 
 function second_order_correction(solver::AbstractMadNLPSolver,alpha_max,theta,varphi,
                                  theta_trial,varphi_d,switching_condition::Bool)
-    @trace(_logger(solver),"Second-order correction started.")
+    @trace(get_logger(solver),"Second-order correction started.")
 
-    wx = primal(__w1(solver))
-    wy = dual(__w1(solver))
-    copyto!(wy, _c_trial(solver))
-    axpy!(alpha_max, _c(solver), wy)
+    wx = primal(get__w1(solver))
+    wy = dual(get__w1(solver))
+    copyto!(wy, get_c_trial(solver))
+    axpy!(alpha_max, get_c(solver), wy)
 
     theta_soc_old = theta_trial
-    for p=1:_opt(solver).max_soc
+    for p=1:get_opt(solver).max_soc
         # compute second order correction
-        set_aug_rhs!(solver, _kkt(solver), wy, _mu(solver))
+        set_aug_rhs!(solver, get_kkt(solver), wy, get_mu(solver))
         dual_inf_perturbation!(
-            primal(_p(solver)),
-            _ind_llb(solver),_ind_uub(solver),_mu(solver),_opt(solver).kappa_d,
+            primal(get_p(solver)),
+            get_ind_llb(solver),get_ind_uub(solver),get_mu(solver),get_opt(solver).kappa_d,
         )
         solve_refine_wrapper!(
-            __w1(solver), solver, _p(solver), __w4(solver)
+            get__w1(solver), solver, get_p(solver), get__w4(solver)
         )
         alpha_soc = get_alpha_max(
-            primal(_x(solver)),
-            primal(_xl(solver)),
-            primal(_xu(solver)),
-            wx,_tau(solver)
+            primal(get_x(solver)),
+            primal(get_xl(solver)),
+            primal(get_xu(solver)),
+            wx,get_tau(solver)
         )
 
-        copyto!(primal(_x_trial(solver)), primal(_x(solver)))
-        axpy!(alpha_soc, wx, primal(_x_trial(solver)))
-        eval_cons_wrapper!(solver, _c_trial(solver), _x_trial(solver))
-        set_obj_val_trial!(solver, eval_f_wrapper(solver, _x_trial(solver)))
+        copyto!(primal(get_x_trial(solver)), primal(get_x(solver)))
+        axpy!(alpha_soc, wx, primal(get_x_trial(solver)))
+        eval_cons_wrapper!(solver, get_c_trial(solver), get_x_trial(solver))
+        set_obj_val_trial!(solver, eval_f_wrapper(solver, get_x_trial(solver)))
 
-        theta_soc = get_theta(_c_trial(solver))
-        varphi_soc= get_varphi(_obj_val_trial(solver),_x_trial_lr(solver),_xl_r(solver),_xu_r(solver),_x_trial_ur(solver),_mu(solver))
+        theta_soc = get_theta(get_c_trial(solver))
+        varphi_soc= get_varphi(get_obj_val_trial(solver),get_x_trial_lr(solver),get_xl_r(solver),get_xu_r(solver),get_x_trial_ur(solver),get_mu(solver))
 
-        !is_filter_acceptable(_filter(solver),theta_soc,varphi_soc) && break
+        !is_filter_acceptable(get_filter(solver),theta_soc,varphi_soc) && break
 
-        if theta <=_theta_min(solver) && switching_condition
+        if theta <=get_theta_min(solver) && switching_condition
             # Case I
-            if is_armijo(varphi_soc,varphi,_opt(solver).eta_phi,_alpha(solver),varphi_d)
-                @trace(_logger(solver),"Step in second order correction accepted by armijo condition.")
+            if is_armijo(varphi_soc,varphi,get_opt(solver).eta_phi,get_alpha(solver),varphi_d)
+                @trace(get_logger(solver),"Step in second order correction accepted by armijo condition.")
                 set_ftype!(solver, "F")
                 set_alpha!(solver, alpha_soc)
                 return true
             end
         else
             # Case II
-            if is_sufficient_progress(theta_soc,theta,_opt(solver).gamma_theta,varphi_soc,varphi,_opt(solver).gamma_phi,has_constraints(solver))
-                @trace(_logger(solver),"Step in second order correction accepted by sufficient progress.")
+            if is_sufficient_progress(theta_soc,theta,get_opt(solver).gamma_theta,varphi_soc,varphi,get_opt(solver).gamma_phi,has_constraints(solver))
+                @trace(get_logger(solver),"Step in second order correction accepted by sufficient progress.")
                 set_ftype!(solver, "H")
                 set_alpha!(solver, alpha_soc)
                 return true
             end
         end
 
-        theta_soc>_opt(solver).kappa_soc*theta_soc_old && break
+        theta_soc>get_opt(solver).kappa_soc*theta_soc_old && break
         theta_soc_old = theta_soc
     end
-    @trace(_logger(solver),"Second-order correction terminated.")
+    @trace(get_logger(solver),"Second-order correction terminated.")
 
     return false
 end
@@ -618,45 +618,45 @@ function inertia_correction!(
     set_del_w!(solver, zero(T))
     set_del_c!(solver, zero(T))
 
-    @trace(_logger(solver),"Inertia-based regularization started.")
+    @trace(get_logger(solver),"Inertia-based regularization started.")
 
     factorize_wrapper!(solver)
 
-    num_pos,num_zero,num_neg = inertia(_kkt(solver).linear_solver)
+    num_pos,num_zero,num_neg = inertia(get_kkt(solver).linear_solver)
 
 
-    solve_status = if is_inertia_correct(_kkt(solver), num_pos, num_zero, num_neg)
+    solve_status = if is_inertia_correct(get_kkt(solver), num_pos, num_zero, num_neg)
         # Try a backsolve. If the factorization has failed, solve_refine_wrapper returns false.
-        solve_refine_wrapper!(_d(solver), solver, _p(solver), __w4(solver))
+        solve_refine_wrapper!(get_d(solver), solver, get_p(solver), get__w4(solver))
     else
         false
     end
 
     while !solve_status
-        @debug(_logger(solver),"Primal-dual perturbed.")
+        @debug(get_logger(solver),"Primal-dual perturbed.")
 
         if n_trial == 0
-            set_del_w!(solver, _del_w_last(solver)==zero(T) ? _opt(solver).first_hessian_perturbation :
-                max(_opt(solver).min_hessian_perturbation,_opt(solver).perturb_dec_fact*_del_w_last(solver))
+            set_del_w!(solver, get_del_w_last(solver)==zero(T) ? get_opt(solver).first_hessian_perturbation :
+                max(get_opt(solver).min_hessian_perturbation,get_opt(solver).perturb_dec_fact*get_del_w_last(solver))
                     )
         else
-            set_del_w!(solver, _del_w(solver) * (_del_w_last(solver)==zero(T) ? _opt(solver).perturb_inc_fact_first : _opt(solver).perturb_inc_fact))
-            if _del_w(solver)>_opt(solver).max_hessian_perturbation
-                _cnt(solver).k+=1
-                @debug(_logger(solver),"Primal regularization is too big. Switching to restoration phase.")
+            set_del_w!(solver, get_del_w(solver) * (get_del_w_last(solver)==zero(T) ? get_opt(solver).perturb_inc_fact_first : get_opt(solver).perturb_inc_fact))
+            if get_del_w(solver)>get_opt(solver).max_hessian_perturbation
+                get_cnt(solver).k+=1
+                @debug(get_logger(solver),"Primal regularization is too big. Switching to restoration phase.")
                 return false
             end
         end
-        set_del_c!(solver, (num_zero == 0 ? zero(T) : _opt(solver).jacobian_regularization_value * _mu(solver)^(_opt(solver).jacobian_regularization_exponent)))
-        regularize_diagonal!(_kkt(solver), _del_w(solver) - del_w_prev, _del_c(solver) - del_c_prev)
-        del_w_prev = _del_w(solver)
-        del_c_prev = _del_c(solver)
+        set_del_c!(solver, (num_zero == 0 ? zero(T) : get_opt(solver).jacobian_regularization_value * get_mu(solver)^(get_opt(solver).jacobian_regularization_exponent)))
+        regularize_diagonal!(get_kkt(solver), get_del_w(solver) - del_w_prev, get_del_c(solver) - del_c_prev)
+        del_w_prev = get_del_w(solver)
+        del_c_prev = get_del_c(solver)
 
         factorize_wrapper!(solver)
-        num_pos,num_zero,num_neg = inertia(_kkt(solver).linear_solver)
+        num_pos,num_zero,num_neg = inertia(get_kkt(solver).linear_solver)
 
-        solve_status = if is_inertia_correct(_kkt(solver), num_pos, num_zero, num_neg)
-            solve_refine_wrapper!(_d(solver), solver, _p(solver), __w4(solver))
+        solve_status = if is_inertia_correct(get_kkt(solver), num_pos, num_zero, num_neg)
+            solve_refine_wrapper!(get_d(solver), solver, get_p(solver), get__w4(solver))
         else
             false
         end
@@ -664,7 +664,7 @@ function inertia_correction!(
         n_trial += 1
     end
 
-    _del_w(solver) != 0 && (set_del_w_last!(solver, _del_w(solver)))
+    get_del_w(solver) != 0 && (set_del_w_last!(solver, get_del_w(solver)))
     return true
 end
 
@@ -678,8 +678,8 @@ function inertia_correction!(
     set_del_w!(solver, zero(T))
     set_del_c!(solver, zero(T))
 
-    @trace(_logger(solver),"Inertia-free regularization started.")
-    dx = primal(_d(solver))
+    @trace(get_logger(solver),"Inertia-free regularization started.")
+    dx = primal(get_d(solver))
     p0 = inertia_corrector.p0
     d0 = inertia_corrector.d0
     t = inertia_corrector.t
@@ -688,42 +688,42 @@ function inertia_correction!(
     g = inertia_corrector.g
 
     set_g_ifr!(solver,g)
-    set_aug_rhs_ifr!(solver, _kkt(solver), p0)
+    set_aug_rhs_ifr!(solver, get_kkt(solver), p0)
 
     factorize_wrapper!(solver)
 
     solve_status = solve_refine_wrapper!(
-        d0, solver, p0, __w3(solver),
+        d0, solver, p0, get__w3(solver),
     ) && solve_refine_wrapper!(
-        _d(solver), solver, _p(solver), __w4(solver),
+        get_d(solver), solver, get_p(solver), get__w4(solver),
     )
     copyto!(t,dx)
     axpy!(-1.,n,t)
 
-    while !curv_test(t,n,g,_kkt(solver),wx,_opt(solver).inertia_free_tol) || !solve_status
-        @debug(_logger(solver),"Primal-dual perturbed.")
+    while !curv_test(t,n,g,get_kkt(solver),wx,get_opt(solver).inertia_free_tol) || !solve_status
+        @debug(get_logger(solver),"Primal-dual perturbed.")
         if n_trial == 0
-            set_del_w!(solver, _del_w_last(solver)==.0 ? _opt(solver).first_hessian_perturbation :
-                max(_opt(solver).min_hessian_perturbation,_opt(solver).perturb_dec_fact*_del_w_last(solver))
+            set_del_w!(solver, get_del_w_last(solver)==.0 ? get_opt(solver).first_hessian_perturbation :
+                max(get_opt(solver).min_hessian_perturbation,get_opt(solver).perturb_dec_fact*get_del_w_last(solver))
                     )
         else
-            set_del_w!(solver, _del_w(solver) * (_del_w_last(solver)==.0 ? _opt(solver).perturb_inc_fact_first : _opt(solver).perturb_inc_fact))
-            if _del_w(solver)>_opt(solver).max_hessian_perturbation
-                _cnt(solver).k+=1
-                @debug(_logger(solver),"Primal regularization is too big. Switching to restoration phase.")
+            set_del_w!(solver, get_del_w(solver) * (get_del_w_last(solver)==.0 ? get_opt(solver).perturb_inc_fact_first : get_opt(solver).perturb_inc_fact))
+            if get_del_w(solver)>get_opt(solver).max_hessian_perturbation
+                get_cnt(solver).k+=1
+                @debug(get_logger(solver),"Primal regularization is too big. Switching to restoration phase.")
                 return false
             end
         end
-        set_del_c!(solver, _opt(solver).jacobian_regularization_value * _mu(solver)^(_opt(solver).jacobian_regularization_exponent))
-        regularize_diagonal!(_kkt(solver), _del_w(solver) - del_w_prev, _del_c(solver) - del_c_prev)
-        del_w_prev = _del_w(solver)
-        del_c_prev = _del_c(solver)
+        set_del_c!(solver, get_opt(solver).jacobian_regularization_value * get_mu(solver)^(get_opt(solver).jacobian_regularization_exponent))
+        regularize_diagonal!(get_kkt(solver), get_del_w(solver) - del_w_prev, get_del_c(solver) - del_c_prev)
+        del_w_prev = get_del_w(solver)
+        del_c_prev = get_del_c(solver)
 
         factorize_wrapper!(solver)
         solve_status = solve_refine_wrapper!(
-            d0, solver, p0, __w3(solver)
+            d0, solver, p0, get__w3(solver)
         ) && solve_refine_wrapper!(
-            _d(solver), solver, _p(solver), __w4(solver)
+            get_d(solver), solver, get_p(solver), get__w4(solver)
         )
         copyto!(t,dx)
         axpy!(-1.,n,t)
@@ -731,7 +731,7 @@ function inertia_correction!(
         n_trial += 1
     end
 
-    _del_w(solver) != 0 && (set_del_w_last!(solver, _del_w(solver)))
+    get_del_w(solver) != 0 && (set_del_w_last!(solver, get_del_w(solver)))
     return true
 end
 
@@ -746,38 +746,38 @@ function inertia_correction!(
     set_del_w!(solver, zero(T))
     set_del_c!(solver, zero(T))
 
-    @trace(_logger(solver),"Inertia-based regularization started.")
+    @trace(get_logger(solver),"Inertia-based regularization started.")
 
     factorize_wrapper!(solver)
 
     solve_status = solve_refine_wrapper!(
-        _d(solver), solver, _p(solver), __w4(solver),
+        get_d(solver), solver, get_p(solver), get__w4(solver),
     )
     while !solve_status
-        @debug(_logger(solver),"Primal-dual perturbed.")
+        @debug(get_logger(solver),"Primal-dual perturbed.")
         if n_trial == 0
-            set_del_w!(solver, _del_w_last(solver)==zero(T) ? _opt(solver).first_hessian_perturbation :
-                max(_opt(solver).min_hessian_perturbation,_opt(solver).perturb_dec_fact*_del_w_last(solver)))
+            set_del_w!(solver, get_del_w_last(solver)==zero(T) ? get_opt(solver).first_hessian_perturbation :
+                max(get_opt(solver).min_hessian_perturbation,get_opt(solver).perturb_dec_fact*get_del_w_last(solver)))
         else
-            set_del_w!(solver, _del_w(solver) * (_del_w_last(solver)==zero(T) ? _opt(solver).perturb_inc_fact_first : _opt(solver).perturb_inc_fact))
-            if _del_w(solver)>_opt(solver).max_hessian_perturbation
-                _cnt(solver).k+=1
-                @debug(_logger(solver),"Primal regularization is too big. Switching to restoration phase.")
+            set_del_w!(solver, get_del_w(solver) * (get_del_w_last(solver)==zero(T) ? get_opt(solver).perturb_inc_fact_first : get_opt(solver).perturb_inc_fact))
+            if get_del_w(solver)>get_opt(solver).max_hessian_perturbation
+                get_cnt(solver).k+=1
+                @debug(get_logger(solver),"Primal regularization is too big. Switching to restoration phase.")
                 return false
             end
         end
-        set_del_c!(solver, _opt(solver).jacobian_regularization_value * _mu(solver)^(_opt(solver).jacobian_regularization_exponent))
-        regularize_diagonal!(_kkt(solver), _del_w(solver) - del_w_prev, _del_c(solver) - del_c_prev)
-        del_w_prev = _del_w(solver)
-        del_c_prev = _del_c(solver)
+        set_del_c!(solver, get_opt(solver).jacobian_regularization_value * get_mu(solver)^(get_opt(solver).jacobian_regularization_exponent))
+        regularize_diagonal!(get_kkt(solver), get_del_w(solver) - del_w_prev, get_del_c(solver) - del_c_prev)
+        del_w_prev = get_del_w(solver)
+        del_c_prev = get_del_c(solver)
 
         factorize_wrapper!(solver)
         solve_status = solve_refine_wrapper!(
-            _d(solver), solver, _p(solver), __w4(solver)
+            get_d(solver), solver, get_p(solver), get__w4(solver)
         )
         n_trial += 1
     end
-    _del_w(solver) != 0 && (set_del_w_last!(solver, _del_w(solver)))
+    get_del_w(solver) != 0 && (set_del_w_last!(solver, get_del_w(solver)))
     return true
 end
 

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -222,7 +222,7 @@ function regular!(solver::AbstractMadNLPSolver{T}) where T
         print_iter(solver)
 
         # evaluate termination criteria
-        (status = evaluate_termination_criteria!(solver)) != REGULAR || return status
+        (status = evaluate_termination_criteria!(solver)) == REGULAR || return status
 
         # evaluate Hessian
         evaluate_hessian!(solver)
@@ -231,10 +231,10 @@ function regular!(solver::AbstractMadNLPSolver{T}) where T
         update_homotopy_parameters!(solver)
 
         # compute the newton step
-        (status = compute_newton_step!(solver)) != REGULAR || return status
+        (status = compute_newton_step!(solver)) == REGULAR || return status
 
         # line search
-        (status = line_search!(solver)) != LINESEARCH_SUCCEEDED || return status
+        (status = line_search!(solver)) == LINESEARCH_SUCCEEDED || return status
 
         update_variables!(solver)
 
@@ -365,16 +365,16 @@ function robust!(solver::AbstractMadNLPSolver{T}) where T
 
         print_iter(solver;is_resto=true)
 
-        (status = evaluate_termination_criteria_RR!(solver) != ROBUST) || return status
+        (status = evaluate_termination_criteria_RR!(solver) == ROBUST) || return status
 
         # update the barrier parameter
         update_homotopy_parameters_RR!(solver)
 
         # compute the newton step
-        (status = compute_newton_step_RR!(solver)) != ROBUST || return status
+        (status = compute_newton_step_RR!(solver)) == ROBUST || return status
 
         # filter start
-        (status = line_search_RR!(solver)) != LINESEARCH_SUCCEEDED || return status
+        (status = line_search_RR!(solver)) == LINESEARCH_SUCCEEDED || return status
 
         # update variables
         update_variables_RR!(solver)

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -238,8 +238,8 @@ function regular!(solver::AbstractMadNLPSolver{T}) where T
 
         update_variables!(solver)
 
-        _cnt(solver).k+=1
-        @trace(_logger(solver),"Proceeding to the next interior point iteration.")
+        get_cnt(solver).k+=1
+        @trace(get_logger(solver),"Proceeding to the next interior point iteration.")
     end
 end
 
@@ -283,7 +283,7 @@ function restore!(solver::AbstractMadNLPSolver{T}) where T
             get_mu(solver),
         )
         # Check for sufficient decrease
-        if F_trial > _opt(solver).soft_resto_pderror_reduction_factor*F
+        if F_trial > get_opt(solver).soft_resto_pderror_reduction_factor*F
             # Sufficient decrease not observed, backing up and starting robust restorer.
             backtrack_restore!(solver)
             return ROBUST
@@ -328,8 +328,8 @@ function robust!(solver::AbstractMadNLPSolver{T}) where T
         update_variables_RR!(solver)
 
         # compeleted an iteration
-        _cnt(solver).k+=1
-        _cnt(solver).t+=1
+        get_cnt(solver).k+=1
+        get_cnt(solver).t+=1
         
         # check if going back to regular phase
         status = check_restoration_successful!(solver)
@@ -338,7 +338,7 @@ function robust!(solver::AbstractMadNLPSolver{T}) where T
             return REGULAR
         end
 
-        @trace(_logger(solver),"Proceeding to the next restoration phase iteration.")
+        @trace(get_logger(solver),"Proceeding to the next restoration phase iteration.")
     end
 end
 

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -456,7 +456,7 @@ function robust!(solver::AbstractMadNLPSolver{T}) where T
         end
 
         # without inertia correction,
-        @trace(_logger(solver),"Solving restoration phase primal-dual system.")
+        @trace(get_logger(solver),"Solving restoration phase primal-dual system.")
         set_aug_rhs_RR!(solver, solver.kkt, RR, solver.opt.rho)
         inertia_correction!(solver.inertia_corrector, solver) || return RESTORATION_FAILED
         finish_aug_solve_RR!(

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -633,7 +633,6 @@ function inertia_correction!(
     end
 
     while !solve_status
-        println("($(num_pos),$(num_zero),$(num_neg))")
         @debug(_logger(solver),"Primal-dual perturbed.")
 
         if n_trial == 0
@@ -641,23 +640,20 @@ function inertia_correction!(
                 max(_opt(solver).min_hessian_perturbation,_opt(solver).perturb_dec_fact*_del_w_last(solver))
                     )
         else
-            _del_w!(solver, _del_w(solver) * _del_w_last(solver)==zero(T) ? _opt(solver).perturb_inc_fact_first : _opt(solver).perturb_inc_fact)
+            _del_w!(solver, _del_w(solver) * (_del_w_last(solver)==zero(T) ? _opt(solver).perturb_inc_fact_first : _opt(solver).perturb_inc_fact))
             if _del_w(solver)>_opt(solver).max_hessian_perturbation
                 _cnt(solver).k+=1
                 @debug(_logger(solver),"Primal regularization is too big. Switching to restoration phase.")
                 return false
             end
         end
-        _del_c!(solver, num_zero == 0 ? zero(T) : _opt(solver).jacobian_regularization_value * _mu(solver)^(_opt(solver).jacobian_regularization_exponent))
+        _del_c!(solver, (num_zero == 0 ? zero(T) : _opt(solver).jacobian_regularization_value * _mu(solver)^(_opt(solver).jacobian_regularization_exponent)))
         regularize_diagonal!(_kkt(solver), _del_w(solver) - del_w_prev, _del_c(solver) - del_c_prev)
-        println("$(_del_w(solver) - del_w_prev), $(_del_c(solver) - del_c_prev)")
         del_w_prev = _del_w(solver)
         del_c_prev = _del_c(solver)
 
         factorize_wrapper!(solver)
         num_pos,num_zero,num_neg = inertia(_kkt(solver).linear_solver)
-        println("$(is_inertia_correct(_kkt(solver), num_pos, num_zero, num_neg))")
-        println("$(_kkt(solver).pr_diag), $(num_variables(_kkt(solver)))")
 
         solve_status = if is_inertia_correct(_kkt(solver), num_pos, num_zero, num_neg)
             solve_refine_wrapper!(_d(solver), solver, _p(solver), __w4(solver))
@@ -711,7 +707,7 @@ function inertia_correction!(
                 max(_opt(solver).min_hessian_perturbation,_opt(solver).perturb_dec_fact*_del_w_last(solver))
                     )
         else
-            _del_w!(solver, _del_w(solver) * _del_w_last(solver)==.0 ? _opt(solver).perturb_inc_fact_first : _opt(solver).perturb_inc_fact)
+            _del_w!(solver, _del_w(solver) * (_del_w_last(solver)==.0 ? _opt(solver).perturb_inc_fact_first : _opt(solver).perturb_inc_fact))
             if _del_w(solver)>_opt(solver).max_hessian_perturbation
                 _cnt(solver).k+=1
                 @debug(_logger(solver),"Primal regularization is too big. Switching to restoration phase.")
@@ -763,7 +759,7 @@ function inertia_correction!(
             _del_w!(solver, _del_w_last(solver)==zero(T) ? _opt(solver).first_hessian_perturbation :
                 max(_opt(solver).min_hessian_perturbation,_opt(solver).perturb_dec_fact*_del_w_last(solver)))
         else
-            _del_w!(solver, _del_w(solver) * _del_w_last(solver)==zero(T) ? _opt(solver).perturb_inc_fact_first : _opt(solver).perturb_inc_fact)
+            _del_w!(solver, _del_w(solver) * (_del_w_last(solver)==zero(T) ? _opt(solver).perturb_inc_fact_first : _opt(solver).perturb_inc_fact))
             if _del_w(solver)>_opt(solver).max_hessian_perturbation
                 _cnt(solver).k+=1
                 @debug(_logger(solver),"Primal regularization is too big. Switching to restoration phase.")

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -264,32 +264,9 @@ function restore!(solver::AbstractMadNLPSolver{T}) where T
     )
 
     while true
-        alpha_max = get_alpha_max(
-            primal(get_x(solver)),
-            primal(get_xl(solver)),
-            primal(get_xu(solver)),
-            primal(get_d(solver)),
-            get_tau(solver),
-        )
-        set_alpha!(solver,min(
-            alpha_max,
-            get_alpha_z(get_zl_r(solver),get_zu_r(solver),dual_lb(get_d(solver)),dual_ub(get_d(solver)),get_tau(solver)),
-        ))
+        take_ftb_step!(solver)
 
-        axpy!(get_alpha(solver), primal(get_d(solver)), full(get_x(solver)))
-        axpy!(get_alpha(solver), dual(get_d(solver)), get_y(solver))
-        get_zl_r(solver) .+= get_alpha(solver) .* dual_lb(get_d(solver))
-        get_zu_r(solver) .+= get_alpha(solver) .* dual_ub(get_d(solver))
-
-        eval_cons_wrapper!(solver,get_c(solver),get_x(solver))
-        eval_grad_f_wrapper!(solver,get_f(solver),get_x(solver))
-        set_obj_val!(solver, eval_f_wrapper(solver,get_x(solver)))
-
-        if !get_opt(solver).jacobian_constant
-            eval_jac_wrapper!(solver,get_kkt(solver),get_x(solver))
-        end
-
-        jtprod!(get_jacl(solver),get_kkt(solver),get_y(solver))
+        evaluate_for_sufficient_decrease_restore!(solver)
 
         F_trial = get_F(
             get_c(solver),
@@ -305,51 +282,23 @@ function restore!(solver::AbstractMadNLPSolver{T}) where T
             get_zu_r(solver),
             get_mu(solver),
         )
-        if F_trial > get_opt(solver).soft_resto_pderror_reduction_factor*F
-            copyto!(primal(get_x(solver)), primal(get__w1(solver)))
-            copyto!(get_y(solver), dual(get__w1(solver)))
-            copyto!(get_c(solver), dual(get__w2(solver))) # backup the previous primal iterate
+        # Check for sufficient decrease
+        if F_trial > _opt(solver).soft_resto_pderror_reduction_factor*F
+            # Sufficient decrease not observed, backing up and starting robust restorer.
+            backtrack_restore!(solver)
             return ROBUST
         end
+        F = F_trial
 
         adjust_boundary!(get_x_lr(solver),get_xl_r(solver),get_x_ur(solver),get_xu_r(solver),get_mu(solver))
 
-        F = F_trial
+        (status = evaluate_termination_criteria_restore!(solver)) == RESTORE || return status
 
-        theta = get_theta(get_c(solver))
-        varphi= get_varphi(get_obj_val(solver),get_x_lr(solver),get_xl_r(solver),get_xu_r(solver),get_x_ur(solver),get_mu(solver))
+        evaluate_for_next_iter_restore!(solver)
 
-        get_cnt(solver).k+=1
-
-        is_filter_acceptable(get_filter(solver),theta,varphi) ? (return REGULAR) : (get_cnt(solver).t+=1)
-        get_cnt(solver).k>=get_opt(solver).max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
-        time()-get_cnt(solver).start_time>=get_opt(solver).max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
-
-
-        sd = get_sd(get_y(solver),get_zl_r(solver),get_zu_r(solver),get_opt(solver).s_max)
-        sc = get_sc(get_zl_r(solver),get_zu_r(solver),get_opt(solver).s_max)
-        set_inf_pr!(solver, get_inf_pr(get_c(solver)))
-        set_inf_du!(solver, get_inf_du(
-            primal(get_f(solver)),
-            primal(get_zl(solver)),
-            primal(get_zu(solver)),
-            get_jacl(solver),
-            sd,
-        ))
-
-        set_inf_compl!(solver, get_inf_compl(get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),zero(T),sc))
-        set_inf_compl_mu!(solver, get_inf_compl(get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),get_mu(solver),sc))
         print_iter(solver)
 
-        !get_opt(solver).hessian_constant && eval_lag_hess_wrapper!(solver,get_kkt(solver),get_x(solver),get_y(solver))
-        set_aug_diagonal!(get_kkt(solver),solver)
-        set_aug_rhs!(solver, get_kkt(solver), get_c(solver), get_mu(solver))
-
-        dual_inf_perturbation!(primal(get_p(solver)),get_ind_llb(solver),get_ind_uub(solver),get_mu(solver),get_opt(solver).kappa_d)
-        factorize_wrapper!(solver)
-        solve_refine_wrapper!(
-            get_d(solver), solver, get_p(solver), get__w4(solver)
-        )
+        compute_newton_step_restore!(solver)
 
         set_ftype!(solver, "f")
     end

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -15,17 +15,17 @@ solve!(nlp::AbstractNLPModel, solver::AbstractMadNLPSolver; kwargs...) = solve!(
     nlp, solver, MadNLPExecutionStats(solver);
     kwargs...)
 solve!(solver::AbstractMadNLPSolver; kwargs...) = solve!(
-    solver.nlp, solver;
+    _nlp(solver), solver;
     kwargs...)
 
 
 function initialize!(solver::AbstractMadNLPSolver{T}) where T
 
-    nlp = solver.nlp
-    opt = solver.opt
+    nlp = _nlp(solver)
+    opt = _opt(solver)
 
     # Initializing variables
-    @trace(solver.logger,"Initializing variables.")
+    @trace(_logger(solver),"Initializing variables.")
     initialize!(
         solver.cb,
         solver.x,
@@ -63,23 +63,22 @@ function initialize!(solver::AbstractMadNLPSolver{T}) where T
     eval_jac_wrapper!(solver, solver.kkt, solver.x)
     eval_grad_f_wrapper!(solver, solver.f,solver.x)
 
-    @trace(solver.logger,"Initializing constraint duals.")
+
+    @trace(_logger(solver),"Initializing constraint duals.")
     if !solver.opt.dual_initialized
         initialize_dual(solver, opt.dual_initialization_method)
     end
 
     # Initializing
-    solver.obj_val = eval_f_wrapper(solver, solver.x)
+    _obj_val!(solver, eval_f_wrapper(solver, solver.x))
     eval_cons_wrapper!(solver, solver.c, solver.x)
     eval_lag_hess_wrapper!(solver, solver.kkt, solver.x, solver.y)
 
     theta = get_theta(solver.c)
-    solver.theta_max = 1e4*max(1,theta)
-    solver.theta_min = 1e-4*max(1,theta)
-
-    mu_init = solver.opt.barrier.mu_init
-    solver.mu = mu_init
-    solver.tau = max(solver.opt.tau_min,1-mu_init)
+    _theta_max!(solver, 1e4*max(1,theta))
+    _theta_min!(solver, 1e-4*max(1,theta))
+    _mu!(solver, solver.opt.barrier.mu_init)
+    _tau!(solver, max(solver.opt.tau_min,1-solver.opt.barrier.mu_init))
     push!(solver.filter, (solver.theta_max,-Inf))
 
     return REGULAR
@@ -90,10 +89,10 @@ struct DualInitializeSetZero <: DualInitializeOptions end
 struct DualInitializeLeastSquares <: DualInitializeOptions end
 
 function initialize_dual(solver::AbstractMadNLPSolver{T}, ::Type{DualInitializeSetZero}) where T
-    fill!(solver.y, zero(T))
+    fill!(_y(solver), zero(T))
 end
 function initialize_dual(solver::AbstractMadNLPSolver{T}, ::Type{DualInitializeLeastSquares}) where T
-    set_initial_rhs!(solver, solver.kkt)
+    set_initial_rhs!(solver, _kkt(solver))
     factorize_wrapper!(solver)
     is_solved = solve_refine_wrapper!(
         solver.d, solver, solver.p, solver._w4
@@ -108,17 +107,17 @@ end
 function reinitialize!(solver::AbstractMadNLPSolver)
     variable(solver.x) .= get_x0(solver.nlp)
 
-    solver.obj_val = eval_f_wrapper(solver, solver.x)
+    _obj_val!(solver, eval_f_wrapper(solver, solver.x))
     eval_grad_f_wrapper!(solver, solver.f, solver.x)
     eval_cons_wrapper!(solver, solver.c, solver.x)
     eval_jac_wrapper!(solver, solver.kkt, solver.x)
     eval_lag_hess_wrapper!(solver, solver.kkt, solver.x, solver.y)
 
     theta = get_theta(solver.c)
-    solver.theta_max=1e4*max(1,theta)
-    solver.theta_min=1e-4*max(1,theta)
-    solver.mu=solver.opt.barrier.mu_init
-    solver.tau=max(solver.opt.tau_min,1-solver.opt.barrier.mu_init)
+    _theta_max!(solver, 1e4*max(1,theta))
+    _theta_min!(solver, 1e-4*max(1,theta))
+    _mu!(solver, solver.opt.barrier.mu_init)
+    _tau!(solver, max(solver.opt.tau_min,1-solver.opt.barrier.mu_init))
     empty!(solver.filter)
     push!(solver.filter, (solver.theta_max,-Inf))
 
@@ -136,62 +135,62 @@ function solve!(
         )
 
     if x != nothing
-        full(solver.x)[1:get_nvar(nlp)] .= x
+        full(_x(solver))[1:get_nvar(nlp)] .= x
     end
     if y != nothing
-        solver.y[1:get_ncon(nlp)] .= y
+        _y(solver)[1:get_ncon(nlp)] .= y
     end
     if zl != nothing
-        full(solver.zl)[1:get_nvar(nlp)] .= zl
+        full(_zl(solver))[1:get_nvar(nlp)] .= zl
     end
     if zu != nothing
-        full(solver.zu)[1:get_nvar(nlp)] .= zu
+        full(_zu(solver))[1:get_nvar(nlp)] .= zu
     end
 
     if !isempty(kwargs)
-        @warn(solver.logger,"The options set during resolve may not have an effect")
-        set_options!(solver.opt, kwargs)
+        @warn(_logger(solver),"The options set during resolve may not have an effect")
+        set_options!(_opt(solver), kwargs)
     end
 
     try
-        if solver.status == INITIAL
-            @notice(solver.logger,"This is $(introduce()), running with $(introduce(solver.kkt.linear_solver))\n")
+        if _status(solver) == INITIAL
+            @notice(_logger(solver),"This is $(introduce()), running with $(introduce(solver.kkt.linear_solver))\n")
             print_init(solver)
-            solver.status = initialize!(solver)
+            _status!(solver, initialize!(solver))
         else # resolving the problem
-            solver.status = reinitialize!(solver)
+            _status!(solver, reinitialize!(solver))
         end
 
         while solver.status >= REGULAR
-            solver.status == REGULAR && (solver.status = regular!(solver))
-            solver.status == RESTORE && (solver.status = restore!(solver))
-            solver.status == ROBUST && (solver.status = robust!(solver))
+            solver.status == REGULAR && (_status!(solver, regular!(solver)))
+            solver.status == RESTORE && (_status!(solver, restore!(solver)))
+            solver.status == ROBUST && (_status!(solver, robust!(solver)))
         end
     catch e
         if e isa InvalidNumberException
             if e.callback == :obj
-                solver.status=INVALID_NUMBER_OBJECTIVE
+                _status!(solver, INVALID_NUMBER_OBJECTIVE)
             elseif e.callback == :grad
-                solver.status=INVALID_NUMBER_GRADIENT
+                _status!(solver, INVALID_NUMBER_GRADIENT)
             elseif e.callback == :cons
-                solver.status=INVALID_NUMBER_CONSTRAINTS
+                _status!(solver, INVALID_NUMBER_CONSTRAINTS)
             elseif e.callback == :jac
-                solver.status=INVALID_NUMBER_JACOBIAN
+                _status!(solver, INVALID_NUMBER_JACOBIAN)
             elseif e.callback == :hess
-                solver.status=INVALID_NUMBER_HESSIAN_LAGRANGIAN
+                _status!(solver, INVALID_NUMBER_HESSIAN_LAGRANGIAN)
             else
-                solver.status=INVALID_NUMBER_DETECTED
+                _status!(solver, INVALID_NUMBER_DETECTED)
             end
         elseif e isa NotEnoughDegreesOfFreedomException
-            solver.status=NOT_ENOUGH_DEGREES_OF_FREEDOM
+            _status!(solver, NOT_ENOUGH_DEGREES_OF_FREEDOM)
         elseif e isa LinearSolverException
-            solver.status=ERROR_IN_STEP_COMPUTATION;
+            _status!(solver, ERROR_IN_STEP_COMPUTATION;)
             solver.opt.rethrow_error && rethrow(e)
         elseif e isa InterruptException
-            solver.status=USER_REQUESTED_STOP
+            _status!(solver, USER_REQUESTED_STOP)
             solver.opt.rethrow_error && rethrow(e)
         else
-            solver.status=INTERNAL_ERROR
+            _status!(solver, INTERNAL_ERROR)
             solver.opt.rethrow_error && rethrow(e)
         end
     finally
@@ -199,10 +198,10 @@ function solve!(
         if !(solver.status < SOLVE_SUCCEEDED)
             print_summary(solver)
         end
-        @notice(solver.logger,"$(Base.text_colors[color_status(solver.status)])EXIT: $(get_status_output(solver.status, solver.opt))$(Base.text_colors[:normal])")
+        @notice(_logger(solver),"$(Base.text_colors[color_status(solver.status)])EXIT: $(get_status_output(solver.status, solver.opt))$(Base.text_colors[:normal])")
         solver.opt.disable_garbage_collector &&
-            (GC.enable(true); @warn(solver.logger,"Julia garbage collector is turned back on"))
-        finalize(solver.logger)
+            (GC.enable(true); @warn(_logger(solver),"Julia garbage collector is turned back on"))
+        finalize(_logger(solver))
 
         update!(stats,solver)
     end
@@ -225,20 +224,20 @@ function regular!(solver::AbstractMadNLPSolver{T}) where T
         jtprod!(solver.jacl, solver.kkt, solver.y)
         sd = get_sd(solver.y,solver.zl_r,solver.zu_r,T(solver.opt.s_max))
         sc = get_sc(solver.zl_r,solver.zu_r,T(solver.opt.s_max))
-        solver.inf_pr = get_inf_pr(solver.c)
-        solver.inf_du = get_inf_du(
+        _inf_pr!(solver, get_inf_pr(solver.c))
+        _inf_du!(solver, get_inf_du(
             full(solver.f),
             full(solver.zl),
             full(solver.zu),
             solver.jacl,
             sd,
-        )
-        solver.inf_compl = get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,zero(T),sc)
+        ))
+        _inf_compl!(solver, get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,zero(T),sc))
 
         print_iter(solver)
 
         # evaluate termination criteria
-        @trace(solver.logger,"Evaluating termination criteria.")
+        @trace(_logger(solver),"Evaluating termination criteria.")
         max(solver.inf_pr,solver.inf_du,solver.inf_compl) <= solver.opt.tol && return SOLVE_SUCCEEDED
         max(solver.inf_pr,solver.inf_du,solver.inf_compl) <= solver.opt.acceptable_tol ?
             (solver.cnt.acceptable_cnt < solver.opt.acceptable_iter ?
@@ -263,16 +262,16 @@ function regular!(solver::AbstractMadNLPSolver{T}) where T
         dual_inf_perturbation!(primal(solver.p),solver.ind_llb,solver.ind_uub,solver.mu,solver.opt.kappa_d)
         inertia_correction!(solver.inertia_corrector, solver) || return ROBUST
 
-        @trace(solver.logger,"Backtracking line search initiated.")
+        @trace(_logger(solver),"Backtracking line search initiated.")
         status = filter_line_search!(solver)
         if status != LINESEARCH_SUCCEEDED
             return status
         end
 
-        @trace(solver.logger,"Updating primal-dual variables.")
+        @trace(_logger(solver),"Updating primal-dual variables.")
         copyto!(full(solver.x), full(solver.x_trial))
         copyto!(solver.c, solver.c_trial)
-        solver.obj_val = solver.obj_val_trial
+        _obj_val!(solver, solver.obj_val_trial)
         adjust_boundary!(solver.x_lr,solver.xl_r,solver.x_ur,solver.xu_r,solver.mu)
 
         axpy!(solver.alpha,dual(solver.d),solver.y)
@@ -295,13 +294,13 @@ function regular!(solver::AbstractMadNLPSolver{T}) where T
         eval_grad_f_wrapper!(solver, solver.f,solver.x)
 
         solver.cnt.k+=1
-        @trace(solver.logger,"Proceeding to the next interior point iteration.")
+        @trace(_logger(solver),"Proceeding to the next interior point iteration.")
     end
 end
 
 
 function restore!(solver::AbstractMadNLPSolver{T}) where T
-    solver.del_w = 0
+    _del_w!(solver, 0)
     # Backup the previous primal iterate
     copyto!(primal(solver._w1), full(solver.x))
     copyto!(dual(solver._w1), solver.y)
@@ -321,8 +320,8 @@ function restore!(solver::AbstractMadNLPSolver{T}) where T
         solver.zu_r,
         solver.mu,
     )
-    solver.alpha_z = zero(T)
-    solver.ftype = "R"
+    _alpha_z!(solver, zero(T))
+    _ftype!(solver, "R")
     while true
         alpha_max = get_alpha_max(
             primal(solver.x),
@@ -331,10 +330,10 @@ function restore!(solver::AbstractMadNLPSolver{T}) where T
             primal(solver.d),
             solver.tau,
         )
-        solver.alpha = min(
+        _alpha!(solver,min(
             alpha_max,
             get_alpha_z(solver.zl_r,solver.zu_r,dual_lb(solver.d),dual_ub(solver.d),solver.tau),
-            )
+        ))
 
         axpy!(solver.alpha, primal(solver.d), full(solver.x))
         axpy!(solver.alpha, dual(solver.d), solver.y)
@@ -343,7 +342,7 @@ function restore!(solver::AbstractMadNLPSolver{T}) where T
 
         eval_cons_wrapper!(solver,solver.c,solver.x)
         eval_grad_f_wrapper!(solver,solver.f,solver.x)
-        solver.obj_val = eval_f_wrapper(solver,solver.x)
+        _obj_val!(solver, eval_f_wrapper(solver,solver.x))
 
         !solver.opt.jacobian_constant && eval_jac_wrapper!(solver,solver.kkt,solver.x)
         jtprod!(solver.jacl,solver.kkt,solver.y)
@@ -385,16 +384,16 @@ function restore!(solver::AbstractMadNLPSolver{T}) where T
 
         sd = get_sd(solver.y,solver.zl_r,solver.zu_r,solver.opt.s_max)
         sc = get_sc(solver.zl_r,solver.zu_r,solver.opt.s_max)
-        solver.inf_pr = get_inf_pr(solver.c)
-        solver.inf_du = get_inf_du(
+        _inf_pr!(solver, get_inf_pr(solver.c))
+        _inf_du!(solver, get_inf_du(
             primal(solver.f),
             primal(solver.zl),
             primal(solver.zu),
             solver.jacl,
             sd,
-        )
+        ))
 
-        solver.inf_compl = get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,zero(T),sc)
+        _inf_compl!(solver, get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,zero(T),sc))
         inf_compl_mu = get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,solver.mu,sc)
         print_iter(solver)
 
@@ -408,7 +407,7 @@ function restore!(solver::AbstractMadNLPSolver{T}) where T
             solver.d, solver, solver.p, solver._w4
         )
 
-        solver.ftype = "f"
+        _ftype!(solver, "f")
     end
 end
 
@@ -422,18 +421,18 @@ function robust!(solver::AbstractMadNLPSolver{T}) where T
         jtprod!(solver.jacl, solver.kkt, solver.y)
 
         # evaluate termination criteria
-        @trace(solver.logger,"Evaluating restoration phase termination criteria.")
+        @trace(_logger(solver),"Evaluating restoration phase termination criteria.")
         sd = get_sd(solver.y,solver.zl_r,solver.zu_r,solver.opt.s_max)
         sc = get_sc(solver.zl_r,solver.zu_r,solver.opt.s_max)
-        solver.inf_pr = get_inf_pr(solver.c)
-        solver.inf_du = get_inf_du(
+        _inf_pr!(solver, get_inf_pr(solver.c))
+        _inf_du!(get_inf_du(
             primal(solver.f),
             primal(solver.zl),
             primal(solver.zu),
             solver.jacl,
             sd,
-        )
-        solver.inf_compl = get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,zero(T),sc)
+        ))
+        _inf_compl!(solver, get_inf_compl(solver.x_lr,solver.xl_r,solver.zl_r,solver.xu_r,solver.x_ur,solver.zu_r,zero(T),sc))
 
         # Robust restoration phase error
         RR.inf_pr_R = get_inf_pr_R(solver.c,RR.pp,RR.nn)
@@ -456,8 +455,8 @@ function robust!(solver::AbstractMadNLPSolver{T}) where T
             eval_lag_hess_wrapper!(solver, solver.kkt, solver.x, solver.y; is_resto=true)
         end
 
-        @trace(solver.logger,"Solving restoration phase primal-dual system.")
-        set_aug_RR!(solver.kkt, solver, RR)
+        # without inertia correction,
+        @trace(_logger(solver),"Solving restoration phase primal-dual system.")
         set_aug_rhs_RR!(solver, solver.kkt, RR, solver.opt.rho)
         inertia_correction!(solver.inertia_corrector, solver) || return RESTORATION_FAILED
         finish_aug_solve_RR!(
@@ -466,13 +465,13 @@ function robust!(solver::AbstractMadNLPSolver{T}) where T
         )
 
         # filter start
-        @trace(solver.logger,"Backtracking line search initiated.")
+        @trace(_logger(solver),"Backtracking line search initiated.")
         status = filter_line_search_RR!(solver)
         if status != LINESEARCH_SUCCEEDED
             return status
         end
 
-        @trace(solver.logger,"Updating primal-dual variables.")
+        @trace(_logger(solver),"Updating primal-dual variables.")
         copyto!(full(solver.x), full(solver.x_trial))
         copyto!(solver.c, solver.c_trial)
         copyto!(RR.pp, RR.pp_trial)
@@ -506,8 +505,8 @@ function robust!(solver::AbstractMadNLPSolver{T}) where T
         adjust_boundary!(solver.x_lr,solver.xl_r,solver.x_ur,solver.xu_r,solver.mu)
 
         # check if going back to regular phase
-        @trace(solver.logger,"Checking if going back to regular phase.")
-        solver.obj_val = eval_f_wrapper(solver, solver.x)
+        @trace(_logger(solver),"Checking if going back to regular phase.")
+        _obj_val!(solver, eval_f_wrapper(solver, solver.x))
         eval_grad_f_wrapper!(solver, solver.f, solver.x)
         theta = get_theta(solver.c)
         varphi= get_varphi(solver.obj_val,solver.x_lr,solver.xl_r,solver.xu_r,solver.x_ur,solver.mu)
@@ -515,7 +514,7 @@ function robust!(solver::AbstractMadNLPSolver{T}) where T
         if is_filter_acceptable(solver.filter,theta,varphi) &&
             theta <= solver.opt.required_infeasibility_reduction * RR.theta_ref
 
-            @trace(solver.logger,"Going back to the regular phase.")
+            @trace(_logger(solver),"Going back to the regular phase.")
             set_initial_rhs!(solver, solver.kkt)
             initialize!(solver.kkt)
 
@@ -538,7 +537,7 @@ function robust!(solver::AbstractMadNLPSolver{T}) where T
         solver.cnt.k>=solver.opt.max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
         time()-solver.cnt.start_time>=solver.opt.max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
 
-        @trace(solver.logger,"Proceeding to the next restoration phase iteration.")
+        @trace(_logger(solver),"Proceeding to the next restoration phase iteration.")
         solver.cnt.k+=1
         solver.cnt.t+=1
     end
@@ -546,7 +545,7 @@ end
 
 function second_order_correction(solver::AbstractMadNLPSolver,alpha_max,theta,varphi,
                                  theta_trial,varphi_d,switching_condition::Bool)
-    @trace(solver.logger,"Second-order correction started.")
+    @trace(_logger(solver),"Second-order correction started.")
 
     wx = primal(solver._w1)
     wy = dual(solver._w1)
@@ -574,7 +573,7 @@ function second_order_correction(solver::AbstractMadNLPSolver,alpha_max,theta,va
         copyto!(primal(solver.x_trial), primal(solver.x))
         axpy!(alpha_soc, wx, primal(solver.x_trial))
         eval_cons_wrapper!(solver, solver.c_trial, solver.x_trial)
-        solver.obj_val_trial = eval_f_wrapper(solver, solver.x_trial)
+        _obj_val_trial!(solver, eval_f_wrapper(solver, solver.x_trial))
 
         theta_soc = get_theta(solver.c_trial)
         varphi_soc= get_varphi(solver.obj_val_trial,solver.x_trial_lr,solver.xl_r,solver.xu_r,solver.x_trial_ur,solver.mu)
@@ -584,17 +583,17 @@ function second_order_correction(solver::AbstractMadNLPSolver,alpha_max,theta,va
         if theta <=solver.theta_min && switching_condition
             # Case I
             if is_armijo(varphi_soc,varphi,solver.opt.eta_phi,solver.alpha,varphi_d)
-                @trace(solver.logger,"Step in second order correction accepted by armijo condition.")
-                solver.ftype = "F"
-                solver.alpha=alpha_soc
+                @trace(_logger(solver),"Step in second order correction accepted by armijo condition.")
+                _ftype!(solver, "F")
+                _alpha!(solver, alpha_soc)
                 return true
             end
         else
             # Case II
             if is_sufficient_progress(theta_soc,theta,solver.opt.gamma_theta,varphi_soc,varphi,solver.opt.gamma_phi,has_constraints(solver))
-                @trace(solver.logger,"Step in second order correction accepted by sufficient progress.")
-                solver.ftype = "H"
-                solver.alpha=alpha_soc
+                @trace(_logger(solver),"Step in second order correction accepted by sufficient progress.")
+                _ftype!(solver, "H")
+                _alpha!(solver, alpha_soc)
                 return true
             end
         end
@@ -602,7 +601,7 @@ function second_order_correction(solver::AbstractMadNLPSolver,alpha_max,theta,va
         theta_soc>solver.opt.kappa_soc*theta_soc_old && break
         theta_soc_old = theta_soc
     end
-    @trace(solver.logger,"Second-order correction terminated.")
+    @trace(_logger(solver),"Second-order correction terminated.")
 
     return false
 end
@@ -614,10 +613,10 @@ function inertia_correction!(
 ) where {T}
 
     n_trial = 0
-    solver.del_w = del_w_prev = zero(T)
-    solver.del_c = del_c_prev = zero(T)
+    _del_w!(solver, del_w_prev = zero(T))
+    _del_c!(solver, del_c_prev = zero(T))
 
-    @trace(solver.logger,"Inertia-based regularization started.")
+    @trace(_logger(solver),"Inertia-based regularization started.")
 
     factorize_wrapper!(solver)
 
@@ -631,20 +630,21 @@ function inertia_correction!(
     end
 
     while !solve_status
-        @debug(solver.logger,"Primal-dual perturbed.")
+        @debug(_logger(solver),"Primal-dual perturbed.")
 
         if n_trial == 0
-            solver.del_w = solver.del_w_last==zero(T) ? solver.opt.first_hessian_perturbation :
+            _del_w!(solver, solver.del_w_last==zero(T) ? solver.opt.first_hessian_perturbation :
                 max(solver.opt.min_hessian_perturbation,solver.opt.perturb_dec_fact*solver.del_w_last)
+                    )
         else
-            solver.del_w*= solver.del_w_last==zero(T) ? solver.opt.perturb_inc_fact_first : solver.opt.perturb_inc_fact
+            _del_w!(solver, solver.del_w * solver.del_w_last==zero(T) ? solver.opt.perturb_inc_fact_first : solver.opt.perturb_inc_fact)
             if solver.del_w>solver.opt.max_hessian_perturbation
                 solver.cnt.k+=1
-                @debug(solver.logger,"Primal regularization is too big. Switching to restoration phase.")
+                @debug(_logger(solver),"Primal regularization is too big. Switching to restoration phase.")
                 return false
             end
         end
-        solver.del_c = num_zero == 0 ? zero(T) : solver.opt.jacobian_regularization_value * solver.mu^(solver.opt.jacobian_regularization_exponent)
+        _del_c!(solver, num_zero == 0 ? zero(T) : solver.opt.jacobian_regularization_value * solver.mu^(solver.opt.jacobian_regularization_exponent))
         regularize_diagonal!(solver.kkt, solver.del_w - del_w_prev, solver.del_c - del_c_prev)
         del_w_prev = solver.del_w
         del_c_prev = solver.del_c
@@ -661,7 +661,7 @@ function inertia_correction!(
         n_trial += 1
     end
 
-    solver.del_w != 0 && (solver.del_w_last = solver.del_w)
+    solver.del_w != 0 && (_del_w_last!(solver, solver.del_w))
     return true
 end
 
@@ -670,10 +670,10 @@ function inertia_correction!(
     solver::AbstractMadNLPSolver{T}
     ) where T
     n_trial = 0
-    solver.del_w = del_w_prev = zero(T)
-    solver.del_c = del_c_prev = zero(T)
+    _del_w!(solver, del_w_prev = zero(T))
+    _del_c!(solver, del_c_prev = zero(T))
 
-    @trace(solver.logger,"Inertia-free regularization started.")
+    @trace(_logger(solver),"Inertia-free regularization started.")
     dx = primal(solver.d)
     p0 = inertia_corrector.p0
     d0 = inertia_corrector.d0
@@ -697,19 +697,20 @@ function inertia_correction!(
     axpy!(-1.,n,t)
 
     while !curv_test(t,n,g,solver.kkt,wx,solver.opt.inertia_free_tol)  || !solve_status
-        @debug(solver.logger,"Primal-dual perturbed.")
+        @debug(_logger(solver),"Primal-dual perturbed.")
         if n_trial == 0
-            solver.del_w = solver.del_w_last==.0 ? solver.opt.first_hessian_perturbation :
+            _del_w!(solver, solver.del_w_last==.0 ? solver.opt.first_hessian_perturbation :
                 max(solver.opt.min_hessian_perturbation,solver.opt.perturb_dec_fact*solver.del_w_last)
+                    )
         else
-            solver.del_w*= solver.del_w_last==.0 ? solver.opt.perturb_inc_fact_first : solver.opt.perturb_inc_fact
+            _del_w!(solver, solver.del_w * solver.del_w_last==.0 ? solver.opt.perturb_inc_fact_first : solver.opt.perturb_inc_fact)
             if solver.del_w>solver.opt.max_hessian_perturbation
                 solver.cnt.k+=1
-                @debug(solver.logger,"Primal regularization is too big. Switching to restoration phase.")
+                @debug(_logger(solver),"Primal regularization is too big. Switching to restoration phase.")
                 return false
             end
         end
-        solver.del_c = solver.opt.jacobian_regularization_value * solver.mu^(solver.opt.jacobian_regularization_exponent)
+        _del_c!(solver, solver.opt.jacobian_regularization_value * solver.mu^(solver.opt.jacobian_regularization_exponent))
         regularize_diagonal!(solver.kkt, solver.del_w - del_w_prev, solver.del_c - del_c_prev)
         del_w_prev = solver.del_w
         del_c_prev = solver.del_c
@@ -726,7 +727,7 @@ function inertia_correction!(
         n_trial += 1
     end
 
-    solver.del_w != 0 && (solver.del_w_last = solver.del_w)
+    solver.del_w != 0 && (_del_w_last!(solver, solver.del_w))
     return true
 end
 
@@ -736,10 +737,10 @@ function inertia_correction!(
     ) where T
 
     n_trial = 0
-    solver.del_w = del_w_prev = zero(T)
-    solver.del_c = del_c_prev = zero(T)
+    _del_w!(solver, del_w_prev = zero(T))
+    _del_c!(solver, del_c_prev = zero(T))
 
-    @trace(solver.logger,"Inertia-based regularization started.")
+    @trace(_logger(solver),"Inertia-based regularization started.")
 
     factorize_wrapper!(solver)
 
@@ -747,19 +748,19 @@ function inertia_correction!(
         solver.d, solver, solver.p, solver._w4,
     )
     while !solve_status
-        @debug(solver.logger,"Primal-dual perturbed.")
+        @debug(_logger(solver),"Primal-dual perturbed.")
         if n_trial == 0
-            solver.del_w = solver.del_w_last==zero(T) ? solver.opt.first_hessian_perturbation :
-                max(solver.opt.min_hessian_perturbation,solver.opt.perturb_dec_fact*solver.del_w_last)
+            _del_w!(solver, solver.del_w_last==zero(T) ? solver.opt.first_hessian_perturbation :
+                max(solver.opt.min_hessian_perturbation,solver.opt.perturb_dec_fact*solver.del_w_last))
         else
-            solver.del_w*= solver.del_w_last==zero(T) ? solver.opt.perturb_inc_fact_first : solver.opt.perturb_inc_fact
+            _del_w!(solver.del_w * solver.del_w_last==zero(T) ? solver.opt.perturb_inc_fact_first : solver.opt.perturb_inc_fact)
             if solver.del_w>solver.opt.max_hessian_perturbation
                 solver.cnt.k+=1
-                @debug(solver.logger,"Primal regularization is too big. Switching to restoration phase.")
+                @debug(_logger(solver),"Primal regularization is too big. Switching to restoration phase.")
                 return false
             end
         end
-        solver.del_c = solver.opt.jacobian_regularization_value * solver.mu^(solver.opt.jacobian_regularization_exponent)
+        _del_c!(solver, solver.opt.jacobian_regularization_value * solver.mu^(solver.opt.jacobian_regularization_exponent))
         regularize_diagonal!(solver.kkt, solver.del_w - del_w_prev, solver.del_c - del_c_prev)
         del_w_prev = solver.del_w
         del_c_prev = solver.del_c
@@ -770,7 +771,7 @@ function inertia_correction!(
         )
         n_trial += 1
     end
-    solver.del_w != 0 && (solver.del_w_last = solver.del_w)
+    solver.del_w != 0 && (_del_w_last!(solver, solver.del_w))
     return true
 end
 

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -365,7 +365,7 @@ function robust!(solver::AbstractMadNLPSolver{T}) where T
 
         print_iter(solver;is_resto=true)
 
-        (status = evaluate_termination_criteria_RR!(solver) == ROBUST) || return status
+        (status = evaluate_termination_criteria_RR!(solver)) == ROBUST || return status
 
         # update the barrier parameter
         update_homotopy_parameters_RR!(solver)
@@ -384,7 +384,7 @@ function robust!(solver::AbstractMadNLPSolver{T}) where T
         _cnt(solver).t+=1
         
         # check if going back to regular phase
-        status = compute_newton_step_RR!(solver)
+        status = check_restoration_successful!(solver)
         if status == REGULAR
             return_from_restoration!(solver)
             return REGULAR

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -394,7 +394,7 @@ function restore!(solver::AbstractMadNLPSolver{T}) where T
         ))
 
         set_inf_compl!(solver, get_inf_compl(get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),zero(T),sc))
-        inf_compl_mu = get_inf_compl(get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),get_mu(solver),sc)
+        set_inf_compl_mu!(solver, get_inf_compl(get_x_lr(solver),get_xl_r(solver),get_zl_r(solver),get_xu_r(solver),get_x_ur(solver),get_zu_r(solver),get_mu(solver),sc))
         print_iter(solver)
 
         !get_opt(solver).hessian_constant && eval_lag_hess_wrapper!(solver,get_kkt(solver),get_x(solver),get_y(solver))
@@ -457,6 +457,7 @@ function robust!(solver::AbstractMadNLPSolver{T}) where T
 
         # without inertia correction,
         @trace(get_logger(solver),"Solving restoration phase primal-dual system.")
+        set_aug_RR!(get_kkt(solver), solver, RR)
         set_aug_rhs_RR!(solver, solver.kkt, RR, solver.opt.rho)
         inertia_correction!(solver.inertia_corrector, solver) || return RESTORATION_FAILED
         finish_aug_solve_RR!(

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -75,11 +75,11 @@ function initialize!(solver::AbstractMadNLPSolver{T}) where T
     eval_lag_hess_wrapper!(solver, _kkt(solver), _x(solver), _y(solver))
 
     theta = get_theta(_c(solver))
-    _theta_max!(solver, 1e4*max(1,theta))
-    _theta_min!(solver, 1e-4*max(1,theta))
+    _theta_max!(solver, T(1e4)*max(one(T),theta))
+    _theta_min!(solver, T(1e-4)*max(one(T),theta))
     _mu!(solver, _opt(solver).barrier.mu_init)
-    _tau!(solver, max(_opt(solver).tau_min,1-_opt(solver).barrier.mu_init))
-    push!(_filter(solver), (_theta_max(solver),-Inf))
+    _tau!(solver, max(_opt(solver).tau_min,one(T)-_opt(solver).barrier.mu_init))
+    push!(_filter(solver), (_theta_max(solver),-T(Inf)))
 
     return REGULAR
 end
@@ -97,7 +97,7 @@ function initialize_dual(solver::AbstractMadNLPSolver{T}, ::Type{DualInitializeL
     is_solved = solve_refine_wrapper!(
         _d(solver), solver, _p(solver), __w4(solver)
     )
-    if !is_solved || (norm(dual(_d(solver)), Inf) > _opt(solver).constr_mult_init_max)
+    if !is_solved || (norm(dual(_d(solver)), T(Inf)) > _opt(solver).constr_mult_init_max)
         fill!(_y(solver), zero(T))
     else
         copyto!(_y(solver), dual(_d(solver)))

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -300,7 +300,7 @@ end
 
 
 function restore!(solver::AbstractMadNLPSolver{T}) where T
-    _del_w!(solver, 0)
+    _del_w!(solver, zero(T))
     # Backup the previous primal iterate
     copyto!(primal(__w1(solver)), full(_x(solver)))
     copyto!(dual(__w1(solver)), _y(solver))

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -425,7 +425,7 @@ function robust!(solver::AbstractMadNLPSolver{T}) where T
         sd = get_sd(_y(solver),_zl_r(solver),_zu_r(solver),_opt(solver).s_max)
         sc = get_sc(_zl_r(solver),_zu_r(solver),_opt(solver).s_max)
         _inf_pr!(solver, get_inf_pr(_c(solver)))
-        _inf_du!(get_inf_du(
+        _inf_du!(solver, get_inf_du(
             primal(_f(solver)),
             primal(_zl(solver)),
             primal(_zu(solver)),

--- a/src/IPM/solver.jl
+++ b/src/IPM/solver.jl
@@ -232,17 +232,17 @@ function regular!(solver::AbstractMadNLPSolver{T}) where T
             _jacl(solver),
             sd,
         ))
-        _inf_compl!(solver, get_inf_compl(_x_lr(solver),_xl_r(solver),_zl_r(solver),_xu_r(solver),_x_ur(solver),_zu_r(solver),zero(T),sc))
+        _inf_compl!(solver, _inf_compl(solver, sc; mu=zero(T)))
 
         print_iter(solver)
 
         # evaluate termination criteria
         @trace(_logger(solver),"Evaluating termination criteria.")
-        max(_inf_pr(solver),_inf_du(solver),_inf_compl(solver)) <= _opt(solver).tol && return SOLVE_SUCCEEDED
-        max(_inf_pr(solver),_inf_du(solver),_inf_compl(solver)) <= _opt(solver).acceptable_tol ?
+        _inf_total(solver) <= _opt(solver).tol && return SOLVE_SUCCEEDED
+        _inf_total(solver) <= _opt(solver).acceptable_tol ?
             (_cnt(solver).acceptable_cnt < _opt(solver).acceptable_iter ?
             _cnt(solver).acceptable_cnt+=1 : return SOLVED_TO_ACCEPTABLE_LEVEL) : (_cnt(solver).acceptable_cnt = 0)
-        max(_inf_pr(solver),_inf_du(solver),_inf_compl(solver)) >= _opt(solver).diverging_iterates_tol && return DIVERGING_ITERATES
+        _inf_total(solver) >= _opt(solver).diverging_iterates_tol && return DIVERGING_ITERATES
         _cnt(solver).k>=_opt(solver).max_iter && return MAXIMUM_ITERATIONS_EXCEEDED
         time()-_cnt(solver).start_time>=_opt(solver).max_wall_time && return MAXIMUM_WALLTIME_EXCEEDED
 

--- a/src/IPM/types.jl
+++ b/src/IPM/types.jl
@@ -1,0 +1,48 @@
+mutable struct RobustRestorer{T, VT}
+    obj_val_R::T
+    f_R::VT
+    x_ref::VT
+
+    theta_ref::T
+    D_R::VT
+    obj_val_R_trial::T
+
+    pp::VT
+    nn::VT
+    zp::VT
+    zn::VT
+
+    dpp::VT
+    dnn::VT
+    dzp::VT
+    dzn::VT
+
+    pp_trial::VT
+    nn_trial::VT
+
+    inf_pr_R::T
+    inf_du_R::T
+    inf_compl_R::T
+
+    mu_R::T
+    tau_R::T
+    zeta::T
+
+    filter::Vector{Tuple{T,T}}
+end
+
+abstract type AbstractInertiaCorrector end
+struct InertiaAuto <: AbstractInertiaCorrector end
+struct InertiaBased <: AbstractInertiaCorrector end
+struct InertiaIgnore <: AbstractInertiaCorrector end
+struct InertiaFree{
+    T,
+    VT <: AbstractVector{T},
+    KKTVec <: AbstractKKTVector{T, VT}
+} <: AbstractInertiaCorrector 
+    p0::KKTVec
+    d0::KKTVec
+    t::VT
+    wx::VT
+    g::VT
+end

--- a/src/IPM/types.jl
+++ b/src/IPM/types.jl
@@ -23,6 +23,7 @@ mutable struct RobustRestorer{T, VT}
     inf_pr_R::T
     inf_du_R::T
     inf_compl_R::T
+    inf_compl_mu_R::T
 
     mu_R::T
     tau_R::T

--- a/src/IPM/types.jl
+++ b/src/IPM/types.jl
@@ -46,3 +46,101 @@ struct InertiaFree{
     wx::VT
     g::VT
 end
+
+
+"""
+    AbstractBarrierUpdate{T}
+
+Abstraction used to implement the different rules to update the barrier parameter.
+The barrier is updated using either a monotone rule or an adaptive rule.
+
+"""
+abstract type AbstractBarrierUpdate{T} end
+
+"""
+    MonotoneUpdate{T} <: AbstractBarrierUpdate{T}
+
+Update the barrier parameter using the classical Fiacco-McCormick monotone rule.
+
+"""
+@kwdef mutable struct MonotoneUpdate{T} <: AbstractBarrierUpdate{T}
+    mu_init::T = 1e-1
+    mu_min::T = 1e-11
+    mu_superlinear_decrease_power::T = 1.5
+    mu_linear_decrease_factor::T = .2
+end
+function MonotoneUpdate(tol::T, barrier_tol_factor) where T
+    return MonotoneUpdate{T}(; mu_min=min(1e-4, tol ) / (barrier_tol_factor + 1))
+end
+
+"""
+    AbstractAdaptiveUpdate{T} <: AbstractBarrierUpdate{T}
+
+Abstraction used to implement the adaptive barrier updates described in [Nocedal2009].
+
+## References
+[Nocedal2009] Nocedal, J., Wächter, A., & Waltz, R. A. (2009).
+Adaptive barrier update strategies for nonlinear interior methods.
+SIAM Journal on Optimization, 19(4), 1674-1693.
+
+"""
+abstract type AbstractAdaptiveUpdate{T} <: AbstractBarrierUpdate{T} end
+
+"""
+    QualityFunctionUpdate{T} <: AbstractAdaptiveUpdate{T}
+
+Find the barrier parameter using a quality function encoding the ℓ1-norm of the KKT violations.
+At each IPM iteration, the minimum of the quality function is found using a Golden search algorithm.
+
+If no sufficient progress is made, the barrier fallbacks to a monotone rule.
+
+## References
+The algorithm is described in [Nocedal2009, Section 4].
+
+"""
+@kwdef mutable struct QualityFunctionUpdate{T} <: AbstractAdaptiveUpdate{T}
+    mu_init::T = 1e-1
+    mu_min::T = 1e-11
+    mu_max::T = 1e5
+    sigma_min::T = 1e-6
+    sigma_max::T = 1e2
+    sigma_tol::T = 1e-2
+    gamma::T = 1.0
+    max_gs_iter::Int = 8
+    # For non-free mode
+    mu_superlinear_decrease_power::T = 1.5
+    mu_linear_decrease_factor::T = .2
+    free_mode::Bool = true
+    globalization::Bool = true
+    n_update::Int = 0
+end
+function QualityFunctionUpdate(tol::T, barrier_tol_factor) where T
+    return QualityFunctionUpdate{T}(; mu_min=min(1e-4, tol ) / (barrier_tol_factor + 1))
+end
+
+"""
+    LOQOUpdate{T} <: AbstractAdaptiveUpdate{T}
+
+Find the barrier parameter using the rule used in the LOQO solver.
+The rule is explicited in [Nocedal2009, Eq (3.6)].
+
+If no sufficient progress is made, the barrier fallbacks to a monotone rule.
+
+## References
+The algorithm is described in [Nocedal2009, Section 3].
+
+"""
+@kwdef mutable struct LOQOUpdate{T} <: AbstractAdaptiveUpdate{T}
+    mu_init::T = 1e-1
+    mu_min::T = 1e-11
+    mu_max::T = 1e5
+    gamma::T = 0.1 # scale factor
+    r::T = .95 # Steplength param
+    mu_superlinear_decrease_power::T = 1.5
+    mu_linear_decrease_factor::T = .2
+    free_mode::Bool = true
+    globalization::Bool = true
+end
+function LOQOUpdate(tol::T, barrier_tol_factor) where T
+    return LOQOUpdate{T}(; mu_min=min(1e-4, tol ) / (barrier_tol_factor + 1))
+end

--- a/src/IPM/utils.jl
+++ b/src/IPM/utils.jl
@@ -21,40 +21,40 @@ mutable struct MadNLPExecutionStats{T, VT} <: AbstractExecutionStats
 end
 
 MadNLPExecutionStats(solver::AbstractMadNLPSolver) =MadNLPExecutionStats(
-    _opt(solver),
-    _status(solver),
-    primal(_x(solver))[1:get_nvar(_nlp(solver))],
-    _obj_val(solver) / _cb(solver).obj_scale[],
-    _c(solver) ./ _cb(solver).con_scale,
-    _inf_du(solver),
-    _inf_pr(solver),
-    copy(_y(solver)),
-    primal(_zl(solver))[1:get_nvar(_nlp(solver))],
-    primal(_zu(solver))[1:get_nvar(_nlp(solver))],
+    get_opt(solver),
+    get_status(solver),
+    primal(get_x(solver))[1:get_nvar(get_nlp(solver))],
+    get_obj_val(solver) / get_cb(solver).obj_scale[],
+    get_c(solver) ./ get_cb(solver).con_scale,
+    get_inf_du(solver),
+    get_inf_pr(solver),
+    copy(get_y(solver)),
+    primal(get_zl(solver))[1:get_nvar(get_nlp(solver))],
+    primal(get_zu(solver))[1:get_nvar(get_nlp(solver))],
     0,
-    _cnt(solver),
+    get_cnt(solver),
 )
 
 function update!(stats::MadNLPExecutionStats, solver::AbstractMadNLPSolver)
-    stats.status = _status(solver)
-    stats.solution .= @view(primal(_x(solver))[1:get_nvar(_nlp(solver))])
-    stats.multipliers .= (_y(solver) .* _cb(solver).con_scale) ./ _cb(solver).obj_scale[]
-    stats.multipliers_L .= @view(primal(_zl(solver))[1:get_nvar(_nlp(solver))]) ./ _cb(solver).obj_scale[]
-    stats.multipliers_U .= @view(primal(_zu(solver))[1:get_nvar(_nlp(solver))]) ./ _cb(solver).obj_scale[]
+    stats.status = get_status(solver)
+    stats.solution .= @view(primal(get_x(solver))[1:get_nvar(get_nlp(solver))])
+    stats.multipliers .= (get_y(solver) .* get_cb(solver).con_scale) ./ get_cb(solver).obj_scale[]
+    stats.multipliers_L .= @view(primal(get_zl(solver))[1:get_nvar(get_nlp(solver))]) ./ get_cb(solver).obj_scale[]
+    stats.multipliers_U .= @view(primal(get_zu(solver))[1:get_nvar(get_nlp(solver))]) ./ get_cb(solver).obj_scale[]
     # stats.solution .= min.(
     #     max.(
-    #         @view(primal(_x(solver))[1:get_nvar(_nlp(solver))]),
-    #         get_lvar(_nlp(solver))
+    #         @view(primal(get_x(solver))[1:get_nvar(get_nlp(solver))]),
+    #         get_lvar(get_nlp(solver))
     #     ),
-    #     get_uvar(_nlp(solver))
+    #     get_uvar(get_nlp(solver))
     # )
-    stats.objective = _obj_val(solver) / _cb(solver).obj_scale[]
-    stats.constraints .= _c(solver) ./ _cb(solver).con_scale .+ _rhs(solver)
-    stats.constraints[_ind_ineq(solver)] .+= slack(_x(solver))
-    stats.dual_feas = _inf_du(solver)
-    stats.primal_feas = _inf_pr(solver)
-    update_z!(_cb(solver), stats.multipliers_L, stats.multipliers_U, _jacl(solver))
-    stats.iter = _cnt(solver).k
+    stats.objective = get_obj_val(solver) / get_cb(solver).obj_scale[]
+    stats.constraints .= get_c(solver) ./ get_cb(solver).con_scale .+ get_rhs(solver)
+    stats.constraints[get_ind_ineq(solver)] .+= slack(get_x(solver))
+    stats.dual_feas = get_inf_du(solver)
+    stats.primal_feas = get_inf_pr(solver)
+    update_z!(get_cb(solver), stats.multipliers_L, stats.multipliers_U, get_jacl(solver))
+    stats.iter = get_cnt(solver).k
     return stats
 end
 
@@ -69,20 +69,20 @@ end
 struct NotEnoughDegreesOfFreedomException <: Exception end
 
 # Utilities
-has_constraints(solver) = _m(solver) != 0
+has_constraints(solver) = get_m(solver) != 0
 
 function get_vars_info(solver)
-    nlp = _nlp(solver)
+    nlp = get_nlp(solver)
 
     x_lb = get_lvar(nlp)
     x_ub = get_uvar(nlp)
-    num_fixed = length(_ind_fixed(solver))
+    num_fixed = length(get_ind_fixed(solver))
     num_var = get_nvar(nlp) - num_fixed
-    num_llb_vars = length(_ind_llb(solver))
+    num_llb_vars = length(get_ind_llb(solver))
 
     # TODO make this non-allocating
     num_lu_vars = sum((x_lb .!=-Inf) .& (x_ub .!= Inf)) - num_fixed
-    num_uub_vars = length(_ind_uub(solver))
+    num_uub_vars = length(get_ind_uub(solver))
     return (
         n_free=num_var,
         n_fixed=num_fixed,
@@ -93,7 +93,7 @@ function get_vars_info(solver)
 end
 
 function get_cons_info(solver)
-    nlp = _nlp(solver)
+    nlp = get_nlp(solver)
 
     g_lb = get_lcon(nlp)
     g_ub = get_ucon(nlp)
@@ -116,88 +116,88 @@ end
 
 # Print functions -----------------------------------------------------------
 function print_init(solver::AbstractMadNLPSolver)
-    @notice(_logger(solver),@sprintf("Number of nonzeros in constraint Jacobian............: %8i", get_nnzj(_nlp(solver).meta)))
-    @notice(_logger(solver),@sprintf("Number of nonzeros in Lagrangian Hessian.............: %8i\n", get_nnzh(_nlp(solver).meta)))
+    @notice(get_logger(solver),@sprintf("Number of nonzeros in constraint Jacobian............: %8i", get_nnzj(get_nlp(solver).meta)))
+    @notice(get_logger(solver),@sprintf("Number of nonzeros in Lagrangian Hessian.............: %8i\n", get_nnzh(get_nlp(solver).meta)))
     var_info = get_vars_info(solver)
     con_info = get_cons_info(solver)
 
-    if get_nvar(_nlp(solver)) < con_info.n_eq
+    if get_nvar(get_nlp(solver)) < con_info.n_eq
         throw(NotEnoughDegreesOfFreedomException())
     end
 
-    @notice(_logger(solver),@sprintf("Total number of variables............................: %8i",var_info.n_free))
-    @notice(_logger(solver),@sprintf("                     variables with only lower bounds: %8i",var_info.n_only_lb))
-    @notice(_logger(solver),@sprintf("                variables with lower and upper bounds: %8i",var_info.n_bounded))
-    @notice(_logger(solver),@sprintf("                     variables with only upper bounds: %8i",var_info.n_only_ub))
-    @notice(_logger(solver),@sprintf("Total number of equality constraints.................: %8i",con_info.n_eq))
-    @notice(_logger(solver),@sprintf("Total number of inequality constraints...............: %8i",con_info.n_ineq))
-    @notice(_logger(solver),@sprintf("        inequality constraints with only lower bounds: %8i",con_info.n_only_lb))
-    @notice(_logger(solver),@sprintf("   inequality constraints with lower and upper bounds: %8i",con_info.n_bounded))
-    @notice(_logger(solver),@sprintf("        inequality constraints with only upper bounds: %8i\n",con_info.n_only_ub))
+    @notice(get_logger(solver),@sprintf("Total number of variables............................: %8i",var_info.n_free))
+    @notice(get_logger(solver),@sprintf("                     variables with only lower bounds: %8i",var_info.n_only_lb))
+    @notice(get_logger(solver),@sprintf("                variables with lower and upper bounds: %8i",var_info.n_bounded))
+    @notice(get_logger(solver),@sprintf("                     variables with only upper bounds: %8i",var_info.n_only_ub))
+    @notice(get_logger(solver),@sprintf("Total number of equality constraints.................: %8i",con_info.n_eq))
+    @notice(get_logger(solver),@sprintf("Total number of inequality constraints...............: %8i",con_info.n_ineq))
+    @notice(get_logger(solver),@sprintf("        inequality constraints with only lower bounds: %8i",con_info.n_only_lb))
+    @notice(get_logger(solver),@sprintf("   inequality constraints with lower and upper bounds: %8i",con_info.n_bounded))
+    @notice(get_logger(solver),@sprintf("        inequality constraints with only upper bounds: %8i\n",con_info.n_only_ub))
     return
 end
 
 function print_iter(solver::AbstractMadNLPSolver; is_resto=false)
-    obj_scale = _cb(solver).obj_scale[]
-    mod(_cnt(solver).k,10)==0&& @info(_logger(solver),@sprintf(
+    obj_scale = get_cb(solver).obj_scale[]
+    mod(get_cnt(solver).k,10)==0&& @info(get_logger(solver),@sprintf(
         "iter    objective    inf_pr   inf_du inf_compl lg(mu) lg(rg) alpha_pr ir ls"))
     if is_resto
-        RR = _RR(solver)::RobustRestorer
+        RR = get_RR(solver)::RobustRestorer
         inf_du = RR.inf_du_R
         inf_pr = RR.inf_pr_R
         inf_compl = RR.inf_compl_R
         mu = log10(RR.mu_R)
     else
-        inf_du = _inf_du(solver)
-        inf_pr = _inf_pr(solver)
-        inf_compl = _inf_compl(solver)
-        mu = log10(_mu(solver))
+        inf_du = get_inf_du(solver)
+        inf_pr = get_inf_pr(solver)
+        inf_compl = get_inf_compl(solver)
+        mu = log10(get_mu(solver))
     end
-    @info(_logger(solver),@sprintf(
+    @info(get_logger(solver),@sprintf(
         "%4i%s% 10.7e %6.2e %6.2e %7.2e %5.1f  %s  %6.2e %2i %2i%s",
-        _cnt(solver).k,is_resto ? "r" : " ",_obj_val(solver)/obj_scale,
+        get_cnt(solver).k,is_resto ? "r" : " ",get_obj_val(solver)/obj_scale,
         inf_pr, inf_du, inf_compl, mu,
-        # _cnt(solver).k == 0 ? 0. : norm(primal(_d(solver)),Inf),
-        _del_w(solver) == 0 ? "   - " : @sprintf("%5.1f",log(10,_del_w(solver))),
-        _alpha(solver),
-        _cnt(solver).ir,
-        _cnt(solver).l,
-        _ftype(solver),))
+        # get_cnt(solver).k == 0 ? 0. : norm(primal(get_d(solver)),Inf),
+        get_del_w(solver) == 0 ? "   - " : @sprintf("%5.1f",log(10,get_del_w(solver))),
+        get_alpha(solver),
+        get_cnt(solver).ir,
+        get_cnt(solver).l,
+        get_ftype(solver),))
     return
 end
 
 function print_summary(solver::AbstractMadNLPSolver)
     # TODO inquire this from nlpmodel wrapper
-    obj_scale = _cb(solver).obj_scale[]
-    _cnt(solver).solver_time = _cnt(solver).total_time-_cnt(solver).linear_solver_time-_cnt(solver).eval_function_time
+    obj_scale = get_cb(solver).obj_scale[]
+    get_cnt(solver).solver_time = get_cnt(solver).total_time-get_cnt(solver).linear_solver_time-get_cnt(solver).eval_function_time
 
-    @notice(_logger(solver),"")
-    @notice(_logger(solver),"Number of Iterations....: $(_cnt(solver).k)\n")
-    @notice(_logger(solver),"                                   (scaled)                 (unscaled)")
-    @notice(_logger(solver),@sprintf("Objective...............:  % 1.16e   % 1.16e",_obj_val(solver),_obj_val(solver)/obj_scale))
-    @notice(_logger(solver),@sprintf("Dual infeasibility......:   %1.16e    %1.16e",_inf_du(solver),_inf_du(solver)/obj_scale))
-    @notice(_logger(solver),@sprintf("Constraint violation....:   %1.16e    %1.16e",norm(_c(solver),Inf),_inf_pr(solver)))
-    @notice(_logger(solver),@sprintf("Complementarity.........:   %1.16e    %1.16e",
-                                _inf_compl(solver)*obj_scale,_inf_compl(solver)))
-    @notice(_logger(solver),@sprintf("Overall NLP error.......:   %1.16e    %1.16e\n",
-                                max(_inf_du(solver)*obj_scale,norm(_c(solver),Inf),_inf_compl(solver)),
-                                max(_inf_du(solver),_inf_pr(solver),_inf_compl(solver))))
+    @notice(get_logger(solver),"")
+    @notice(get_logger(solver),"Number of Iterations....: $(get_cnt(solver).k)\n")
+    @notice(get_logger(solver),"                                   (scaled)                 (unscaled)")
+    @notice(get_logger(solver),@sprintf("Objective...............:  % 1.16e   % 1.16e",get_obj_val(solver),get_obj_val(solver)/obj_scale))
+    @notice(get_logger(solver),@sprintf("Dual infeasibility......:   %1.16e    %1.16e",get_inf_du(solver),get_inf_du(solver)/obj_scale))
+    @notice(get_logger(solver),@sprintf("Constraint violation....:   %1.16e    %1.16e",norm(get_c(solver),Inf),get_inf_pr(solver)))
+    @notice(get_logger(solver),@sprintf("Complementarity.........:   %1.16e    %1.16e",
+                                get_inf_compl(solver)*obj_scale,get_inf_compl(solver)))
+    @notice(get_logger(solver),@sprintf("Overall NLP error.......:   %1.16e    %1.16e\n",
+                                max(get_inf_du(solver)*obj_scale,norm(get_c(solver),Inf),get_inf_compl(solver)),
+                                max(get_inf_du(solver),get_inf_pr(solver),get_inf_compl(solver))))
 
-    @notice(_logger(solver),"Number of objective function evaluations              = $(_cnt(solver).obj_cnt)")
-    @notice(_logger(solver),"Number of objective gradient evaluations              = $(_cnt(solver).obj_grad_cnt)")
-    @notice(_logger(solver),"Number of constraint evaluations                      = $(_cnt(solver).con_cnt)")
-    @notice(_logger(solver),"Number of constraint Jacobian evaluations             = $(_cnt(solver).con_jac_cnt)")
-    @notice(_logger(solver),"Number of Lagrangian Hessian evaluations              = $(_cnt(solver).lag_hess_cnt)\n")
-    @notice(_logger(solver),@sprintf("Total wall secs in initialization                     = %6.3f",
-                                _cnt(solver).init_time))
-    @notice(_logger(solver),@sprintf("Total wall secs in linear solver                      = %6.3f",
-                                _cnt(solver).linear_solver_time))
-    @notice(_logger(solver),@sprintf("Total wall secs in NLP function evaluations           = %6.3f",
-                                _cnt(solver).eval_function_time))
-    @notice(_logger(solver),@sprintf("Total wall secs in solver (w/o init./fun./lin. alg.)  = %6.3f",
-                                _cnt(solver).total_time - _cnt(solver).init_time - _cnt(solver).linear_solver_time - _cnt(solver).eval_function_time))
-    @notice(_logger(solver),@sprintf("Total wall secs                                       = %6.3f\n",
-                                _cnt(solver).total_time))
+    @notice(get_logger(solver),"Number of objective function evaluations              = $(get_cnt(solver).obj_cnt)")
+    @notice(get_logger(solver),"Number of objective gradient evaluations              = $(get_cnt(solver).obj_grad_cnt)")
+    @notice(get_logger(solver),"Number of constraint evaluations                      = $(get_cnt(solver).con_cnt)")
+    @notice(get_logger(solver),"Number of constraint Jacobian evaluations             = $(get_cnt(solver).con_jac_cnt)")
+    @notice(get_logger(solver),"Number of Lagrangian Hessian evaluations              = $(get_cnt(solver).lag_hess_cnt)\n")
+    @notice(get_logger(solver),@sprintf("Total wall secs in initialization                     = %6.3f",
+                                get_cnt(solver).init_time))
+    @notice(get_logger(solver),@sprintf("Total wall secs in linear solver                      = %6.3f",
+                                get_cnt(solver).linear_solver_time))
+    @notice(get_logger(solver),@sprintf("Total wall secs in NLP function evaluations           = %6.3f",
+                                get_cnt(solver).eval_function_time))
+    @notice(get_logger(solver),@sprintf("Total wall secs in solver (w/o init./fun./lin. alg.)  = %6.3f",
+                                get_cnt(solver).total_time - get_cnt(solver).init_time - get_cnt(solver).linear_solver_time - get_cnt(solver).eval_function_time))
+    @notice(get_logger(solver),@sprintf("Total wall secs                                       = %6.3f\n",
+                                get_cnt(solver).total_time))
 end
 
 
@@ -205,11 +205,11 @@ function string(solver::AbstractMadNLPSolver)
     """
                 Interior point solver
 
-                number of variables......................: $(get_nvar(_nlp(solver)))
-                number of constraints....................: $(get_ncon(_nlp(solver)))
-                number of nonzeros in Lagrangian Hessian.: $(get_nnzh(_nlp(solver).meta))
-                number of nonzeros in constraint Jacobian: $(get_nnzj(_nlp(solver).meta))
-                status...................................: $(_status(solver))
+                number of variables......................: $(get_nvar(get_nlp(solver)))
+                number of constraints....................: $(get_ncon(get_nlp(solver)))
+                number of nonzeros in Lagrangian Hessian.: $(get_nnzh(get_nlp(solver).meta))
+                number of nonzeros in constraint Jacobian: $(get_nnzj(get_nlp(solver).meta))
+                status...................................: $(get_status(solver))
                 """
 end
 print(io::IO,solver::AbstractMadNLPSolver) = print(io, string(solver))

--- a/src/IPM/utils.jl
+++ b/src/IPM/utils.jl
@@ -21,40 +21,40 @@ mutable struct MadNLPExecutionStats{T, VT} <: AbstractExecutionStats
 end
 
 MadNLPExecutionStats(solver::AbstractMadNLPSolver) =MadNLPExecutionStats(
-    solver.opt,
-    solver.status,
-    primal(solver.x)[1:get_nvar(solver.nlp)],
-    solver.obj_val / solver.cb.obj_scale[],
-    solver.c ./ solver.cb.con_scale,
-    solver.inf_du,
-    solver.inf_pr,
-    copy(solver.y),
-    primal(solver.zl)[1:get_nvar(solver.nlp)],
-    primal(solver.zu)[1:get_nvar(solver.nlp)],
+    _opt(solver),
+    _status(solver),
+    primal(_x(solver))[1:get_nvar(_nlp(solver))],
+    _obj_val(solver) / _cb(solver).obj_scale[],
+    _c(solver) ./ _cb(solver).con_scale,
+    _inf_du(solver),
+    _inf_pr(solver),
+    copy(_y(solver)),
+    primal(_zl(solver))[1:get_nvar(_nlp(solver))],
+    primal(_zu(solver))[1:get_nvar(_nlp(solver))],
     0,
-    solver.cnt,
+    _cnt(solver),
 )
 
 function update!(stats::MadNLPExecutionStats, solver::AbstractMadNLPSolver)
-    stats.status = solver.status
-    stats.solution .= @view(primal(solver.x)[1:get_nvar(solver.nlp)])
-    stats.multipliers .= (solver.y .* solver.cb.con_scale) ./ solver.cb.obj_scale[]
-    stats.multipliers_L .= @view(primal(solver.zl)[1:get_nvar(solver.nlp)]) ./ solver.cb.obj_scale[]
-    stats.multipliers_U .= @view(primal(solver.zu)[1:get_nvar(solver.nlp)]) ./ solver.cb.obj_scale[]
+    stats.status = _status(solver)
+    stats.solution .= @view(primal(_x(solver))[1:get_nvar(_nlp(solver))])
+    stats.multipliers .= (_y(solver) .* _cb(solver).con_scale) ./ _cb(solver).obj_scale[]
+    stats.multipliers_L .= @view(primal(_zl(solver))[1:get_nvar(_nlp(solver))]) ./ _cb(solver).obj_scale[]
+    stats.multipliers_U .= @view(primal(_zu(solver))[1:get_nvar(_nlp(solver))]) ./ _cb(solver).obj_scale[]
     # stats.solution .= min.(
     #     max.(
-    #         @view(primal(solver.x)[1:get_nvar(solver.nlp)]),
-    #         get_lvar(solver.nlp)
+    #         @view(primal(_x(solver))[1:get_nvar(_nlp(solver))]),
+    #         get_lvar(_nlp(solver))
     #     ),
-    #     get_uvar(solver.nlp)
+    #     get_uvar(_nlp(solver))
     # )
-    stats.objective = solver.obj_val / solver.cb.obj_scale[]
-    stats.constraints .= solver.c ./ solver.cb.con_scale .+ solver.rhs
-    stats.constraints[solver.ind_ineq] .+= slack(solver.x)
-    stats.dual_feas = solver.inf_du
-    stats.primal_feas = solver.inf_pr
-    update_z!(solver.cb, stats.multipliers_L, stats.multipliers_U, solver.jacl)
-    stats.iter = solver.cnt.k
+    stats.objective = _obj_val(solver) / _cb(solver).obj_scale[]
+    stats.constraints .= _c(solver) ./ _cb(solver).con_scale .+ _rhs(solver)
+    stats.constraints[_ind_ineq(solver)] .+= slack(_x(solver))
+    stats.dual_feas = _inf_du(solver)
+    stats.primal_feas = _inf_pr(solver)
+    update_z!(_cb(solver), stats.multipliers_L, stats.multipliers_U, _jacl(solver))
+    stats.iter = _cnt(solver).k
     return stats
 end
 
@@ -69,20 +69,20 @@ end
 struct NotEnoughDegreesOfFreedomException <: Exception end
 
 # Utilities
-has_constraints(solver) = solver.m != 0
+has_constraints(solver) = _m(solver) != 0
 
 function get_vars_info(solver)
-    nlp = solver.nlp
+    nlp = _nlp(solver)
 
     x_lb = get_lvar(nlp)
     x_ub = get_uvar(nlp)
-    num_fixed = length(solver.ind_fixed)
+    num_fixed = length(_ind_fixed(solver))
     num_var = get_nvar(nlp) - num_fixed
-    num_llb_vars = length(solver.ind_llb)
+    num_llb_vars = length(_ind_llb(solver))
 
     # TODO make this non-allocating
     num_lu_vars = sum((x_lb .!=-Inf) .& (x_ub .!= Inf)) - num_fixed
-    num_uub_vars = length(solver.ind_uub)
+    num_uub_vars = length(_ind_uub(solver))
     return (
         n_free=num_var,
         n_fixed=num_fixed,
@@ -93,7 +93,7 @@ function get_vars_info(solver)
 end
 
 function get_cons_info(solver)
-    nlp = solver.nlp
+    nlp = _nlp(solver)
 
     g_lb = get_lcon(nlp)
     g_ub = get_ucon(nlp)
@@ -116,88 +116,88 @@ end
 
 # Print functions -----------------------------------------------------------
 function print_init(solver::AbstractMadNLPSolver)
-    @notice(solver.logger,@sprintf("Number of nonzeros in constraint Jacobian............: %8i", get_nnzj(solver.nlp.meta)))
-    @notice(solver.logger,@sprintf("Number of nonzeros in Lagrangian Hessian.............: %8i\n", get_nnzh(solver.nlp.meta)))
+    @notice(_logger(solver),@sprintf("Number of nonzeros in constraint Jacobian............: %8i", get_nnzj(_nlp(solver).meta)))
+    @notice(_logger(solver),@sprintf("Number of nonzeros in Lagrangian Hessian.............: %8i\n", get_nnzh(_nlp(solver).meta)))
     var_info = get_vars_info(solver)
     con_info = get_cons_info(solver)
 
-    if get_nvar(solver.nlp) < con_info.n_eq
+    if get_nvar(_nlp(solver)) < con_info.n_eq
         throw(NotEnoughDegreesOfFreedomException())
     end
 
-    @notice(solver.logger,@sprintf("Total number of variables............................: %8i",var_info.n_free))
-    @notice(solver.logger,@sprintf("                     variables with only lower bounds: %8i",var_info.n_only_lb))
-    @notice(solver.logger,@sprintf("                variables with lower and upper bounds: %8i",var_info.n_bounded))
-    @notice(solver.logger,@sprintf("                     variables with only upper bounds: %8i",var_info.n_only_ub))
-    @notice(solver.logger,@sprintf("Total number of equality constraints.................: %8i",con_info.n_eq))
-    @notice(solver.logger,@sprintf("Total number of inequality constraints...............: %8i",con_info.n_ineq))
-    @notice(solver.logger,@sprintf("        inequality constraints with only lower bounds: %8i",con_info.n_only_lb))
-    @notice(solver.logger,@sprintf("   inequality constraints with lower and upper bounds: %8i",con_info.n_bounded))
-    @notice(solver.logger,@sprintf("        inequality constraints with only upper bounds: %8i\n",con_info.n_only_ub))
+    @notice(_logger(solver),@sprintf("Total number of variables............................: %8i",var_info.n_free))
+    @notice(_logger(solver),@sprintf("                     variables with only lower bounds: %8i",var_info.n_only_lb))
+    @notice(_logger(solver),@sprintf("                variables with lower and upper bounds: %8i",var_info.n_bounded))
+    @notice(_logger(solver),@sprintf("                     variables with only upper bounds: %8i",var_info.n_only_ub))
+    @notice(_logger(solver),@sprintf("Total number of equality constraints.................: %8i",con_info.n_eq))
+    @notice(_logger(solver),@sprintf("Total number of inequality constraints...............: %8i",con_info.n_ineq))
+    @notice(_logger(solver),@sprintf("        inequality constraints with only lower bounds: %8i",con_info.n_only_lb))
+    @notice(_logger(solver),@sprintf("   inequality constraints with lower and upper bounds: %8i",con_info.n_bounded))
+    @notice(_logger(solver),@sprintf("        inequality constraints with only upper bounds: %8i\n",con_info.n_only_ub))
     return
 end
 
 function print_iter(solver::AbstractMadNLPSolver; is_resto=false)
-    obj_scale = solver.cb.obj_scale[]
-    mod(solver.cnt.k,10)==0&& @info(solver.logger,@sprintf(
+    obj_scale = _cb(solver).obj_scale[]
+    mod(_cnt(solver).k,10)==0&& @info(_logger(solver),@sprintf(
         "iter    objective    inf_pr   inf_du inf_compl lg(mu) lg(rg) alpha_pr ir ls"))
     if is_resto
-        RR = solver.RR::RobustRestorer
+        RR = _RR(solver)::RobustRestorer
         inf_du = RR.inf_du_R
         inf_pr = RR.inf_pr_R
         inf_compl = RR.inf_compl_R
         mu = log10(RR.mu_R)
     else
-        inf_du = solver.inf_du
-        inf_pr = solver.inf_pr
-        inf_compl = solver.inf_compl
-        mu = log10(solver.mu)
+        inf_du = _inf_du(solver)
+        inf_pr = _inf_pr(solver)
+        inf_compl = _inf_compl(solver)
+        mu = log10(_mu(solver))
     end
-    @info(solver.logger,@sprintf(
+    @info(_logger(solver),@sprintf(
         "%4i%s% 10.7e %6.2e %6.2e %7.2e %5.1f  %s  %6.2e %2i %2i%s",
-        solver.cnt.k,is_resto ? "r" : " ",solver.obj_val/obj_scale,
+        _cnt(solver).k,is_resto ? "r" : " ",_obj_val(solver)/obj_scale,
         inf_pr, inf_du, inf_compl, mu,
-        # solver.cnt.k == 0 ? 0. : norm(primal(solver.d),Inf),
-        solver.del_w == 0 ? "   - " : @sprintf("%5.1f",log(10,solver.del_w)),
-        solver.alpha,
-        solver.cnt.ir,
-        solver.cnt.l,
-        solver.ftype,))
+        # _cnt(solver).k == 0 ? 0. : norm(primal(_d(solver)),Inf),
+        _del_w(solver) == 0 ? "   - " : @sprintf("%5.1f",log(10,_del_w(solver))),
+        _alpha(solver),
+        _cnt(solver).ir,
+        _cnt(solver).l,
+        _ftype(solver),))
     return
 end
 
 function print_summary(solver::AbstractMadNLPSolver)
     # TODO inquire this from nlpmodel wrapper
-    obj_scale = solver.cb.obj_scale[]
-    solver.cnt.solver_time = solver.cnt.total_time-solver.cnt.linear_solver_time-solver.cnt.eval_function_time
+    obj_scale = _cb(solver).obj_scale[]
+    _cnt(solver).solver_time = _cnt(solver).total_time-_cnt(solver).linear_solver_time-_cnt(solver).eval_function_time
 
-    @notice(solver.logger,"")
-    @notice(solver.logger,"Number of Iterations....: $(solver.cnt.k)\n")
-    @notice(solver.logger,"                                   (scaled)                 (unscaled)")
-    @notice(solver.logger,@sprintf("Objective...............:  % 1.16e   % 1.16e",solver.obj_val,solver.obj_val/obj_scale))
-    @notice(solver.logger,@sprintf("Dual infeasibility......:   %1.16e    %1.16e",solver.inf_du,solver.inf_du/obj_scale))
-    @notice(solver.logger,@sprintf("Constraint violation....:   %1.16e    %1.16e",norm(solver.c,Inf),solver.inf_pr))
-    @notice(solver.logger,@sprintf("Complementarity.........:   %1.16e    %1.16e",
-                                solver.inf_compl*obj_scale,solver.inf_compl))
-    @notice(solver.logger,@sprintf("Overall NLP error.......:   %1.16e    %1.16e\n",
-                                max(solver.inf_du*obj_scale,norm(solver.c,Inf),solver.inf_compl),
-                                max(solver.inf_du,solver.inf_pr,solver.inf_compl)))
+    @notice(_logger(solver),"")
+    @notice(_logger(solver),"Number of Iterations....: $(_cnt(solver).k)\n")
+    @notice(_logger(solver),"                                   (scaled)                 (unscaled)")
+    @notice(_logger(solver),@sprintf("Objective...............:  % 1.16e   % 1.16e",_obj_val(solver),_obj_val(solver)/obj_scale))
+    @notice(_logger(solver),@sprintf("Dual infeasibility......:   %1.16e    %1.16e",_inf_du(solver),_inf_du(solver)/obj_scale))
+    @notice(_logger(solver),@sprintf("Constraint violation....:   %1.16e    %1.16e",norm(_c(solver),Inf),_inf_pr(solver)))
+    @notice(_logger(solver),@sprintf("Complementarity.........:   %1.16e    %1.16e",
+                                _inf_compl(solver)*obj_scale,_inf_compl(solver)))
+    @notice(_logger(solver),@sprintf("Overall NLP error.......:   %1.16e    %1.16e\n",
+                                max(_inf_du(solver)*obj_scale,norm(_c(solver),Inf),_inf_compl(solver)),
+                                max(_inf_du(solver),_inf_pr(solver),_inf_compl(solver))))
 
-    @notice(solver.logger,"Number of objective function evaluations              = $(solver.cnt.obj_cnt)")
-    @notice(solver.logger,"Number of objective gradient evaluations              = $(solver.cnt.obj_grad_cnt)")
-    @notice(solver.logger,"Number of constraint evaluations                      = $(solver.cnt.con_cnt)")
-    @notice(solver.logger,"Number of constraint Jacobian evaluations             = $(solver.cnt.con_jac_cnt)")
-    @notice(solver.logger,"Number of Lagrangian Hessian evaluations              = $(solver.cnt.lag_hess_cnt)\n")
-    @notice(solver.logger,@sprintf("Total wall secs in initialization                     = %6.3f",
-                                solver.cnt.init_time))
-    @notice(solver.logger,@sprintf("Total wall secs in linear solver                      = %6.3f",
-                                solver.cnt.linear_solver_time))
-    @notice(solver.logger,@sprintf("Total wall secs in NLP function evaluations           = %6.3f",
-                                solver.cnt.eval_function_time))
-    @notice(solver.logger,@sprintf("Total wall secs in solver (w/o init./fun./lin. alg.)  = %6.3f",
-                                solver.cnt.total_time - solver.cnt.init_time - solver.cnt.linear_solver_time - solver.cnt.eval_function_time))
-    @notice(solver.logger,@sprintf("Total wall secs                                       = %6.3f\n",
-                                solver.cnt.total_time))
+    @notice(_logger(solver),"Number of objective function evaluations              = $(_cnt(solver).obj_cnt)")
+    @notice(_logger(solver),"Number of objective gradient evaluations              = $(_cnt(solver).obj_grad_cnt)")
+    @notice(_logger(solver),"Number of constraint evaluations                      = $(_cnt(solver).con_cnt)")
+    @notice(_logger(solver),"Number of constraint Jacobian evaluations             = $(_cnt(solver).con_jac_cnt)")
+    @notice(_logger(solver),"Number of Lagrangian Hessian evaluations              = $(_cnt(solver).lag_hess_cnt)\n")
+    @notice(_logger(solver),@sprintf("Total wall secs in initialization                     = %6.3f",
+                                _cnt(solver).init_time))
+    @notice(_logger(solver),@sprintf("Total wall secs in linear solver                      = %6.3f",
+                                _cnt(solver).linear_solver_time))
+    @notice(_logger(solver),@sprintf("Total wall secs in NLP function evaluations           = %6.3f",
+                                _cnt(solver).eval_function_time))
+    @notice(_logger(solver),@sprintf("Total wall secs in solver (w/o init./fun./lin. alg.)  = %6.3f",
+                                _cnt(solver).total_time - _cnt(solver).init_time - _cnt(solver).linear_solver_time - _cnt(solver).eval_function_time))
+    @notice(_logger(solver),@sprintf("Total wall secs                                       = %6.3f\n",
+                                _cnt(solver).total_time))
 end
 
 
@@ -205,11 +205,11 @@ function string(solver::AbstractMadNLPSolver)
     """
                 Interior point solver
 
-                number of variables......................: $(get_nvar(solver.nlp))
-                number of constraints....................: $(get_ncon(solver.nlp))
-                number of nonzeros in Lagrangian Hessian.: $(get_nnzh(solver.nlp.meta))
-                number of nonzeros in constraint Jacobian: $(get_nnzj(solver.nlp.meta))
-                status...................................: $(solver.status)
+                number of variables......................: $(get_nvar(_nlp(solver)))
+                number of constraints....................: $(get_ncon(_nlp(solver)))
+                number of nonzeros in Lagrangian Hessian.: $(get_nnzh(_nlp(solver).meta))
+                number of nonzeros in constraint Jacobian: $(get_nnzj(_nlp(solver).meta))
+                status...................................: $(_status(solver))
                 """
 end
 print(io::IO,solver::AbstractMadNLPSolver) = print(io, string(solver))


### PR DESCRIPTION
WIP until #497 goes in.

This PR separates out the steps within each MadNLP iteration as `step_name(solver::AbstractMadNLPSolver)`. Extensions to MadNLP then only need to provide specializations for the sections of the algorithm that they change. This should help minimize the maintenance burden for those extensions.

If people want to review just the changes in this PR easily the diff can be found here: https://github.com/apozharski/MadNLP.jl/pull/3/files