### PR TITLE
Fix hessian for dense KKT

### DIFF
--- a/src/Callbacks/nlpmodels.jl
+++ b/src/Callbacks/nlpmodels.jl
@@ -875,6 +875,9 @@ function _eval_lag_hess_wrapper!(
     @inbounds @simd for k in 1:length(cb.hess_I)
         i, j = cb.hess_I[k], cb.hess_J[k]
         hess[i, j] += hess_buffer[k]
+        if i != j
+            hess[j, i] += hess_buffer[k]
+        end
     end
     return hess
 end


### PR DESCRIPTION
This PR fills both sides of the hessian in the dense KKT/sparse callback case. This is what happens when you use the MOI interface and ask for DenseKKTSystem. It is a particularly nasty bug since the solver still converges, which is probably why it was never noticed.


<details> <summary> MWE </summary>

In this problem, before the fix, SparseKKTSystem takes 5 iterations, but DenseKKTSystem takes 27, due to wrong hessian terms.
After the fix, they both take 5 iterations as expected.

Before PR:

```julia
julia> using MadNLP, JuMP
julia> m = Model(MadNLP.Optimizer);
julia> @variable(m, x);
julia> @variable(m, y);
julia> @variable(m, p in MOI.Parameter(1.0));
julia> @constraint(m, x + y >= p);
julia> @objective(m, Min, x^2 + 2*x*y + 3*y^2);
julia> optimize!(m)
This is MadNLP version v0.8.12, running with umfpack

iter    objective    inf_pr   inf_du inf_compl lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
   0  0.0000000e+00 1.01e+00 6.67e-01 1.00e-02  -1.0 0.00e+00    -  0.00e+00 0.00e+00   0
   1  1.1842560e+00 4.16e-17 2.22e-15 1.92e-01  -1.0 1.09e+00    -  1.00e+00 1.00e+00h  1
   2  1.0157006e+00 1.39e-17 4.44e-16 1.58e-02  -2.5 8.04e-02    -  1.00e+00 1.00e+00h  1
   3  1.0002685e+00 1.65e-17 4.44e-16 2.69e-04  -3.8 7.69e-03    -  1.00e+00 1.00e+00h  1
   4  1.0000019e+00 1.01e-16 4.44e-16 1.88e-06  -5.7 1.33e-04    -  1.00e+00 1.00e+00h  1
   5  9.9999998e-01 3.70e-17 2.22e-16 2.51e-09  -8.6 9.39e-07    -  1.00e+00 1.00e+00h  1

Number of Iterations....: 5

EXIT: Optimal Solution Found (tol = 1.0e-08).


julia> m = Model(() ->MadNLP.Optimizer(; kkt_system=MadNLP.DenseKKTSystem, linear_solver=LapackCPUSolver));
julia> @variable(m, x);
julia> @variable(m, y);
julia> @variable(m, p in MOI.Parameter(1.0));
julia> @constraint(m, x + y >= p);
julia> @objective(m, Min, x^2 + 2*x*y + 3*y^2);
julia> optimize!(m)
This is MadNLP version v0.8.12, running with Lapack-CPU (BUNCHKAUFMAN)

iter    objective    inf_pr   inf_du inf_compl lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
   0  0.0000000e+00 1.01e+00 6.67e-01 1.00e-02  -1.0 0.00e+00    -  0.00e+00 0.00e+00   0
   1  1.3454464e+00 1.53e-16 1.64e+00 1.54e-01  -1.0 8.20e-01    -  1.00e+00 1.00e+00h  1
   2  1.0693081e+00 9.71e-17 3.10e-01 4.80e-02  -1.0 1.55e-01    -  1.00e+00 1.00e+00h  1
   3  1.0271379e+00 2.53e-16 1.23e-01 2.21e-02  -1.7 6.17e-02    -  1.00e+00 1.00e+00h  1
   4  1.0047787e+00 9.54e-17 6.10e-02 3.51e-03  -2.5 3.05e-02    -  1.00e+00 1.00e+00h  1
   5  1.0031392e+00 1.23e-16 2.63e-02 2.84e-03  -2.5 1.32e-02    -  1.00e+00 1.00e+00h  1
   6  1.0002457e+00 6.55e-17 1.37e-02 1.71e-04  -3.8 6.84e-03    -  1.00e+00 1.00e+00h  1
   7  1.0001691e+00 6.87e-17 6.18e-03 1.50e-04  -3.8 3.09e-03    -  1.00e+00 1.00e+00h  1
   8  1.0001549e+00 6.71e-17 3.09e-03 1.50e-04  -3.8 1.54e-03    -  1.00e+00 1.00e+00h  1
   9  1.0001515e+00 1.14e-16 1.54e-03 1.50e-04  -3.8 7.72e-04    -  1.00e+00 1.00e+00h  1
iter    objective    inf_pr   inf_du inf_compl lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
  10  1.0001506e+00 7.38e-17 7.72e-04 1.50e-04  -3.8 3.86e-04    -  1.00e+00 1.00e+00h  1
  11  1.0000019e+00 3.27e-17 4.23e-04 1.88e-06  -5.7 2.12e-04    -  1.00e+00 1.00e+00h  1
  12  1.0000018e+00 4.00e-17 1.74e-04 1.84e-06  -5.7 8.72e-05    -  1.00e+00 1.00e+00h  1
  13  1.0000018e+00 1.15e-16 8.72e-05 1.84e-06  -5.7 4.36e-05    -  1.00e+00 1.00e+00h  1
  14  1.0000018e+00 1.04e-16 4.36e-05 1.84e-06  -5.7 2.18e-05    -  1.00e+00 1.00e+00h  1
  15  1.0000018e+00 5.96e-17 2.18e-05 1.84e-06  -5.7 1.09e-05    -  1.00e+00 1.00e+00h  1
  16  1.0000018e+00 1.43e-16 1.09e-05 1.84e-06  -5.7 5.45e-06    -  1.00e+00 1.00e+00h  1
  17  9.9999998e-01 5.04e-17 5.91e-06 2.51e-09  -8.6 2.96e-06    -  1.00e+00 1.00e+00h  1
  18  9.9999998e-01 1.57e-17 2.49e-06 2.51e-09  -8.6 1.25e-06    -  1.00e+00 1.00e+00h  1
  19  9.9999998e-01 1.67e-17 1.25e-06 2.51e-09  -8.6 6.24e-07    -  1.00e+00 1.00e+00h  1
iter    objective    inf_pr   inf_du inf_compl lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
  20  9.9999998e-01 4.10e-17 6.24e-07 2.51e-09  -8.6 3.12e-07    -  1.00e+00 1.00e+00h  1
  21  9.9999998e-01 1.43e-17 3.12e-07 2.51e-09  -8.6 1.56e-07    -  1.00e+00 1.00e+00h  1
  22  9.9999998e-01 9.99e-19 1.56e-07 2.51e-09  -8.6 7.80e-08    -  1.00e+00 1.00e+00h  1
  23  9.9999998e-01 6.12e-17 7.80e-08 2.51e-09  -8.6 3.90e-08    -  1.00e+00 1.00e+00h  1
  24  9.9999998e-01 3.68e-17 3.90e-08 2.51e-09  -8.6 1.95e-08    -  1.00e+00 1.00e+00h  1
  25  9.9999998e-01 2.45e-17 1.95e-08 2.51e-09  -8.6 9.75e-09    -  1.00e+00 1.00e+00h  1
  26  9.9999998e-01 1.15e-18 1.01e-08 9.09e-10  -9.0 5.07e-09    -  1.00e+00 1.00e+00h  1
  27  9.9999998e-01 4.27e-18 4.67e-09 9.09e-10  -9.0 2.34e-09    -  1.00e+00 1.00e+00h  1

Number of Iterations....: 27

julia> unsafe_backend(m).solver.kkt.aug_com
4×4 Matrix{Float64}:
 2.0  2.0   0.0     1.0
 0.0  6.0   0.0     1.0
 0.0  0.0   4.4e9  -1.0
 1.0  1.0  -1.0     0.0
```

After PR:

```julia
julia> using MadNLP, JuMP
julia> m = Model(() ->MadNLP.Optimizer(; kkt_system=MadNLP.DenseKKTSystem, linear_solver=LapackCPUSolver));
julia> @variable(m, x);
julia> @variable(m, y);
julia> @variable(m, p in MOI.Parameter(1.0));
julia> @constraint(m, x + y >= p);
julia> @objective(m, Min, x^2 + 2*x*y + 3*y^2);
julia> optimize!(m)
This is MadNLP version v0.8.12, running with Lapack-CPU (BUNCHKAUFMAN)

iter    objective    inf_pr   inf_du inf_compl lg(mu) lg(rg) alpha_pr ir ls
   0  0.0000000e+00 1.01e+00 6.67e-01 1.00e-02  -1.0     -   0.00e+00  1  0
   1  1.1842560e+00 2.78e-17 1.33e-15 1.92e-01  -1.0     -   1.00e+00  1  1h
   2  1.0157006e+00 6.94e-17 4.44e-16 1.58e-02  -2.5     -   1.00e+00  1  1h
   3  1.0002685e+00 1.65e-17 0.00e+00 2.69e-04  -3.8     -   1.00e+00  1  1h
   4  1.0000019e+00 1.01e-16 4.44e-16 1.88e-06  -5.7     -   1.00e+00  1  1h
   5  9.9999998e-01 3.70e-17 0.00e+00 2.51e-09  -8.6     -   1.00e+00  1  1h

Number of Iterations....: 5

EXIT: Optimal Solution Found (tol = 1.0e-08).

4×4 Matrix{Float64}:
 2.0  2.0   0.0         1.0
 2.0  6.0   0.0         1.0
 0.0  0.0   2.12714e6  -1.0
 1.0  1.0  -1.0         0.0
```


</details>