### PR TITLE
Removing 99% of allocations in `solve!`

### DIFF
--- a/lib/MadNLPGPU/src/IPM/kernels.jl
+++ b/lib/MadNLPGPU/src/IPM/kernels.jl
@@ -452,3 +452,7 @@ function get_rel_search_norm(x::AbstractGPUVectorOrSubVector{T}, dx::AbstractGPU
         x, dx
     )
 end
+
+function populate_RR_nn!(nn, c, mu, rho)
+    map!((c) -> (mu - rho*c)/(2*rho)+sqrt(((mu-rho*c)/(2*rho))^2 + mu*c/(2*rho)))
+end

--- a/lib/MadNLPGPU/src/IPM/kernels.jl
+++ b/lib/MadNLPGPU/src/IPM/kernels.jl
@@ -453,6 +453,6 @@ function get_rel_search_norm(x::AbstractGPUVectorOrSubVector{T}, dx::AbstractGPU
     )
 end
 
-function populate_RR_nn!(nn, c, mu, rho)
+function populate_RR_nn!(nn::AbstractGPUVectorOrSubVector{T}, c::AbstractGPUVectorOrSubVector{T}, mu, rho) where T
     map!((c) -> (mu - rho*c)/(2*rho)+sqrt(((mu-rho*c)/(2*rho))^2 + mu*c/(2*rho)))
 end

--- a/lib/MadNLPGPU/src/IPM/kernels.jl
+++ b/lib/MadNLPGPU/src/IPM/kernels.jl
@@ -1,0 +1,439 @@
+# TODO(@anton): All of these could probably be made more efficient via custom kernels.
+#               For now I am just returning the mapreduce functionality here so MadNLPGPU works again.
+
+function get_varphi(obj_val, x_lr::VT, xl_r::VT, xu_r::VT, x_ur::VT, mu) where {VT <: AbstractGPUVector}
+    return obj_val + mapreduce(
+        (x1,x2) -> _get_varphi(x1,x2,mu), +, x_lr, xl_r
+    ) + mapreduce(
+        (x1,x2) -> _get_varphi(x1,x2,mu), +, xu_r, x_ur
+    )
+end
+
+function get_inf_du(f::VT, zl::VT, zu::VT, jacl::VT, sd) where {VT <: AbstractGPUVector}
+    return mapreduce((f,zl,zu,jacl) -> abs(f-zl+zu+jacl), max, f, zl, zu, jacl; init = zero(eltype(f))) / sd
+end
+
+
+function get_inf_compl(x_lr::VT, xl_r::VT, zl_r::VT, xu_r::VT, x_ur::VT, zu_r::VT, mu, sc) where {VT <: AbstractGPUVector}
+    return max(
+        mapreduce(
+            (x_lr, xl_r, zl_r) -> abs((x_lr-xl_r)*zl_r-mu),
+            max,
+            x_lr, xl_r, zl_r;
+            init = zero(eltype(x_lr))
+        ),
+        mapreduce(
+            (xu_r, x_ur, zu_r) -> abs((xu_r-x_ur)*zu_r-mu),
+            max,
+            xu_r, x_ur, zu_r;
+            init = zero(eltype(x_lr))
+        )
+    ) / sc
+end
+
+function get_min_complementarity(x_lr::AbstractGPUVector{T}, xl_r::AbstractGPUVector{T}, zl_r::AbstractGPUVector{T},
+                                 x_ur::AbstractGPUVector{T}, xu_r::AbstractGPUVector{T}, zu_r::AbstractGPUVector{T}) where T
+    cc_lb = mapreduce((x_l, xl, zl) -> (x_l-xl)*zl, min, x_lr, xl_r, zl_r, init=T(Inf))
+    cc_ub = mapreduce((x_u, xu, zu) -> (xu-x_u)*zu, min, x_ur, xu_r, zu_r, init=T(Inf))
+    return min(cc_lb,cc_ub)
+end
+
+function get_varphi_d(
+    f::AbstractGPUVector{T},
+    x::AbstractGPUVector{T},
+    xl::AbstractGPUVector{T},
+    xu::AbstractGPUVector{T},
+    dx::AbstractGPUVector{T},
+    mu,
+) where T
+    return mapreduce(
+        (f,x,xl,xu,dx)-> (f - mu/(x-xl) + mu/(xu-x)) * dx,
+        +,
+        f, x, xl, xu, dx;
+        init = zero(T)
+    )
+end
+
+function get_alpha_max(
+    x::AbstractGPUVector{T},
+    xl::AbstractGPUVector{T},
+    xu::AbstractGPUVector{T},
+    dx::AbstractGPUVector{T},
+    tau,
+) where T
+    return min(
+        mapreduce(
+            (x, xl, dx) -> dx < 0 ? (-x+xl)*tau/dx : T(Inf),
+            min,
+
+            x, xl, dx,
+            init = one(T)
+        ),
+        mapreduce(
+            (x, xu, dx) -> dx > 0 ? (-x+xu)*tau/dx : T(Inf),
+            min,
+            x, xu, dx,
+            init = one(T)
+        )
+    )
+end
+
+function get_alpha_z(
+    zl_r::AbstractGPUVector{T},
+    zu_r::AbstractGPUVector{T},
+    dzl::AbstractGPUVector{T},
+    dzu::AbstractGPUVector{T},
+    tau,
+)  where T
+    return min(
+        mapreduce(
+            (zl_r, dzl) -> dzl < 0 ? (-zl_r)*tau/dzl : T(Inf),
+            min,
+            zl_r, dzl,
+            init = one(T)
+        ),
+        mapreduce(
+            (zu_r, dzu) -> dzu < 0 ? (-zu_r)*tau/dzu : T(Inf),
+            min,
+            zu_r, dzu,
+            init = one(T)
+        )
+    )
+end
+
+function get_obj_val_R(
+    p::AbstractGPUVector{T},
+    n::AbstractGPUVector{T},
+    D_R::AbstractGPUVector{T},
+    x::AbstractGPUVector{T},
+    x_ref::AbstractGPUVector{T},
+    rho,
+    zeta,
+) where T
+    return mapreduce(
+        (p,n,D_R,x,x_ref) -> rho*(p+n) .+ zeta/2*D_R^2*(x-x_ref)^2,
+        +,
+        p,n,D_R,x,x_ref;
+        init = zero(T)
+    )
+end
+
+function get_theta_R(
+    c::AbstractGPUVector{T},
+    p::AbstractGPUVector{T},
+    n::AbstractGPUVector{T},
+) where T
+    return mapreduce(
+        (c,p,n) -> abs(c-p+n),
+        +,
+        c,p,n;
+        init = zero(T)
+    )
+end
+
+function get_inf_pr_R(
+    c::AbstractGPUVector{T},
+    p::AbstractGPUVector{T},
+    n::AbstractGPUVector{T},
+) where T
+    return mapreduce(
+        (c,p,n) -> abs(c-p+n),
+        max,
+        c,p,n;
+        init = zero(T)
+    )
+end
+
+function get_inf_du_R(
+    f_R::AbstractGPUVector{T},
+    l::AbstractGPUVector{T},
+    zl::AbstractGPUVector{T},
+    zu::AbstractGPUVector{T},
+    jacl::AbstractGPUVector{T},
+    zp::AbstractGPUVector{T},
+    zn::AbstractGPUVector{T},
+    rho,
+    sd,
+)  where T
+    return max(
+        mapreduce(
+            (f_R, zl, zu, jacl) -> abs(f_R-zl+zu+jacl),
+            max,
+            f_R, zl, zu, jacl;
+            init = zero(T)
+        ),
+        mapreduce(
+            (l, zp) -> abs(rho-l-zp),
+            max,
+            l, zp;
+            init = zero(T)
+        ),
+        mapreduce(
+            (l, zn) -> abs(rho+l-zn),
+            max,
+            l, zn;
+            init = zero(T)
+        )
+    ) / sd
+end
+
+
+function get_inf_compl_R(
+    x_lr::SubVector{T, VT, VI},
+    xl_r,
+    zl_r,
+    xu_r,
+    x_ur,
+    zu_r,
+    pp,
+    zp,
+    nn,
+    zn,
+    mu_R,
+    sc
+) where {T, VT <: AbstractGPUVector{T}, VI}
+    return max(
+        mapreduce(
+            (x_lr, xl_r, zl_r) -> abs((x_lr-xl_r)*zl_r-mu_R),
+            max,
+            x_lr, xl_r, zl_r;
+            init = zero(T)
+        ),
+        mapreduce(
+            (xu_r, x_ur, zu_r) -> abs((xu_r-x_ur)*zu_r-mu_R),
+            max,
+            xu_r, x_ur, zu_r;
+            init = zero(T)
+        ),
+        mapreduce(
+            (pp, zp) -> abs(pp*zp-mu_R),
+            max,
+            pp, zp;
+            init = zero(T)
+        ),
+        mapreduce(
+            (nn, zn) -> abs(nn*zn-mu_R),
+            max,
+            nn, zn;
+            init = zero(T)
+        ),
+    ) / sc
+end
+
+function get_alpha_max_R(
+    x::AbstractGPUVector{T},
+    xl::AbstractGPUVector{T},
+    xu::AbstractGPUVector{T},
+    dx::AbstractGPUVector{T},
+    pp::AbstractGPUVector{T},
+    dpp::AbstractGPUVector{T},
+    nn::AbstractGPUVector{T},
+    dnn::AbstractGPUVector{T},
+    tau_R,
+) where T
+    return min(
+        mapreduce(
+            (x,xl,xu,dx) -> if dx < 0
+                (-x+xl)*tau_R/dx
+            elseif dx > 0
+                (-x+xu)*tau_R/dx
+            else
+                T(Inf)
+            end,
+            min,
+            x,xl,xu,dx;
+            init = one(T)
+        ),
+        mapreduce(
+            (pp, dpp)-> if dpp < 0
+                -pp*tau_R/dpp
+            else
+                T(Inf)
+            end,
+            min,
+            pp, dpp;
+            init = one(T)
+        ),
+        mapreduce(
+            (nn, dnn)-> if dnn < 0
+                -nn*tau_R/dnn
+            else
+                T(Inf)
+            end,
+            min,
+            nn, dnn;
+            init = one(T)
+        )
+    )
+end
+
+function get_alpha_z_R(
+    zl_r::SubVector{T, VT, VI},
+    zu_r,
+    dzl,
+    dzu,
+    zp,
+    dzp,
+    zn,
+    dzn,
+    tau_R,
+) where {T, VT <: AbstractGPUVector{T}, VI}
+
+    f(d,z) = d < 0 ? -z*tau_R/d : T(Inf)
+    return min(
+        mapreduce(
+            f,
+            min,
+            dzl, zl_r;
+            init = one(T)
+        ),
+        mapreduce(
+            f,
+            min,
+            dzu, zu_r;
+            init = one(T)
+        ),
+        mapreduce(
+            f,
+            min,
+            dzp, zp;
+            init = one(T)
+        ),
+        mapreduce(
+            f,
+            min,
+            dzn, zn;
+            init = one(T)
+        )
+    )
+end
+
+function get_varphi_R(
+    obj_val,
+    x_lr::SubVector{T, VT, VI},
+    xl_r,
+    xu_r,
+    x_ur,
+    pp,
+    nn,
+    mu_R,
+)  where {T, VT <: AbstractGPUVector{T}, VI}
+    varphi_R = obj_val
+    f1(x) = x < 0 ? T(Inf) : mu_R*log(x)
+    function f2(x,y)
+        d = x - y
+        d < 0 ? T(Inf) : mu_R * log(d)
+    end
+
+    return obj_val - +(
+        mapreduce(
+            f2,
+            +,
+            x_lr, xl_r;
+            init = zero(T)
+        ),
+        mapreduce(
+            f2,
+            +,
+            xu_r, x_ur;
+            init = zero(T)
+        ),
+        mapreduce(
+            f1,
+            +,
+            pp;
+            init = zero(T)
+        ),
+        mapreduce(
+            f1,
+            +,
+            nn;
+            init = zero(T)
+        )
+    )
+end
+
+function get_F(
+    c::AbstractGPUVector{T},
+    f,
+    zl,
+    zu,
+    jacl,
+    x_lr,
+    xl_r,
+    zl_r,
+    xu_r,
+    x_ur,
+    zu_r,
+    mu,
+) where T
+    F1 = mapreduce(
+        abs,
+        +,
+        c;
+        init = zero(T)
+    )
+    F2 = mapreduce(
+        (f,zl,zu,jacl) -> abs(f-zl+zu+jacl),
+        +,
+        f,zl,zu,jacl;
+        init = zero(T)
+    )
+    F3 = mapreduce(
+        (x_lr,xl_r,zl_r) -> (x_lr >= xl_r && zl_r >= 0) ? abs((x_lr-xl_r)*zl_r-mu) : T(Inf),
+        +,
+        x_lr,xl_r,zl_r;
+        init = zero(T)
+    )
+    F4 = mapreduce(
+        (xu_r,x_ur,zu_r) -> (xu_r >= x_ur && zu_r >= 0) ? abs((xu_r-xu_r)*zu_r-mu) : T(Inf),
+        +,
+        xu_r,xu_r,zu_r;
+        init = zero(T)
+    )
+    return F1 + F2 + F3 + F4
+end
+
+function get_varphi_d_R(
+    f_R::AbstractGPUVector{T},
+    x::AbstractGPUVector{T},
+    xl::AbstractGPUVector{T},
+    xu::AbstractGPUVector{T},
+    dx::AbstractGPUVector{T},
+    pp::AbstractGPUVector{T},
+    nn::AbstractGPUVector{T},
+    dpp::AbstractGPUVector{T},
+    dnn::AbstractGPUVector{T},
+    mu_R,
+    rho,
+) where T
+    f(x,dx) = (rho - mu_R/x) * dx
+    return +(
+        mapreduce(
+            (f_R, x, xl, xu, dx) -> (f_R - mu_R/(x-xl) + mu_R/(xu-x)) * dx,
+            +,
+            f_R, x, xl, xu, dx;
+            init = zero(T)
+        ),
+        mapreduce(
+            f,
+            +,
+            pp,dpp;
+            init = zero(T)
+        ),
+        mapreduce(
+            f,
+            +,
+            nn,dnn;
+            init = zero(T)
+        ),
+    )
+end
+
+function get_rel_search_norm(x::AbstractGPUVector{T}, dx::AbstractGPUVector{T}) where T
+    return mapreduce(
+        (x,dx) -> abs(dx) / (one(T) + abs(x)),
+        max,
+        x, dx
+    )
+end

