### PR TITLE
Remove extra `build_kkt!` call

### DIFF
--- a/src/KKT/KKTsystem.jl
+++ b/src/KKT/KKTsystem.jl
@@ -219,7 +219,6 @@ function regularize_diagonal!(kkt::AbstractKKTSystem, primal, dual)
     kkt.reg .+= primal
     kkt.pr_diag .+= primal
     kkt.du_diag .-= dual
-    build_kkt!(kkt)
 end
 
 Base.size(kkt::AbstractKKTSystem) = size(kkt.aug_com)


### PR DESCRIPTION
@sshin23 #481 added this `build_kkt!` to the fallback `regularize_diagonal!`: https://github.com/MadNLP/MadNLP.jl/blob/7a4b239dc908d97d37776072af5d89bd8fb4ea6b/src/KKT/KKTsystem.jl#L218-L223
but I notice the `ScaledSparseKKTSystem` version (the only other version) does not have it
https://github.com/MadNLP/MadNLP.jl/blob/7a4b239dc908d97d37776072af5d89bd8fb4ea6b/src/KKT/Sparse/scaled_augmented.jl#L238-L242
furthermore, all callers of `regularize_diagonal!` (the versions of `inertia_correction!`) proceed to call `factorize_wrapper!` which itself calls `build_kkt!`. So it seems to be unnecessary, this PR removes it. 