### PR TITLE
`AbstractWrapperModel` api missing returns

### DIFF
--- a/src/Callbacks/wrappers.jl
+++ b/src/Callbacks/wrappers.jl
@@ -153,7 +153,7 @@ function NLPModels.hess_structure!(
     NLPModels.hess_structure!(m.inner, m.hrows, m.hcols)
     copyto!(rows, m.hrows)
     copyto!(cols, m.hcols)
-    return rows,cols
+    return rows, cols
 end
 
 function NLPModels.jtprod!(


### PR DESCRIPTION
This was blocking using `SparseWrapperModel` with MadNCL because of this call to `NLPModels.grad()` returning `:nothing`:

https://github.com/MadNLP/MadNCL.jl/blob/e3d488a4654e1db5158dbf4fb3129643b5b8a7cf/src/Models/scaled.jl#L60

Thanks to @haamidr for bringing this to my attention!