### PR TITLE
Fix barrier initialization with type conversion

### DIFF
--- a/src/IPM/options.jl
+++ b/src/IPM/options.jl
@@ -96,7 +96,7 @@ end
 
     # Barrier
     # mu_min by courtesy of Ipopt
-    barrier::AbstractBarrierUpdate{T} = MonotoneUpdate(tol, barrier_tol_factor)
+    barrier::AbstractBarrierUpdate{T} = MonotoneUpdate(T(tol), barrier_tol_factor)
     tau_min::T = 0.99
 end
 


### PR DESCRIPTION
A test failed in `Float32` because of that (discovered in #524).