### PR TITLE
Properly map NLP constraint index for MOI dual

### DIFF
--- a/ext/MadNLPMOI/MadNLPMOI.jl
+++ b/ext/MadNLPMOI/MadNLPMOI.jl
@@ -1151,7 +1151,7 @@ function MOI.get(
     MOI.check_result_index_bounds(model, attr)
     MOI.throw_if_not_valid(model, ci)
     s = -1.0
-    return s * model.result.multipliers[ci.value]
+    return s * model.result.multipliers[row(model, ci)]
 end
 
 function MOI.get(


### PR DESCRIPTION
I believe it is due to clash between `ci.value` for different `ci` types. The MWE below has one NLP constriant, one QP constraint. This may not be the only place that needs adjustment.

Before the fix:
```julia
using JuMP, MadNLP, Ipopt

m = Model(MadNLP.Optimizer); set_silent(m)
@variable(m, x, start=0.5)
@variable(m, y, start=0.5)
@constraint(m, mc1, y - sin(x) >= 0)
@constraint(m, mc2, x + y == 1.0)
@objective(m, Min, (1-x)^2 + 100*(y-x^2)^2)
optimize!(m)


m2 = Model(Ipopt.Optimizer); set_silent(m2)
@variable(m2, x, start=0.5)
@variable(m2, y, start=0.5)
@constraint(m2, ic1, y - sin(x) >= 0)
@constraint(m2, ic2, x + y == 1.0)
@objective(m2, Min, (1-x)^2 + 100*(y-x^2)^2)
optimize!(m2)

println("$(dual(mc1))  $(dual(ic1))")
# -4.166791970209907  49.75333483477855
println("$(dual(mc2))  $(dual(ic2))")
# -4.166791970209907  -4.16679196972487
```