### PR TITLE
Release 0.9.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,6 +134,13 @@ jobs:
           using Pkg
           Pkg.add("CUDA")
           Pkg.add("CUDSS")
+          # Pin the CUDA runtime to a 12.x toolkit so the self-hosted
+          # V100 runner keeps working: CUDA 13 dropped sm_70 support, and
+          # without this pin CUDA_Runtime_jll may auto-select CUDA 13.
+          # See JuliaGPU/CUDA.jl#3134 — once that fix is in a tagged
+          # CUDA.jl release, this pin can be removed.
+          using CUDA
+          CUDA.set_runtime_version!(v"12.9")
       - name: Add AMDGPU
         if: matrix.gpu == 'amdgpu'
         shell: julia --project=./lib/MadNLPGPU/test --color=yes {0}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MadNLP"
 uuid = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 LDLFactorizations = "40e66cde-538c-5869-a4ad-c39174c6795b"

--- a/docs/install.jl
+++ b/docs/install.jl
@@ -11,3 +11,10 @@ Base.compilecache(Base.identify_package("MadNLPTests"))
 Base.compilecache(Base.identify_package("MadNLPGPU"))
 Base.compilecache(Base.identify_package("MadNLP"))
 Pkg.instantiate()
+
+# Pin the CUDA runtime to a 12.x toolkit so the self-hosted V100 runner
+# keeps working: CUDA 13 dropped sm_70 support, and without this pin
+# CUDA_Runtime_jll may auto-select CUDA 13. See JuliaGPU/CUDA.jl#3134 —
+# once that fix is in a tagged CUDA.jl release, this pin can be removed.
+using CUDA
+CUDA.set_runtime_version!(v"12.9")

--- a/lib/MadNLPGPU/Project.toml
+++ b/lib/MadNLPGPU/Project.toml
@@ -1,6 +1,6 @@
 name = "MadNLPGPU"
 uuid = "d72a61cc-809d-412f-99be-fd81f4b8a598"
-version = "0.8.0"
+version = "0.9.0"
 
 [deps]
 AMD = "14f7f29c-3bd6-536c-9a0b-7339e30b5a3e"

--- a/lib/MadNLPTests/Project.toml
+++ b/lib/MadNLPTests/Project.toml
@@ -1,6 +1,6 @@
 name = "MadNLPTests"
 uuid = "b52a2a03-04ab-4a5f-9698-6a2deff93217"
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"


### PR DESCRIPTION
I had to bump MadNLPGPU from 0.8.0 to 0.9.0 because of a CUDA dependency change 9 (-> weak deps).

Release notes draft:

### MadNLP v0.9.2

> Highlights: new **SchurComplementKKTSystem** for two-stage stochastic programs (CPU + GPU), an API cleanup so solver and wrapper internals are accessed through getter functions, and a MUMPS 5.8.x fix.

**New features**
- Add `SchurComplementKKTSystem` for exploiting the block-arrowhead structure of two-stage stochastic programs. Reduces each Newton step to a dense `nd × nd` design-variable system via per-scenario eliminations. CPU variant uses Umfpack for the per-scenario blocks by default; GPU variant lives in the `MadNLPGPU` CUDA extension and uses batched cuDSS + strided-batched CUBLAS. (#598)

**API changes**
- Solver member access is now through getter functions instead of direct field access. Downstream code that reaches into `MadNLPSolver` fields will need to migrate. (#497)
- Wrapper models use getters for inner-model access. (#595)
- `solve` is now re-exported from `SolverCore`, aligning MadNLP with the broader JuliaSmoothOptimizers ecosystem. (#601)

**Fixes**
- Update MUMPS bindings for the 5.8.x ABI. (#613)

**Documentation**
- Fix `mu_init` in the warm-start tutorial. (#607)

---

### MadNLPGPU v0.9.0

> Highlights: CUDA/CUDSS and AMDGPU are now weak dependencies, and the new Schur-complement KKT system has a GPU backend.

- **CUDA/CUDSS moved to weak deps**, GPU backend code deduplicated. Installing MadNLPGPU no longer pulls CUDA on machines without it; the CUDA-specific code (`LapackCUDASolver`, `CUDSSSolver`, GPU Schur) lives in the `MadNLPGPUCUDAExt` extension and loads only when both CUDA.jl and CUDSS.jl are present. The AMDGPU backend follows the same pattern via `MadNLPGPUAMDGPUExt`. (#596)
- **GPU SchurComplementKKTSystem**: batched per-scenario factorizations via cuDSS, Schur accumulation via CUBLAS strided-batched GEMM. (#598)
- Requires MadNLP ≥ 0.9.2.

**Known issue — V100 / Volta (sm_70):**
CUDA Toolkit 13 dropped support for Volta GPUs. Starting at CUDA.jl v5.10 (March 2026), Pkg may resolve to a CUDA.jl that auto-selects the CUDA 13 runtime, which then fails on V100. MadNLPGPU's compat allows this. Until [JuliaGPU/CUDA.jl#3134](https://github.com/JuliaGPU/CUDA.jl/pull/3134) ships in a tagged release, V100 users should pin to a CUDA 12.x toolkit by running once per environment:

```julia
using CUDA
CUDA.set_runtime_version!(v"12.9")    # any 12.x works
```

Alternatively, pin `CUDA = "~5.9"` in your project's `Project.toml`.

---

### MadNLPTests v0.6.1

- Add Schur-complement two-stage stochastic test fixtures used by `MadNLP` and `MadNLPGPU` Schur tests. (#598)
