### PR TITLE
[documentation] Update the tutorial related to the custom KKT system

### DIFF
--- a/docs/src/tutorials/kktsystem.md
+++ b/docs/src/tutorials/kktsystem.md
@@ -104,8 +104,8 @@ The attributes `kkt.hess` and `kkt.jac` are accessed respectively using
 the getters [`get_hessian`](@ref) and [`get_jacobian`](@ref).
 
 Every time MadNLP queries the Hessian and the Jacobian, it updates the
-nonzeros values in `kkt.hess` and `kkt.jac`.
-Rightafter, MadNLP calls respectively
+nonzero values in `kkt.hess` and `kkt.jac`.
+Rightafter, MadNLP calls
 the functions [`compress_hessian!`](@ref) and [`compress_jacobian!`](@ref) respectively, to propagate these updates to all internal structures of the KKT system `kkt` associated with the Hessian and the Jacobian.
 
 To recap, every time we evaluate the Hessian and the Jacobian, MadNLP


### PR DESCRIPTION
On top of branch `fp/update_documentation`.
This should be merged after #570.

--> [preview](https://madsuite.org/MadNLP.jl/previews/PR572/tutorials/kktsystem/) <--

@frapac, I have a few questions and remarks:

* Should we specify that the system `K` refers to `SparseUnreducedKKTSystem`?
* Would it make sense to rename `l_diag`, `l_lower`, etc., to `l_primal` / `xl`, `l_dual` / `zl`, etc., for clarity?
* Do I understand correctly that `compress_hessian!` and `compress_jacobian!` update the blocks corresponding to the Hessian and Jacobian in the KKT system? I’m not sure I understand the term “compress” in this context.
* Regarding `pr_diag`: you mentioned it is a regularization term, but it seems to correspond exactly to the entries in the (1,1) block when reducing the system from unreduced → reduced. Do we call it regularization because it is added to the Lagrangian Hessian and may help ensure the matrix is SPD? In the related note, should we specify that the default values of `pr_diag` and `du_diag` only apply to this subset of the KKT formulation (`AbstractReducedKKTSystem`)?
* Why do we need to assemble `jac_raw`?
* Does `MadNLP._kktmul!` work for all KKT formulations?
* What exactly does the function `primal_dual(w)` do? Is it just a view for `(x, y)`?
* For the variables `n_var`, `n_ineq`, `n_tot`: is `n_tot` the total number of variables or constraints? I think `n_ineq` is used to determine the number of slacks, so `n_tot` might be the total number of variables, but this is not completely clear to me.