### PR TITLE
LBFGS is only supported with the KKT formulation SparseKKTSystem

### DIFF
--- a/src/IPM/factorization.jl
+++ b/src/IPM/factorization.jl
@@ -161,21 +161,21 @@ function solve!(
     kkt::SparseUnreducedKKTSystem{T, VT, MT, QN},
     w::AbstractKKTVector
     ) where {T, VT, MT, QN<:CompactLBFGS}
-    error("Quasi-Newton approximation of the Hessian is not supported by the KKT formulation SparseUnreducedKKTSystem.")
+    error("Quasi-Newton approximation of the Hessian is not supported by the KKT formulation SparseUnreducedKKTSystem. Please use SparseKKTSystem instead.")
 end
 
 function solve!(
     kkt::SparseCondensedKKTSystem{T, VT, MT, QN},
     w::AbstractKKTVector
     ) where {T, VT, MT, QN<:CompactLBFGS}
-    error("Quasi-Newton approximation of the Hessian is not supported by the KKT formulation SparseCondensedKKTSystem.")
+    error("Quasi-Newton approximation of the Hessian is not supported by the KKT formulation SparseCondensedKKTSystem. Please use SparseKKTSystem instead.")
 end
 
 function solve!(
     kkt::ScaledSparseKKTSystem{T, VT, MT, QN},
     w::AbstractKKTVector
     ) where {T, VT, MT, QN<:CompactLBFGS}
-    error("Quasi-Newton approximation of the Hessian is not supported by the KKT formulation ScaledSparseKKTSystem.")
+    error("Quasi-Newton approximation of the Hessian is not supported by the KKT formulation ScaledSparseKKTSystem. Please use SparseKKTSystem instead.")
 end
 
 function solve!(


### PR DESCRIPTION
It is better to have an error then returning the wrong result (it is the case on GPU where we only use the condensed formulation).