### PR TITLE
Apply `obj_scale` in `unpack_z` in `MakeParameter` case

### DIFF
--- a/src/Callbacks/nlpmodels.jl
+++ b/src/Callbacks/nlpmodels.jl
@@ -688,7 +688,7 @@ function unpack_x!(x_full, cb::SparseCallback{T, VT, VI, NLP, FH}, x) where {T, 
 end
 function unpack_z!(z_full, cb::SparseCallback{T, VT, VI, NLP, FH}, z) where {T, VT, VI, NLP, FH<:MakeParameter}
     free = cb.fixed_handler.free
-    z_full[free] .= z
+    z_full[free] .= z ./ cb.obj_scale[]
 end
 
 


### PR DESCRIPTION
The generic case scales:

https://github.com/MadNLP/MadNLP.jl/blob/ef07381034c80b74a72b4858d587b5f48e914f81/src/Callbacks/nlpmodels.jl#L658-L660

but the MakeParameter one doesn't:

https://github.com/MadNLP/MadNLP.jl/blob/ef07381034c80b74a72b4858d587b5f48e914f81/src/Callbacks/nlpmodels.jl#L689-L692

This PR adds scaling to the latter case. Maybe it should be removed from the former instead?