--- a/lib/MadNLPGPU/src/IPM/kernels.jl
+++ b/lib/MadNLPGPU/src/IPM/kernels.jl
@@ -454,5 +454,5 @@ function get_rel_search_norm(x::AbstractGPUVectorOrSubVector{T}, dx::AbstractGPU
 end
 
 function populate_RR_nn!(nn::AbstractGPUVectorOrSubVector{T}, c::AbstractGPUVectorOrSubVector{T}, mu, rho) where T
-    map!((c) -> (mu - rho*c)/(2*rho)+sqrt(((mu-rho*c)/(2*rho))^2 + mu*c/(2*rho)))
+    map!((c) -> (mu - rho*c)/(2*rho)+sqrt(((mu-rho*c)/(2*rho))^2 + mu*c/(2*rho)), nn, c)
 end

--- a/lib/MadNLPGPU/src/IPM/kernels.jl
+++ b/lib/MadNLPGPU/src/IPM/kernels.jl
@@ -1,7 +1,10 @@
 # TODO(@anton): All of these could probably be made more efficient via custom kernels.
 #               For now I am just returning the mapreduce functionality here so MadNLPGPU works again.
 
-function get_varphi(obj_val, x_lr::VT, xl_r::VT, xu_r::VT, x_ur::VT, mu) where {VT <: AbstractGPUVector}
+const AbstractGPUVectorOrSubVector{T,VT<:AbstractGPUVector{T}} = Union{AbstractGPUVector{T}, SubVector{T, VT}}
+
+function get_varphi(obj_val, x_lr::VT, xl_r::VT, xu_r::VT, x_ur::VT, mu)
+    where {T, VT <: AbstractGPUVectorOrSubVector{T}}
     return obj_val + mapreduce(
         (x1,x2) -> _get_varphi(x1,x2,mu), +, x_lr, xl_r
     ) + mapreduce(
@@ -9,12 +12,12 @@ function get_varphi(obj_val, x_lr::VT, xl_r::VT, xu_r::VT, x_ur::VT, mu) where {
     )
 end
 
-function get_inf_du(f::VT, zl::VT, zu::VT, jacl::VT, sd) where {VT <: AbstractGPUVector}
+function get_inf_du(f::VT, zl::VT, zu::VT, jacl::VT, sd) where {VT <: AbstractGPUVectorOrSubVector}
     return mapreduce((f,zl,zu,jacl) -> abs(f-zl+zu+jacl), max, f, zl, zu, jacl; init = zero(eltype(f))) / sd
 end
 
 
-function get_inf_compl(x_lr::VT, xl_r::VT, zl_r::VT, xu_r::VT, x_ur::VT, zu_r::VT, mu, sc) where {VT <: AbstractGPUVector}
+function get_inf_compl(x_lr::VT, xl_r::VT, zl_r::VT, xu_r::VT, x_ur::VT, zu_r::VT, mu, sc) where {VT <: AbstractGPUVectorOrSubVector}
     return max(
         mapreduce(
             (x_lr, xl_r, zl_r) -> abs((x_lr-xl_r)*zl_r-mu),
@@ -31,19 +34,19 @@ function get_inf_compl(x_lr::VT, xl_r::VT, zl_r::VT, xu_r::VT, x_ur::VT, zu_r::V
     ) / sc
 end
 
-function get_min_complementarity(x_lr::AbstractGPUVector{T}, xl_r::AbstractGPUVector{T}, zl_r::AbstractGPUVector{T},
-                                 x_ur::AbstractGPUVector{T}, xu_r::AbstractGPUVector{T}, zu_r::AbstractGPUVector{T}) where T
+function get_min_complementarity(x_lr::AbstractGPUVectorOrSubVector{T}, xl_r::AbstractGPUVectorOrSubVector{T}, zl_r::AbstractGPUVectorOrSubVector{T},
+                                 x_ur::AbstractGPUVectorOrSubVector{T}, xu_r::AbstractGPUVectorOrSubVector{T}, zu_r::AbstractGPUVectorOrSubVector{T}) where T
     cc_lb = mapreduce((x_l, xl, zl) -> (x_l-xl)*zl, min, x_lr, xl_r, zl_r, init=T(Inf))
     cc_ub = mapreduce((x_u, xu, zu) -> (xu-x_u)*zu, min, x_ur, xu_r, zu_r, init=T(Inf))
     return min(cc_lb,cc_ub)
 end
 
 function get_varphi_d(
-    f::AbstractGPUVector{T},
-    x::AbstractGPUVector{T},
-    xl::AbstractGPUVector{T},
-    xu::AbstractGPUVector{T},
-    dx::AbstractGPUVector{T},
+    f::AbstractGPUVectorOrSubVector{T},
+    x::AbstractGPUVectorOrSubVector{T},
+    xl::AbstractGPUVectorOrSubVector{T},
+    xu::AbstractGPUVectorOrSubVector{T},
+    dx::AbstractGPUVectorOrSubVector{T},
     mu,
 ) where T
     return mapreduce(
@@ -55,10 +58,10 @@ function get_varphi_d(
 end
 
 function get_alpha_max(
-    x::AbstractGPUVector{T},
-    xl::AbstractGPUVector{T},
-    xu::AbstractGPUVector{T},
-    dx::AbstractGPUVector{T},
+    x::AbstractGPUVectorOrSubVector{T},
+    xl::AbstractGPUVectorOrSubVector{T},
+    xu::AbstractGPUVectorOrSubVector{T},
+    dx::AbstractGPUVectorOrSubVector{T},
     tau,
 ) where T
     return min(
@@ -79,10 +82,10 @@ function get_alpha_max(
 end
 
 function get_alpha_z(
-    zl_r::AbstractGPUVector{T},
-    zu_r::AbstractGPUVector{T},
-    dzl::AbstractGPUVector{T},
-    dzu::AbstractGPUVector{T},
+    zl_r::AbstractGPUVectorOrSubVector{T},
+    zu_r::AbstractGPUVectorOrSubVector{T},
+    dzl::AbstractGPUVectorOrSubVector{T},
+    dzu::AbstractGPUVectorOrSubVector{T},
     tau,
 )  where T
     return min(
@@ -102,11 +105,11 @@ function get_alpha_z(
 end
 
 function get_obj_val_R(
-    p::AbstractGPUVector{T},
-    n::AbstractGPUVector{T},
-    D_R::AbstractGPUVector{T},
-    x::AbstractGPUVector{T},
-    x_ref::AbstractGPUVector{T},
+    p::AbstractGPUVectorOrSubVector{T},
+    n::AbstractGPUVectorOrSubVector{T},
+    D_R::AbstractGPUVectorOrSubVector{T},
+    x::AbstractGPUVectorOrSubVector{T},
+    x_ref::AbstractGPUVectorOrSubVector{T},
     rho,
     zeta,
 ) where T
@@ -119,9 +122,9 @@ function get_obj_val_R(
 end
 
 function get_theta_R(
-    c::AbstractGPUVector{T},
-    p::AbstractGPUVector{T},
-    n::AbstractGPUVector{T},
+    c::AbstractGPUVectorOrSubVector{T},
+    p::AbstractGPUVectorOrSubVector{T},
+    n::AbstractGPUVectorOrSubVector{T},
 ) where T
     return mapreduce(
         (c,p,n) -> abs(c-p+n),
@@ -132,9 +135,9 @@ function get_theta_R(
 end
 
 function get_inf_pr_R(
-    c::AbstractGPUVector{T},
-    p::AbstractGPUVector{T},
-    n::AbstractGPUVector{T},
+    c::AbstractGPUVectorOrSubVector{T},
+    p::AbstractGPUVectorOrSubVector{T},
+    n::AbstractGPUVectorOrSubVector{T},
 ) where T
     return mapreduce(
         (c,p,n) -> abs(c-p+n),
@@ -145,13 +148,13 @@ function get_inf_pr_R(
 end
 
 function get_inf_du_R(
-    f_R::AbstractGPUVector{T},
-    l::AbstractGPUVector{T},
-    zl::AbstractGPUVector{T},
-    zu::AbstractGPUVector{T},
-    jacl::AbstractGPUVector{T},
-    zp::AbstractGPUVector{T},
-    zn::AbstractGPUVector{T},
+    f_R::AbstractGPUVectorOrSubVector{T},
+    l::AbstractGPUVectorOrSubVector{T},
+    zl::AbstractGPUVectorOrSubVector{T},
+    zu::AbstractGPUVectorOrSubVector{T},
+    jacl::AbstractGPUVectorOrSubVector{T},
+    zp::AbstractGPUVectorOrSubVector{T},
+    zn::AbstractGPUVectorOrSubVector{T},
     rho,
     sd,
 )  where T
@@ -179,7 +182,7 @@ end
 
 
 function get_inf_compl_R(
-    x_lr::SubVector{T, VT, VI},
+    x_lr::AbstractGPUVectorOrSubVector{T},
     xl_r,
     zl_r,
     xu_r,
@@ -191,7 +194,7 @@ function get_inf_compl_R(
     zn,
     mu_R,
     sc
-) where {T, VT <: AbstractGPUVector{T}, VI}
+) where {T}
     return max(
         mapreduce(
             (x_lr, xl_r, zl_r) -> abs((x_lr-xl_r)*zl_r-mu_R),
@@ -221,14 +224,14 @@ function get_inf_compl_R(
 end
 
 function get_alpha_max_R(
-    x::AbstractGPUVector{T},
-    xl::AbstractGPUVector{T},
-    xu::AbstractGPUVector{T},
-    dx::AbstractGPUVector{T},
-    pp::AbstractGPUVector{T},
-    dpp::AbstractGPUVector{T},
-    nn::AbstractGPUVector{T},
-    dnn::AbstractGPUVector{T},
+    x::AbstractGPUVectorOrSubVector{T},
+    xl::AbstractGPUVectorOrSubVector{T},
+    xu::AbstractGPUVectorOrSubVector{T},
+    dx::AbstractGPUVectorOrSubVector{T},
+    pp::AbstractGPUVectorOrSubVector{T},
+    dpp::AbstractGPUVectorOrSubVector{T},
+    nn::AbstractGPUVectorOrSubVector{T},
+    dnn::AbstractGPUVectorOrSubVector{T},
     tau_R,
 ) where T
     return min(
@@ -268,7 +271,7 @@ function get_alpha_max_R(
 end
 
 function get_alpha_z_R(
-    zl_r::SubVector{T, VT, VI},
+    zl_r::AbstractGPUVectorOrSubVector{T},
     zu_r,
     dzl,
     dzu,
@@ -277,7 +280,7 @@ function get_alpha_z_R(
     zn,
     dzn,
     tau_R,
-) where {T, VT <: AbstractGPUVector{T}, VI}
+) where {T}
 
     f(d,z) = d < 0 ? -z*tau_R/d : T(Inf)
     return min(
@@ -310,14 +313,14 @@ end
 
 function get_varphi_R(
     obj_val,
-    x_lr::SubVector{T, VT, VI},
+    x_lr::AbstractGPUVectorOrSubVector{T},
     xl_r,
     xu_r,
     x_ur,
     pp,
     nn,
     mu_R,
-)  where {T, VT <: AbstractGPUVector{T}, VI}
+)  where {T}
     varphi_R = obj_val
     f1(x) = x < 0 ? T(Inf) : mu_R*log(x)
     function f2(x,y)
@@ -354,7 +357,7 @@ function get_varphi_R(
 end
 
 function get_F(
-    c::AbstractGPUVector{T},
+    c::AbstractGPUVectorOrSubVector{T},
     f,
     zl,
     zu,
@@ -395,15 +398,15 @@ function get_F(
 end
 
 function get_varphi_d_R(
-    f_R::AbstractGPUVector{T},
-    x::AbstractGPUVector{T},
-    xl::AbstractGPUVector{T},
-    xu::AbstractGPUVector{T},
-    dx::AbstractGPUVector{T},
-    pp::AbstractGPUVector{T},
-    nn::AbstractGPUVector{T},
-    dpp::AbstractGPUVector{T},
-    dnn::AbstractGPUVector{T},
+    f_R::AbstractGPUVectorOrSubVector{T},
+    x::AbstractGPUVectorOrSubVector{T},
+    xl::AbstractGPUVectorOrSubVector{T},
+    xu::AbstractGPUVectorOrSubVector{T},
+    dx::AbstractGPUVectorOrSubVector{T},
+    pp::AbstractGPUVectorOrSubVector{T},
+    nn::AbstractGPUVectorOrSubVector{T},
+    dpp::AbstractGPUVectorOrSubVector{T},
+    dnn::AbstractGPUVectorOrSubVector{T},
     mu_R,
     rho,
 ) where T
@@ -430,7 +433,7 @@ function get_varphi_d_R(
     )
 end
 
-function get_rel_search_norm(x::AbstractGPUVector{T}, dx::AbstractGPUVector{T}) where T
+function get_rel_search_norm(x::AbstractGPUVectorOrSubVector{T}, dx::AbstractGPUVectorOrSubVector{T}) where T
     return mapreduce(
         (x,dx) -> abs(dx) / (one(T) + abs(x)),
         max,

--- a/lib/MadNLPGPU/src/IPM/kernels.jl
+++ b/lib/MadNLPGPU/src/IPM/kernels.jl
@@ -126,11 +126,17 @@ function get_obj_val_R(
     zeta,
 ) where T
     return mapreduce(
-        (p,n,D_R,x,x_ref) -> rho*(p+n) .+ zeta/2*D_R^2*(x-x_ref)^2,
+        (p,n) -> rho*(p+n),
         +,
-        p,n,D_R,x,x_ref;
+        p,n;
         init = zero(T)
-    )
+    ) +
+        mapreduce(
+            (D_R,x,x_ref) -> zeta/2*D_R^2*(x-x_ref)^2,
+            +,
+            D_R,x,x_ref;
+            init = zero(T)
+        )
 end
 
 function get_theta_R(

--- a/lib/MadNLPGPU/src/IPM/kernels.jl
+++ b/lib/MadNLPGPU/src/IPM/kernels.jl
@@ -3,8 +3,14 @@
 
 const AbstractGPUVectorOrSubVector{T,VT<:AbstractGPUVector{T}} = Union{AbstractGPUVector{T}, SubVector{T, VT}}
 
-function get_varphi(obj_val, x_lr::VT, xl_r::VT, xu_r::VT, x_ur::VT, mu)
-    where {T, VT <: AbstractGPUVectorOrSubVector{T}}
+function get_varphi(
+    obj_val,
+    x_lr::VT,
+    xl_r::VT,
+    xu_r::VT,
+    x_ur::VT,
+    mu
+) where {T, VT <: AbstractGPUVectorOrSubVector{T}}
     return obj_val + mapreduce(
         (x1,x2) -> _get_varphi(x1,x2,mu), +, x_lr, xl_r
     ) + mapreduce(
@@ -34,8 +40,14 @@ function get_inf_compl(x_lr::VT, xl_r::VT, zl_r::VT, xu_r::VT, x_ur::VT, zu_r::V
     ) / sc
 end
 
-function get_min_complementarity(x_lr::AbstractGPUVectorOrSubVector{T}, xl_r::AbstractGPUVectorOrSubVector{T}, zl_r::AbstractGPUVectorOrSubVector{T},
-                                 x_ur::AbstractGPUVectorOrSubVector{T}, xu_r::AbstractGPUVectorOrSubVector{T}, zu_r::AbstractGPUVectorOrSubVector{T}) where T
+function get_min_complementarity(
+    x_lr::AbstractGPUVectorOrSubVector{T},
+    xl_r::AbstractGPUVectorOrSubVector{T},
+    zl_r::AbstractGPUVectorOrSubVector{T},
+    x_ur::AbstractGPUVectorOrSubVector{T},
+    xu_r::AbstractGPUVectorOrSubVector{T},
+    zu_r::AbstractGPUVectorOrSubVector{T}
+) where T
     cc_lb = mapreduce((x_l, xl, zl) -> (x_l-xl)*zl, min, x_lr, xl_r, zl_r, init=T(Inf))
     cc_ub = mapreduce((x_u, xu, zu) -> (xu-x_u)*zu, min, x_ur, xu_r, zu_r, init=T(Inf))
     return min(cc_lb,cc_ub)

--- a/lib/MadNLPGPU/src/IPM/kernels.jl
+++ b/lib/MadNLPGPU/src/IPM/kernels.jl
@@ -1,5 +1,5 @@
-# TODO(@anton): All of these could probably be made more efficient via custom kernels.
-#               For now I am just returning the mapreduce functionality here so MadNLPGPU works again.
+# NOTE: All of these could probably be made more efficient via custom kernels or nonallocating mapreduce.
+#       For now we just use the standard mapreduce functionality which may allocate.
 
 const AbstractGPUVectorOrSubVector{T,VT<:AbstractGPUVector{T}} = Union{AbstractGPUVector{T}, SubVector{T, VT}}
 

--- a/lib/MadNLPGPU/src/IPM/kernels.jl
+++ b/lib/MadNLPGPU/src/IPM/kernels.jl
@@ -1,8 +1,6 @@
 # NOTE: All of these could probably be made more efficient via custom kernels or nonallocating mapreduce.
 #       For now we just use the standard mapreduce functionality which may allocate.
 
-const AbstractGPUVectorOrSubVector{T,VT<:AbstractGPUVector{T}} = Union{AbstractGPUVector{T}, SubVector{T, VT}}
-
 function get_varphi(
     obj_val,
     x_lr::VT,

--- a/lib/MadNLPGPU/src/IPM/utils.jl
+++ b/lib/MadNLPGPU/src/IPM/utils.jl
@@ -1,0 +1,6 @@
+@inline function count_lu_bounds(lb::AbstractGPUVectorOrSubVector{T}, ub::AbstractGPUVectorOrSubVector{T}) where {T}
+    num_lu_bounds = sum((g_lb .!= -Inf) .& (g_ub .!=  Inf))
+    num_le_bounds = sum((g_lb .!= -Inf) .& (g_ub .==  Inf))
+    num_ue_bounds = sum((g_ub .!=  Inf) .& (g_lb .== -Inf))
+    return num_lu_bounds, num_le_bounds, num_ue_bounds
+end

--- a/lib/MadNLPGPU/src/IPM/utils.jl
+++ b/lib/MadNLPGPU/src/IPM/utils.jl
@@ -1,6 +1,6 @@
 @inline function count_lu_bounds(lb::AbstractGPUVectorOrSubVector{T}, ub::AbstractGPUVectorOrSubVector{T}) where {T}
-    num_lu_bounds = sum((g_lb .!= -Inf) .& (g_ub .!=  Inf))
-    num_le_bounds = sum((g_lb .!= -Inf) .& (g_ub .==  Inf))
-    num_ue_bounds = sum((g_ub .!=  Inf) .& (g_lb .== -Inf))
+    num_lu_bounds = sum((lb .!= -Inf) .& (ub .!=  Inf))
+    num_le_bounds = sum((lb .!= -Inf) .& (ub .==  Inf))
+    num_ue_bounds = sum((ub .!=  Inf) .& (lb .== -Inf))
     return num_lu_bounds, num_le_bounds, num_ue_bounds
 end

--- a/lib/MadNLPGPU/src/MadNLPGPU.jl
+++ b/lib/MadNLPGPU/src/MadNLPGPU.jl
@@ -21,7 +21,11 @@ import MadNLP:
     setup_cholesky!, setup_lu!, setup_qr!, setup_evd!, setup_bunchkaufman!,
     factorize_cholesky!, factorize_lu!, factorize_qr!, factorize_evd!, factorize_bunchkaufman!,
     solve_cholesky!, solve_lu!, solve_qr!, solve_evd!, solve_bunchkaufman!
-
+import MadNLP:
+    _get_varphi, get_varphi, get_inf_du, get_inf_compl, get_min_complementarity,
+    get_varphi_d, get_alpha_max, get_alpha_z, get_obj_val_R, get_theta_R, get_inf_pr_R,
+    get_inf_du_R, get_inf_compl_R, get_alpha_max_R, get_alpha_z_R, get_varphi_R, get_F,
+    get_varphi_d_R, get_rel_search_norm
 # AMD and Metis
 import AMD, Metis
 

--- a/lib/MadNLPGPU/src/MadNLPGPU.jl
+++ b/lib/MadNLPGPU/src/MadNLPGPU.jl
@@ -25,7 +25,7 @@ import MadNLP:
     _get_varphi, get_varphi, get_inf_du, get_inf_compl, get_min_complementarity,
     get_varphi_d, get_alpha_max, get_alpha_z, get_obj_val_R, get_theta_R, get_inf_pr_R,
     get_inf_du_R, get_inf_compl_R, get_alpha_max_R, get_alpha_z_R, get_varphi_R, get_F,
-    get_varphi_d_R, get_rel_search_norm
+    get_varphi_d_R, get_rel_search_norm, SubVector
 # AMD and Metis
 import AMD, Metis
 

--- a/lib/MadNLPGPU/src/MadNLPGPU.jl
+++ b/lib/MadNLPGPU/src/MadNLPGPU.jl
@@ -36,6 +36,7 @@ include("utils.jl")
 include("KKT/gpu_dense.jl")
 include("KKT/gpu_sparse.jl")
 include("KKT/gpu_qn.jl")
+include("IPM/kernels.jl")
 
 global LapackCUDASolver
 global CUDSSSolver

--- a/lib/MadNLPGPU/src/MadNLPGPU.jl
+++ b/lib/MadNLPGPU/src/MadNLPGPU.jl
@@ -25,7 +25,7 @@ import MadNLP:
     _get_varphi, get_varphi, get_inf_du, get_inf_compl, get_min_complementarity,
     get_varphi_d, get_alpha_max, get_alpha_z, get_obj_val_R, get_theta_R, get_inf_pr_R,
     get_inf_du_R, get_inf_compl_R, get_alpha_max_R, get_alpha_z_R, get_varphi_R, get_F,
-    get_varphi_d_R, get_rel_search_norm, SubVector
+    get_varphi_d_R, get_rel_search_norm, populate_RR_nn!, SubVector
 # AMD and Metis
 import AMD, Metis
 

--- a/lib/MadNLPGPU/src/MadNLPGPU.jl
+++ b/lib/MadNLPGPU/src/MadNLPGPU.jl
@@ -29,6 +29,8 @@ import MadNLP:
 # AMD and Metis
 import AMD, Metis
 
+const AbstractGPUVectorOrSubVector{T,VT<:AbstractGPUVector{T}} = Union{AbstractGPUVector{T}, SubVector{T, VT}}
+
 include("KKT/kernels_dense.jl")
 include("KKT/kernels_sparse.jl")
 include("KKT/kernels_qn.jl")

--- a/lib/MadNLPGPU/src/MadNLPGPU.jl
+++ b/lib/MadNLPGPU/src/MadNLPGPU.jl
@@ -25,7 +25,7 @@ import MadNLP:
     _get_varphi, get_varphi, get_inf_du, get_inf_compl, get_min_complementarity,
     get_varphi_d, get_alpha_max, get_alpha_z, get_obj_val_R, get_theta_R, get_inf_pr_R,
     get_inf_du_R, get_inf_compl_R, get_alpha_max_R, get_alpha_z_R, get_varphi_R, get_F,
-    get_varphi_d_R, get_rel_search_norm, populate_RR_nn!, SubVector
+    get_varphi_d_R, get_rel_search_norm, populate_RR_nn!, SubVector, count_lu_bounds
 # AMD and Metis
 import AMD, Metis
 

--- a/lib/MadNLPGPU/src/MadNLPGPU.jl
+++ b/lib/MadNLPGPU/src/MadNLPGPU.jl
@@ -36,6 +36,7 @@ include("utils.jl")
 include("KKT/gpu_dense.jl")
 include("KKT/gpu_sparse.jl")
 include("KKT/gpu_qn.jl")
+include("IPM/utils.jl")
 include("IPM/kernels.jl")
 
 global LapackCUDASolver

--- a/src/Callbacks/nlpmodels.jl
+++ b/src/Callbacks/nlpmodels.jl
@@ -519,8 +519,6 @@ function create_callback(
     x0 = similar(get_x0(nlp))
     con_buffer = similar(x0, m)
     fill!(con_buffer, zero(T))
-    jac_buffer = similar(x0, m, n)
-    fill!(jac_buffer, zero(T))
     grad_buffer = similar(x0, n)
     fill!(grad_buffer, zero(T))
     obj_scale = Ref(one(T))
@@ -712,9 +710,8 @@ function set_scaling!(
     grad_buffer = cb.grad_buffer
 
     # Set scaling
-    jac = similar(con_buffer, cb.nnzj)
-    _eval_jac_wrapper!(cb, x0, jac)
-    set_con_scale_sparse!(con_scale, cb.jac_I, jac, nlp_scaling_max_gradient)
+    _eval_jac_wrapper!(cb, x0, cb.jac_buffer)
+    set_con_scale_sparse!(con_scale, cb.jac_I, cb.jac_buffer, nlp_scaling_max_gradient)
     set_jac_scale_sparse!(jac_scale, con_scale, cb.jac_I)
 
     _eval_grad_f_wrapper!(cb, x0, grad_buffer)

--- a/src/Callbacks/nlpmodels.jl
+++ b/src/Callbacks/nlpmodels.jl
@@ -710,8 +710,9 @@ function set_scaling!(
     grad_buffer = cb.grad_buffer
 
     # Set scaling
-    _eval_jac_wrapper!(cb, x0, cb.jac_buffer)
-    set_con_scale_sparse!(con_scale, cb.jac_I, cb.jac_buffer, nlp_scaling_max_gradient)
+    jac = similar(con_buffer, cb.nnzj)
+    _eval_jac_wrapper!(cb, x0, jac)
+    set_con_scale_sparse!(con_scale, cb.jac_I, jac, nlp_scaling_max_gradient)
     set_jac_scale_sparse!(jac_scale, con_scale, cb.jac_I)
 
     _eval_grad_f_wrapper!(cb, x0, grad_buffer)

--- a/src/IPM/IPM.jl
+++ b/src/IPM/IPM.jl
@@ -99,7 +99,7 @@ mutable struct MadNLPSolver{
     filter::Vector{Tuple{T,T}}
 
     inertia_corrector::IC
-    RR::Union{Nothing,RobustRestorer{T}}
+    RR::Union{Nothing,RobustRestorer{T,VT}}
     intermediate_callback::ICB
     status::Status
     output::Dict

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -524,18 +524,17 @@ function get_alpha_z_R(
     tau_R,
 ) where {T, VT <: AbstractVector{T}, VI}
     alpha_z_R = one(T)
-    f(d,z) = d < 0.0 ? -z*tau_R/d : T(Inf)
     for ii in eachindex(dzl)
-        alpha_z_R = min(alpha_z_R, f(dzl[ii], zl_r[ii]))
+        alpha_z_R = min(alpha_z_R, dzl[ii] < 0.0 ? -zl_r[ii]*tau_R/dzl[ii] : T(Inf))
     end
     for ii in eachindex(dzu)
-        alpha_z_R = min(alpha_z_R, f(dzu[ii], zu_r[ii]))
+        alpha_z_R = min(alpha_z_R, dzu[ii] < 0.0 ? -zu_r[ii]*tau_R/dzu[ii] : T(Inf))
     end
     for ii in eachindex(dzp)
-        alpha_z_R = min(alpha_z_R, f(dzp[ii], zp[ii]))
+        alpha_z_R = min(alpha_z_R, dzp[ii] < 0.0 ? -zp[ii]*tau_R/dzp[ii] : T(Inf))
     end
     for ii in eachindex(dzn)
-        alpha_z_R = min(alpha_z_R, f(dzn[ii], zn[ii]))
+        alpha_z_R = min(alpha_z_R, dzn[ii] < 0.0 ? -zn[ii]*tau_R/dzn[ii] : T(Inf))
     end
     return alpha_z_R
 end
@@ -551,22 +550,19 @@ function get_varphi_R(
     mu_R,
 )  where {T, VT <: AbstractVector{T}, VI}
     varphi_R = obj_val
-    f1(x) = x < 0.0 ? T(Inf) : mu_R*log(x)
-    function f2(x,y)
-        d = x - y
-        d < 0.0 ? T(Inf) : mu_R * log(d)
-    end
     for ii in eachindex(x_lr)
-        varphi_R -= f2(x_lr[ii], xl_r[ii])
+        d = x_lr[ii] - xl_r[ii]
+        varphi_R -= d < 0.0 ? T(Inf) : mu_R * log(d)
     end
     for ii in eachindex(xu_r)
-        varphi_R -= f2(xu_r[ii], x_ur[ii])
+        d = xu_r[ii] - x_ur[ii]
+        varphi_R -= d < 0.0 ? T(Inf) : mu_R * log(d)
     end
     for ii in eachindex(pp)
-        varphi_R -= f1(pp[ii])
+        varphi_R -= pp[ii] < 0.0 ? T(Inf) : mu_R*log(pp[ii])
     end
     for ii in eachindex(nn)
-        varphi_R -= f1(nn[ii])
+        varphi_R -= nn[ii] < 0.0 ? T(Inf) : mu_R*log(nn[ii])
     end
     return varphi_R
 end
@@ -624,16 +620,15 @@ function get_varphi_d_R(
     mu_R,
     rho,
 ) where T
-    f(x,dx) = (rho - mu_R/x) * dx
     varphi_d = zero(T)
     for ii in eachindex(f_R)
         varphi_d += (f_R[ii] - mu_R/(x[ii]-xl[ii]) + mu_R/(xu[ii]-x[ii])) * dx[ii]
     end
     for ii in eachindex(pp)
-        varphi_d += f(pp[ii],dpp[ii])
+        varphi_d += (rho - mu_R/pp[ii]) * dpp[ii]
     end
     for ii in eachindex(nn)
-        varphi_d += f(nn[ii],dnn[ii])
+        varphi_d += (rho - mu_R/nn[ii]) * dnn[ii]
     end
     return varphi_d
 end

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -399,7 +399,10 @@ function get_obj_val_R(
 ) where T
     obj_val_R = zero(T)
     for ii in eachindex(p)
-        obj_val_R += rho*(p[ii]+n[ii]) .+ zeta/2*D_R[ii]^2*(x[ii]-x_ref[ii])^2
+        obj_val_R += rho*(p[ii]+n[ii])
+    end
+    for ii in eachindex(x)
+        obj_val_R += zeta/2*D_R[ii]^2*(x[ii]-x_ref[ii])^2
     end
     return obj_val_R
 end

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -21,8 +21,8 @@ end
 
 function _set_aug_diagonal!(kkt::AbstractKKTSystem)
     copyto!(kkt.pr_diag, kkt.reg)
-    kkt.pr_diag[kkt.ind_lb] .-= kkt.l_lower ./ kkt.l_diag
-    kkt.pr_diag[kkt.ind_ub] .-= kkt.u_lower ./ kkt.u_diag
+    @views kkt.pr_diag[kkt.ind_lb] .-= kkt.l_lower ./ kkt.l_diag
+    @views kkt.pr_diag[kkt.ind_ub] .-= kkt.u_lower ./ kkt.u_diag
     return
 end
 
@@ -49,19 +49,19 @@ function _set_aug_diagonal!(kkt::ScaledSparseKKTSystem{T}) where T
     xuzl = kkt.buffer2
     fill!(xlzu, zero(T))
     fill!(xuzl, zero(T))
+    @views begin
+        xlzu[kkt.ind_ub] .= kkt.u_lower    # zᵘ
+        xlzu[kkt.ind_lb] .*= kkt.l_diag    # (X - Xˡ) zᵘ
 
-    xlzu[kkt.ind_ub] .= kkt.u_lower    # zᵘ
-    xlzu[kkt.ind_lb] .*= kkt.l_diag    # (X - Xˡ) zᵘ
+        xuzl[kkt.ind_lb] .= kkt.l_lower    # zˡ
+        xuzl[kkt.ind_ub] .*= kkt.u_diag    # (Xᵘ - X) zˡ
 
-    xuzl[kkt.ind_lb] .= kkt.l_lower    # zˡ
-    xuzl[kkt.ind_ub] .*= kkt.u_diag    # (Xᵘ - X) zˡ
+        kkt.pr_diag .= xlzu .+ xuzl
 
-    kkt.pr_diag .= xlzu .+ xuzl
-
-    fill!(kkt.scaling_factor, one(T))
-    kkt.scaling_factor[kkt.ind_lb] .*= sqrt.(kkt.l_diag)
-    kkt.scaling_factor[kkt.ind_ub] .*= sqrt.(kkt.u_diag)
-
+        fill!(kkt.scaling_factor, one(T))
+        kkt.scaling_factor[kkt.ind_lb] .*= sqrt.(kkt.l_diag)
+        kkt.scaling_factor[kkt.ind_ub] .*= sqrt.(kkt.u_diag)
+    end
     # Scale regularization by scaling factor.
     kkt.pr_diag .+= kkt.reg .* kkt.scaling_factor.^2
     return
@@ -207,11 +207,11 @@ function set_initial_bounds!(xl::AbstractVector{T}, xu::AbstractVector{T}, tol) 
     # If `tol` is set to zero, keep the bounds unchanged.
     if tol > zero(T)
         map!(
-            x->x - max(one(T), abs(x)) .* tol,
+            x->x - max(one(T), abs(x)) * tol,
             xl, xl
         )
         map!(
-            x->x + max(one(T), abs(x)) .* tol,
+            x->x + max(one(T), abs(x)) * tol,
             xu, xu
         )
     end
@@ -270,34 +270,37 @@ function _get_varphi(x1::T, x2::T, mu::T) where T
 end
 
 function get_varphi(obj_val, x_lr, xl_r, xu_r, x_ur, mu)
-    return obj_val + mapreduce(
-        (x1,x2) -> _get_varphi(x1,x2,mu), +, x_lr, xl_r
-    ) + mapreduce(
-        (x1,x2) -> _get_varphi(x1,x2,mu), +, xu_r, x_ur
-    )
+    varphi = obj_val
+    # TODO(@anton) Check if we can @simd this
+    for ii in eachindex(x_lr)
+        varphi += _get_varphi(x_lr[ii],xl_r[ii],mu)
+    end
+    for ii in eachindex(xu_r)
+        varphi += _get_varphi(xu_r[ii],x_ur[ii],mu)
+    end
+    return varphi
 end
 
 @inline get_inf_pr(c::AbstractVector) = norm(c, Inf)
 
 function get_inf_du(f, zl, zu, jacl, sd)
-    return mapreduce((f,zl,zu,jacl) -> abs(f-zl+zu+jacl), max, f, zl, zu, jacl; init = zero(eltype(f))) / sd
+    inf_du = zero(eltype(f))
+    for ii in eachindex(f)
+        inf_du = max(inf_du, abs(f[ii]-zl[ii]+zu[ii]+jacl[ii]))
+    end
+    return inf_du / sd
 end
 
 function get_inf_compl(x_lr, xl_r, zl_r, xu_r, x_ur, zu_r, mu, sc)
-    return max(
-        mapreduce(
-            (x_lr, xl_r, zl_r) -> abs((x_lr-xl_r)*zl_r-mu),
-            max,
-            x_lr, xl_r, zl_r;
-            init = zero(eltype(x_lr))
-        ),
-        mapreduce(
-            (xu_r, x_ur, zu_r) -> abs((xu_r-x_ur)*zu_r-mu),
-            max,
-            xu_r, x_ur, zu_r;
-            init = zero(eltype(x_lr))
-        )
-    ) / sc
+    inf_compl = zero(eltype(x_lr))
+    for ii in eachindex(x_lr)
+        inf_compl = max(inf_compl, abs((x_lr[ii]-xl_r[ii])*zl_r[ii]-mu))
+    end
+    for ii in eachindex(xu_r)
+        inf_compl = max(inf_compl, abs((xu_r[ii]-x_ur[ii])*zu_r[ii]-mu))
+    end
+
+    return inf_compl / sc
 end
 
 function get_average_complementarity(x_lr, xl_r, zl_r, x_ur, xu_r, zu_r)
@@ -319,9 +322,14 @@ end
 
 function get_min_complementarity(x_lr::AbstractVector{T}, xl_r::AbstractVector{T}, zl_r::AbstractVector{T},
                                  x_ur::AbstractVector{T}, xu_r::AbstractVector{T}, zu_r::AbstractVector{T}) where T
-    cc_lb = mapreduce((x_l, xl, zl) -> (x_l-xl)*zl, min, x_lr, xl_r, zl_r, init=T(Inf))
-    cc_ub = mapreduce((x_u, xu, zu) -> (xu-x_u)*zu, min, x_ur, xu_r, zu_r, init=T(Inf))
-    return min(cc_lb,cc_ub)
+    min_comp = T(Inf)
+    for ii in eachindex(x_lr)
+        min_comp = min(min_comp, (x_lr[ii]-xl_r[ii])*zl_r[ii])
+    end
+    for ii in eachindex(x_lr)
+        min_comp = min(min_comp, (xu_r[ii]-x_ur[ii])*zu_r[ii])
+    end
+    return min_comp
 end
 
 function get_min_complementarity(solver::AbstractMadNLPSolver)
@@ -339,12 +347,11 @@ function get_varphi_d(
     dx::AbstractVector{T},
     mu,
 ) where T
-    return mapreduce(
-        (f,x,xl,xu,dx)-> (f - mu/(x-xl) + mu/(xu-x)) * dx,
-        +,
-        f, x, xl, xu, dx;
-        init = zero(T)
-    )
+    varphi_d = zero(T)
+    @simd for ii in eachindex(f)
+        varphi_d += (f[ii] - mu/(x[ii]-xl[ii]) + mu/(xu[ii]-x[ii])) * dx[ii]
+    end
+    return varphi_d
 end
 
 function get_alpha_max(
@@ -354,21 +361,14 @@ function get_alpha_max(
     dx::AbstractVector{T},
     tau,
 ) where T
-    return min(
-        mapreduce(
-            (x, xl, dx) -> dx < 0 ? (-x+xl)*tau/dx : T(Inf),
-            min,
-
-            x, xl, dx,
-            init = one(T)
-        ),
-        mapreduce(
-            (x, xu, dx) -> dx > 0 ? (-x+xu)*tau/dx : T(Inf),
-            min,
-            x, xu, dx,
-            init = one(T)
-        )
-    )
+    alpha_max = one(T)
+    for ii in eachindex(x)
+        alpha_max = min(alpha_max,
+                        dx[ii] < 0 ? (-x[ii]+xl[ii])*tau/dx[ii] : T(Inf),
+                        dx[ii] > 0 ? (-x[ii]+xu[ii])*tau/dx[ii] : T(Inf),
+                        )
+    end
+    return alpha_max
 end
 
 function get_alpha_z(
@@ -378,20 +378,14 @@ function get_alpha_z(
     dzu::AbstractVector{T},
     tau,
 )  where T
-    return min(
-        mapreduce(
-            (zl_r, dzl) -> dzl < 0 ? (-zl_r)*tau/dzl : T(Inf),
-            min,
-            zl_r, dzl,
-            init = one(T)
-        ),
-        mapreduce(
-            (zu_r, dzu) -> dzu < 0 ? (-zu_r)*tau/dzu : T(Inf),
-            min,
-            zu_r, dzu,
-            init = one(T)
-        )
-    )
+    alpha_z = one(T)
+    for ii in eachindex(zl_r)
+        alpha_z = min(alpha_z, dzl[ii] < 0 ? (-zl_r[ii])*tau/dzl[ii] : T(Inf))
+    end
+    for ii in eachindex(zu_r)
+        alpha_z = min(alpha_z, dzu[ii] < 0 ? (-zu_r[ii])*tau/dzu[ii] : T(Inf))
+    end
+    return alpha_z
 end
 
 function get_obj_val_R(
@@ -403,12 +397,11 @@ function get_obj_val_R(
     rho,
     zeta,
 ) where T
-    return mapreduce(
-        (p,n,D_R,x,x_ref) -> rho*(p+n) .+ zeta/2*D_R^2*(x-x_ref)^2,
-        +,
-        p,n,D_R,x,x_ref;
-        init = zero(T)
-    )
+    obj_val_R = zero(T)
+    for ii in eachindex(p)
+        obj_val += rho*(p[ii]+n[ii]) .+ zeta/2*D_R[ii]^2*(x[ii]-x_ref[ii])^2
+    end
+    return obj_val
 end
 
 @inline get_theta(c) = norm(c, 1)
@@ -418,12 +411,11 @@ function get_theta_R(
     p::AbstractVector{T},
     n::AbstractVector{T},
 ) where T
-    return mapreduce(
-        (c,p,n) -> abs(c-p+n),
-        +,
-        c,p,n;
-        init = zero(T)
-    )
+    theta_R = zero(T)
+    for ii in eachindex(c)
+        theta_R += abs(c[ii]-p[ii]+n[ii])
+    end
+    return theta_R
 end
 
 function get_inf_pr_R(
@@ -431,12 +423,11 @@ function get_inf_pr_R(
     p::AbstractVector{T},
     n::AbstractVector{T},
 ) where T
-    return mapreduce(
-        (c,p,n) -> abs(c-p+n),
-        max,
-        c,p,n;
-        init = zero(T)
-    )
+    theta_R = zero(T)
+    for ii in eachindex(c)
+        theta_R = max(theta_R, abs(c[ii]-p[ii]+n[ii]))
+    end
+    return theta_R
 end
 
 function get_inf_du_R(
@@ -449,27 +440,15 @@ function get_inf_du_R(
     zn::AbstractVector{T},
     rho,
     sd,
-)  where T
-    return max(
-        mapreduce(
-            (f_R, zl, zu, jacl) -> abs(f_R-zl+zu+jacl),
-            max,
-            f_R, zl, zu, jacl;
-            init = zero(T)
-        ),
-        mapreduce(
-            (l, zp) -> abs(rho-l-zp),
-            max,
-            l, zp;
-            init = zero(T)
-        ),
-        mapreduce(
-            (l, zn) -> abs(rho+l-zn),
-            max,
-            l, zn;
-            init = zero(T)
-        )
-    ) / sd
+) where T
+    inf_du_R = zero(T)
+    for ii in eachinex(f_R)
+        inf_du_R = max(inf_du_R, abs(f_R[ii]-zl[ii]+zu[ii]+jacl[ii]))
+    end
+    for ii in eachindex(l)
+        inf_du_R = max(inf_du_R, abs(rho-l[ii]-zp[ii]), abs(rho+l[ii]-zn[ii]))
+    end
+    return inf_du_R / sd
 end
 
 function get_inf_compl_R(
@@ -486,32 +465,20 @@ function get_inf_compl_R(
     mu_R,
     sc
 ) where {T, VT <: AbstractVector{T}, VI}
-    return max(
-        mapreduce(
-            (x_lr, xl_r, zl_r) -> abs((x_lr-xl_r)*zl_r-mu_R),
-            max,
-            x_lr, xl_r, zl_r;
-            init = zero(T)
-        ),
-        mapreduce(
-            (xu_r, x_ur, zu_r) -> abs((xu_r-x_ur)*zu_r-mu_R),
-            max,
-            xu_r, x_ur, zu_r;
-            init = zero(T)
-        ),
-        mapreduce(
-            (pp, zp) -> abs(pp*zp-mu_R),
-            max,
-            pp, zp;
-            init = zero(T)
-        ),
-        mapreduce(
-            (nn, zn) -> abs(nn*zn-mu_R),
-            max,
-            nn, zn;
-            init = zero(T)
-        ),
-    ) / sc
+    inf_compl_R = zero(T)
+    for ii in eachindex(x_lr)
+        inf_compl_R = max(inf_compl_R, abs((x_lr[ii]-xl_r[ii])*zl_r[ii]-mu_R))
+    end
+    for ii in eachindex(xu_r)
+        inf_compl_R = max(inf_compl_R, abs((xu_r[ii]-x_ur[ii])*zu_r[ii]-mu_R))
+    end
+    for ii in eachindex(pp)
+        inf_compl_R = max(inf_compl_R, abs(pp[ii]*zp[ii]-mu_R))
+    end
+    for ii in eachindex(nn)
+        inf_compl_R = max(inf_compl_R, abs(nn[ii]*zn[ii]-mu_R))
+    end
+    return inf_compl_R / sc
 end
 
 function get_alpha_max_R(
@@ -525,40 +492,24 @@ function get_alpha_max_R(
     dnn::AbstractVector{T},
     tau_R,
 ) where T
-    return min(
-        mapreduce(
-            (x,xl,xu,dx) -> if dx < 0
-                (-x+xl)*tau_R/dx
-            elseif dx > 0
-                (-x+xu)*tau_R/dx
-            else
-                T(Inf)
-            end,
-            min,
-            x,xl,xu,dx;
-            init = one(T)
-        ),
-        mapreduce(
-            (pp, dpp)-> if dpp < 0
-                -pp*tau_R/dpp
-            else
-                T(Inf)
-            end,
-            min,
-            pp, dpp;
-            init = one(T)
-        ),
-        mapreduce(
-            (nn, dnn)-> if dnn < 0
-                -nn*tau_R/dnn
-            else
-                T(Inf)
-            end,
-            min,
-            nn, dnn;
-            init = one(T)
-        )
-    )
+    alpha_max_R = one(T)
+    for ii in eachindex(x)
+        candidate = if dx[ii] < 0
+            (-x[ii]+xl[ii])*tau_R/dx[ii]
+        elseif dx > 0
+            (-x[ii]+xu[ii])*tau_R/dx[ii]
+        else
+            T(Inf)
+        end
+        alpha_max_R = min(alpha_max_R, candidate)
+    end
+    for ii in eachindex(pp)
+        alpha_max_R = min(alpha_max_R, dpp[ii] < 0 ? -pp[ii]*tau_R/dpp[ii] : T(inf))
+    end
+    for ii in eachindex(nn)
+        alpha_max_R = min(alpha_max_R, dnn[ii] < 0 ? -nn[ii]*tau_R/dnn[ii] : T(inf))
+    end
+    return alpha_max_R
 end
 
 function get_alpha_z_R(
@@ -572,34 +523,21 @@ function get_alpha_z_R(
     dzn,
     tau_R,
 ) where {T, VT <: AbstractVector{T}, VI}
-
+    alpha_z_R = one(T)
     f(d,z) = d < 0 ? -z*tau_R/d : T(Inf)
-    return min(
-        mapreduce(
-            f,
-            min,
-            dzl, zl_r;
-            init = one(T)
-        ),
-        mapreduce(
-            f,
-            min,
-            dzu, zu_r;
-            init = one(T)
-        ),
-        mapreduce(
-            f,
-            min,
-            dzp, zp;
-            init = one(T)
-        ),
-        mapreduce(
-            f,
-            min,
-            dzn, zn;
-            init = one(T)
-        )
-    )
+    for ii in eachindex(dzl)
+        alpha_z_R = min(alpha_z_R, f(dzl[ii], zl_r[ii]))
+    end
+    for ii in eachindex(dzu)
+        alpha_z_R = min(alpha_z_R, f(dzu[ii], zu_r[ii]))
+    end
+    for ii in eachindex(dzp)
+        alpha_z_R = min(alpha_z_R, f(dzp[ii], zp[ii]))
+    end
+    for ii in eachindex(dzn)
+        alpha_z_R = min(alpha_z_R, f(dzn[ii], zn[ii]))
+    end
+    return alpha_z_R
 end
 
 function get_varphi_R(
@@ -618,33 +556,19 @@ function get_varphi_R(
         d = x - y
         d < 0 ? T(Inf) : mu_R * log(d)
     end
-
-    return obj_val - +(
-        mapreduce(
-            f2,
-            +,
-            x_lr, xl_r;
-            init = zero(T)
-        ),
-        mapreduce(
-            f2,
-            +,
-            xu_r, x_ur;
-            init = zero(T)
-        ),
-        mapreduce(
-            f1,
-            +,
-            pp;
-            init = zero(T)
-        ),
-        mapreduce(
-            f1,
-            +,
-            nn;
-            init = zero(T)
-        )
-    )
+    for ii in eachindex(x_lr)
+        varphi_R -= f2(x_lr[ii], xl_r[ii])
+    end
+    for ii in eachindex(xu_r)
+        varphi_R -= f2(xu_r[ii], x_ur[ii])
+    end
+    for ii in eachindex(pp)
+        varphi_R -= f1(pp)
+    end
+    for ii in eachindex(nn)
+        varphi_R -= f1(nn)
+    end
+    return varphi_R
 end
 
 function get_F(
@@ -661,30 +585,29 @@ function get_F(
     zu_r,
     mu,
 ) where T
+    # NOTE: Does not allocate
     F1 = mapreduce(
         abs,
         +,
         c;
         init = zero(T)
     )
-    F2 = mapreduce(
-        (f,zl,zu,jacl) -> abs(f-zl+zu+jacl),
-        +,
-        f,zl,zu,jacl;
-        init = zero(T)
-    )
-    F3 = mapreduce(
-        (x_lr,xl_r,zl_r) -> (x_lr >= xl_r && zl_r >= 0) ? abs((x_lr-xl_r)*zl_r-mu) : T(Inf),
-        +,
-        x_lr,xl_r,zl_r;
-        init = zero(T)
-    )
-    F4 = mapreduce(
-        (xu_r,x_ur,zu_r) -> (xu_r >= x_ur && zu_r >= 0) ? abs((xu_r-xu_r)*zu_r-mu) : T(Inf),
-        +,
-        xu_r,xu_r,zu_r;
-        init = zero(T)
-    )
+
+    F2 = zero(T)
+    for ii in eachindex(f)
+        F2 += abs(f[ii]-zl[ii]+zu[ii]+jacl[ii])
+    end
+
+    F3 = zero(T)
+    for ii in eachindex(x_lr)
+        F3 += (x_lr[ii] >= xl_r[ii] && zl_r[ii] >= 0) ? abs((x_lr[ii]-xl_r[ii])*zl_r[ii]-mu) : T(Inf)
+    end
+
+    F4 = zero(T)
+    for ii in eachindex(xu_r)
+        F4 += (xu_r[ii] >= x_ur[ii] && zu_r[ii] >= 0) ? abs((xu_r[ii]-xu_r[ii])*zu_r[ii]-mu) : T(Inf)
+    end
+
     return F1 + F2 + F3 + F4
 end
 
@@ -702,26 +625,17 @@ function get_varphi_d_R(
     rho,
 ) where T
     f(x,dx) = (rho - mu_R/x) * dx
-    return +(
-        mapreduce(
-            (f_R, x, xl, xu, dx) -> (f_R - mu_R/(x-xl) + mu_R/(xu-x)) * dx,
-            +,
-            f_R, x, xl, xu, dx;
-            init = zero(T)
-        ),
-        mapreduce(
-            f,
-            +,
-            pp,dpp;
-            init = zero(T)
-        ),
-        mapreduce(
-            f,
-            +,
-            nn,dnn;
-            init = zero(T)
-        ),
-    )
+    varphi_d = zero(T)
+    for ii in eachindex(f_R)
+        varphi_d += (f_R[ii] - mu_R/(x[ii]-xl[ii]) + mu_R/(xu[ii]-x[ii])) * dx[ii]
+    end
+    for ii in eachindex(pp)
+        varphi_d += f(pp[ii],dpp[ii])
+    end
+    for ii in eachindex(nn)
+        varphi_d += f(nn[ii],dnn[ii])
+    end
+    return varphi_d
 end
 
 function _initialize_variables!(x::T, xl, xu, bound_push, bound_fac) where T
@@ -762,11 +676,11 @@ function adjust_boundary!(
 end
 
 function get_rel_search_norm(x::AbstractVector{T}, dx::AbstractVector{T}) where T
-    return mapreduce(
-        (x,dx) -> abs(dx) / (one(T) + abs(x)),
-        max,
-        x, dx
-    )
+    rel_search_norm = zero(T)
+    for ii in eachindex(x)
+        rel_search_norm = max(rel_search_norm, abs(dx[ii]) / (one(T) + abs(x[ii])))
+    end
+    return rel_search_norm
 end
 
 # Utility functions
@@ -905,7 +819,9 @@ function get_ftype(filter,theta,theta_trial,varphi,varphi_trial,switching_condit
 end
 
 function dual_inf_perturbation!(px, ind_llb, ind_uub, mu, kappa_d)
-    px[ind_llb] .-= mu*kappa_d
-    px[ind_uub] .+= mu*kappa_d
+    @views begin
+        px[ind_llb] .-= mu*kappa_d
+        px[ind_uub] .+= mu*kappa_d
+    end
 end
 

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -326,7 +326,7 @@ function get_min_complementarity(x_lr::AbstractVector{T}, xl_r::AbstractVector{T
     for ii in eachindex(x_lr)
         min_comp = min(min_comp, (x_lr[ii]-xl_r[ii])*zl_r[ii])
     end
-    for ii in eachindex(x_lr)
+    for ii in eachindex(xu_r)
         min_comp = min(min_comp, (xu_r[ii]-x_ur[ii])*zu_r[ii])
     end
     return min_comp
@@ -399,9 +399,9 @@ function get_obj_val_R(
 ) where T
     obj_val_R = zero(T)
     for ii in eachindex(p)
-        obj_val += rho*(p[ii]+n[ii]) .+ zeta/2*D_R[ii]^2*(x[ii]-x_ref[ii])^2
+        obj_val_R += rho*(p[ii]+n[ii]) .+ zeta/2*D_R[ii]^2*(x[ii]-x_ref[ii])^2
     end
-    return obj_val
+    return obj_val_R
 end
 
 @inline get_theta(c) = norm(c, 1)
@@ -423,11 +423,11 @@ function get_inf_pr_R(
     p::AbstractVector{T},
     n::AbstractVector{T},
 ) where T
-    theta_R = zero(T)
+    inf_pr_R = zero(T)
     for ii in eachindex(c)
-        theta_R = max(theta_R, abs(c[ii]-p[ii]+n[ii]))
+        inf_pr_R = max(inf_pr_R, abs(c[ii]-p[ii]+n[ii]))
     end
-    return theta_R
+    return inf_pr_R
 end
 
 function get_inf_du_R(
@@ -442,7 +442,7 @@ function get_inf_du_R(
     sd,
 ) where T
     inf_du_R = zero(T)
-    for ii in eachinex(f_R)
+    for ii in eachindex(f_R)
         inf_du_R = max(inf_du_R, abs(f_R[ii]-zl[ii]+zu[ii]+jacl[ii]))
     end
     for ii in eachindex(l)
@@ -496,7 +496,7 @@ function get_alpha_max_R(
     for ii in eachindex(x)
         candidate = if dx[ii] < 0
             (-x[ii]+xl[ii])*tau_R/dx[ii]
-        elseif dx > 0
+        elseif dx[ii] > 0
             (-x[ii]+xu[ii])*tau_R/dx[ii]
         else
             T(Inf)
@@ -504,10 +504,10 @@ function get_alpha_max_R(
         alpha_max_R = min(alpha_max_R, candidate)
     end
     for ii in eachindex(pp)
-        alpha_max_R = min(alpha_max_R, dpp[ii] < 0 ? -pp[ii]*tau_R/dpp[ii] : T(inf))
+        alpha_max_R = min(alpha_max_R, dpp[ii] < 0 ? -pp[ii]*tau_R/dpp[ii] : T(Inf))
     end
     for ii in eachindex(nn)
-        alpha_max_R = min(alpha_max_R, dnn[ii] < 0 ? -nn[ii]*tau_R/dnn[ii] : T(inf))
+        alpha_max_R = min(alpha_max_R, dnn[ii] < 0 ? -nn[ii]*tau_R/dnn[ii] : T(Inf))
     end
     return alpha_max_R
 end
@@ -524,7 +524,7 @@ function get_alpha_z_R(
     tau_R,
 ) where {T, VT <: AbstractVector{T}, VI}
     alpha_z_R = one(T)
-    f(d,z) = d < 0 ? -z*tau_R/d : T(Inf)
+    f(d,z) = d < 0.0 ? -z*tau_R/d : T(Inf)
     for ii in eachindex(dzl)
         alpha_z_R = min(alpha_z_R, f(dzl[ii], zl_r[ii]))
     end
@@ -551,10 +551,10 @@ function get_varphi_R(
     mu_R,
 )  where {T, VT <: AbstractVector{T}, VI}
     varphi_R = obj_val
-    f1(x) = x < 0 ? T(Inf) : mu_R*log(x)
+    f1(x) = x < 0.0 ? T(Inf) : mu_R*log(x)
     function f2(x,y)
         d = x - y
-        d < 0 ? T(Inf) : mu_R * log(d)
+        d < 0.0 ? T(Inf) : mu_R * log(d)
     end
     for ii in eachindex(x_lr)
         varphi_R -= f2(x_lr[ii], xl_r[ii])
@@ -563,10 +563,10 @@ function get_varphi_R(
         varphi_R -= f2(xu_r[ii], x_ur[ii])
     end
     for ii in eachindex(pp)
-        varphi_R -= f1(pp)
+        varphi_R -= f1(pp[ii])
     end
     for ii in eachindex(nn)
-        varphi_R -= f1(nn)
+        varphi_R -= f1(nn[ii])
     end
     return varphi_R
 end

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -820,3 +820,8 @@ function dual_inf_perturbation!(px, ind_llb, ind_uub, mu, kappa_d)
     end
 end
 
+function populate_RR_nn!(nn, c, mu, rho)
+    for ii in eachindex(nn)
+        nn[ii] = (mu - rho*c[ii])/(2*rho)+ sqrt(((mu-rho*c[ii])/(2*rho))^2 + mu*c[ii]/(2*rho))
+    end
+end

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -348,7 +348,7 @@ function get_varphi_d(
     mu,
 ) where T
     varphi_d = zero(T)
-    @simd for ii in eachindex(f)
+    for ii in eachindex(f)
         varphi_d += (f[ii] - mu/(x[ii]-xl[ii]) + mu/(xu[ii]-x[ii])) * dx[ii]
     end
     return varphi_d

--- a/src/IPM/kernels.jl
+++ b/src/IPM/kernels.jl
@@ -271,7 +271,6 @@ end
 
 function get_varphi(obj_val, x_lr, xl_r, xu_r, x_ur, mu)
     varphi = obj_val
-    # TODO(@anton) Check if we can @simd this
     for ii in eachindex(x_lr)
         varphi += _get_varphi(x_lr[ii],xl_r[ii],mu)
     end

--- a/src/IPM/line_search.jl
+++ b/src/IPM/line_search.jl
@@ -51,8 +51,9 @@ function filter_line_search!(solver::AbstractMadNLPSolver{T}) where T
             get_filter(solver),theta,theta_trial,varphi,varphi_trial,switching_condition,armijo_condition,
             get_theta_min(solver),get_opt(solver).obj_max_inc,get_opt(solver).gamma_theta,get_opt(solver).gamma_phi,
             has_constraints(solver))
-                )
-        if get_ftype(solver) in ["f","h"]
+                   )
+
+        if get_ftype(solver) in ("f","h")
             @trace(get_logger(solver),"Step accepted with type $(get_ftype(solver))")
             break
         end

--- a/src/IPM/restoration.jl
+++ b/src/IPM/restoration.jl
@@ -36,10 +36,11 @@ function RobustRestorer(solver::AbstractMadNLPSolver{T}) where {T}
     )
 end
 
-function initialize_robust_restorer!(solver::AbstractMadNLPSolver{T}) where T
+function initialize_robust_restorer!(solver::AbstractMadNLPSolver{T}) where {T}
     @trace(get_logger(solver),"Initializing restoration phase variables.")
     get_RR(solver) == nothing && (set_RR!(solver, RobustRestorer(solver)))
-    RR = get_RR(solver)
+    # Explicitly type otherwise we get type instability because compiler can't know RR != nothing
+    RR::RobustRestorer = get_RR(solver)
 
     copyto!(RR.x_ref, full(get_x(solver)))
     RR.theta_ref = get_theta(get_c(solver))
@@ -51,11 +52,7 @@ function initialize_robust_restorer!(solver::AbstractMadNLPSolver{T}) where T
 
     rho = get_opt(solver).rho
     mu = RR.mu_R
-    RR.nn .=
-        (mu .- rho*get_c(solver))./2 ./rho .+
-        sqrt.(
-            ((mu.-rho*get_c(solver))./2 ./rho).^2 + mu.*get_c(solver)./2 ./rho
-        )
+    populate_RR_nn!(RR.nn, get_c(solver), mu, rho)
     RR.pp .= get_c(solver) .+ RR.nn
     RR.zp .= RR.mu_R ./ RR.pp
     RR.zn .= RR.mu_R ./ RR.nn

--- a/src/IPM/utils.jl
+++ b/src/IPM/utils.jl
@@ -94,7 +94,7 @@ has_constraints(solver) = get_m(solver) != 0
 end
 
 
-function get_vars_info(solver)
+function get_vars_info(solver::AbstractMadNLPSolver)
     nlp = get_nlp(solver)
 
     x_lb = get_lvar(nlp)
@@ -115,7 +115,7 @@ function get_vars_info(solver)
     )
 end
 
-function get_cons_info(solver)
+function get_cons_info(solver::AbstractMadNLPSolver)
     nlp = get_nlp(solver)
 
     g_lb = get_lcon(nlp)

--- a/src/IPM/utils.jl
+++ b/src/IPM/utils.jl
@@ -88,7 +88,7 @@ function get_vars_info(solver)
 
     num_lu_vars = 0
     for ii in eachindex(x_lb)
-        if (x_lb !=-Inf) && (x_ub != Inf)
+        if (x_lb[ii] !=-Inf) && (x_ub[ii] != Inf)
             num_lu_vars += 1
         end
     end
@@ -114,9 +114,9 @@ function get_cons_info(solver)
     num_le_cons = 0
     num_ue_cons = 0
     for ii in eachindex(g_lb)
-        if (g_lb != -Inf) && (g_ub ==  Inf)
+        if (g_lb[ii] != -Inf) && (g_ub[ii] == Inf)
             num_le_cons += 1
-        elseif (g_ub !=  Inf) && (g_lb == -Inf)
+        elseif (g_ub[ii] !=  Inf) && (g_lb[ii] == -Inf)
             num_ue_cons += 1
         end
     end

--- a/src/IPM/utils.jl
+++ b/src/IPM/utils.jl
@@ -86,8 +86,13 @@ function get_vars_info(solver)
     num_var = get_nvar(nlp) - num_fixed
     num_llb_vars = length(get_ind_llb(solver))
 
-    # TODO make this non-allocating
-    num_lu_vars = sum((x_lb .!=-Inf) .& (x_ub .!= Inf)) - num_fixed
+    num_lu_vars = 0
+    for ii in eachindex(x_lb)
+        if (x_lb !=-Inf) && (x_ub != Inf)
+            num_lu_vars += 1
+        end
+    end
+    num_lu_vars = num_lu_vars - num_fixed
     num_uub_vars = length(get_ind_uub(solver))
     return (
         n_free=num_var,
@@ -104,11 +109,17 @@ function get_cons_info(solver)
     g_lb = get_lcon(nlp)
     g_ub = get_ucon(nlp)
 
-    # TODO make this non-allocating
-    num_eq_cons = sum(g_lb .== g_ub)
-    num_ineq_cons = length(g_lb) - num_eq_cons
-    num_le_cons = sum((g_lb .!= -Inf) .& (g_ub .==  Inf))
-    num_ue_cons = sum((g_ub .!=  Inf) .& (g_lb .== -Inf))
+    num_eq_cons = length(solver.cb.ind_eq)
+    num_ineq_cons = length(solver.cb.ind_ineq)
+    num_le_cons = 0
+    num_ue_cons = 0
+    for ii in eachindex(g_lb)
+        if (g_lb != -Inf) && (g_ub ==  Inf)
+            num_le_cons += 1
+        elseif (g_ub !=  Inf) && (g_lb == -Inf)
+            num_ue_cons += 1
+        end
+    end
     num_lu_cons = num_ineq_cons - num_le_cons - num_ue_cons
 
     return (

--- a/src/IPM/utils.jl
+++ b/src/IPM/utils.jl
@@ -77,6 +77,23 @@ struct NotEnoughDegreesOfFreedomException <: Exception end
 # Utilities
 has_constraints(solver) = get_m(solver) != 0
 
+@inline function count_lu_bounds(lb::AbstractVector, ub::AbstractVector)
+    num_lu_bounds = 0
+    num_le_bounds = 0
+    num_ue_bounds = 0
+    for ii in eachindex(lb)
+        if (lb[ii] !=-Inf) && (ub[ii] != Inf)
+            num_lu_bounds += 1
+        elseif (lb[ii] == -Inf)
+            num_ue_bounds += 1
+        elseif (ub[ii] == Inf)
+            num_le_bounds += 1
+        end
+    end
+    return num_lu_bounds, num_le_bounds, num_ue_bounds
+end
+
+
 function get_vars_info(solver)
     nlp = get_nlp(solver)
 
@@ -86,12 +103,7 @@ function get_vars_info(solver)
     num_var = get_nvar(nlp) - num_fixed
     num_llb_vars = length(get_ind_llb(solver))
 
-    num_lu_vars = 0
-    for ii in eachindex(x_lb)
-        if (x_lb[ii] !=-Inf) && (x_ub[ii] != Inf)
-            num_lu_vars += 1
-        end
-    end
+    num_lu_vars,_,_ = count_lu_bounds(x_lb, x_ub)
     num_lu_vars = num_lu_vars - num_fixed
     num_uub_vars = length(get_ind_uub(solver))
     return (
@@ -111,15 +123,7 @@ function get_cons_info(solver)
 
     num_eq_cons = length(solver.cb.ind_eq)
     num_ineq_cons = length(solver.cb.ind_ineq)
-    num_le_cons = 0
-    num_ue_cons = 0
-    for ii in eachindex(g_lb)
-        if (g_lb[ii] != -Inf) && (g_ub[ii] == Inf)
-            num_le_cons += 1
-        elseif (g_ub[ii] !=  Inf) && (g_lb[ii] == -Inf)
-            num_ue_cons += 1
-        end
-    end
+    _,num_le_cons,num_ue_cons = count_lu_bounds(g_lb, g_ub)
     num_lu_cons = num_ineq_cons - num_le_cons - num_ue_cons
 
     return (


### PR DESCRIPTION
Currently the use of `mapreduce` everywhere causes a relatively large amount of allocations to happen during `solve!`. This is my initial attempt at fixing these, though in all likelihood I have broken some GPU functionality which was relying on the multiple dispatch of `mapreduce`.