### PR TITLE
Store variable & constraint names in the MOI wrapper

### DIFF
--- a/ext/MadNLPMOI/MOI_wrapper.jl
+++ b/ext/MadNLPMOI/MOI_wrapper.jl
@@ -41,10 +41,10 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
     variables::MOI.Utilities.VariablesContainer{Float64}
     list_of_variable_indices::Vector{MOI.VariableIndex}
     variable_primal_start::Vector{Union{Nothing,Float64}}
-    variable_names::Dict{MOI.VariableIndex,String}
-    constraint_names::Dict{MOI.ConstraintIndex,String}
-    name_to_variable::Union{Nothing,Dict{String,Union{Nothing,MOI.VariableIndex}}}
-    name_to_constraint_index::Union{Nothing,Dict{String,Union{Nothing,MOI.ConstraintIndex}}}
+    variable_names::Dict{MOI.VariableIndex, String}
+    constraint_names::Dict{MOI.ConstraintIndex, String}
+    name_to_variable::Union{Nothing, Dict{String, Union{Nothing, MOI.VariableIndex}}}
+    name_to_constraint_index::Union{Nothing, Dict{String, Union{Nothing, MOI.ConstraintIndex}}}
 
     nlp_data::MOI.NLPBlockData
     nlp_dual_start::Union{Nothing,Vector{Float64}}
@@ -87,8 +87,8 @@ function Optimizer(; kwargs...)
         MOI.Utilities.VariablesContainer{Float64}(),
         MOI.VariableIndex[],
         Union{Nothing,Float64}[],
-        Dict{MOI.VariableIndex,String}(),
-        Dict{MOI.ConstraintIndex,String}(),
+        Dict{MOI.VariableIndex, String}(),
+        Dict{MOI.ConstraintIndex, String}(),
         nothing,
         nothing,
         MOI.NLPBlockData([], _EmptyNLPEvaluator(), false),
@@ -905,11 +905,11 @@ end
 MOI.supports(::Optimizer, ::MOI.VariableName, ::Type{MOI.VariableIndex}) = true
 
 function MOI.set(
-    model::Optimizer,
-    ::MOI.VariableName,
-    vi::MOI.VariableIndex,
-    name::String,
-)
+        model::Optimizer,
+        ::MOI.VariableName,
+        vi::MOI.VariableIndex,
+        name::String,
+    )
     MOI.throw_if_not_valid(model, vi)
     if isempty(name)
         delete!(model.variable_names, vi)
@@ -942,7 +942,7 @@ function MOI.get(model::Optimizer, ::Type{MOI.VariableIndex}, name::String)
 end
 
 function _rebuild_name_to_variable(model::Optimizer)
-    model.name_to_variable = Dict{String,Union{Nothing,MOI.VariableIndex}}()
+    model.name_to_variable = Dict{String, Union{Nothing, MOI.VariableIndex}}()
     for (vi, name) in model.variable_names
         if haskey(model.name_to_variable, name)
             model.name_to_variable[name] = nothing
@@ -961,16 +961,16 @@ end
 # `VariableIndexConstraintNameError`, mirroring Gurobi.jl/Xpress.jl. Vector
 # constraints (VectorNonlinearOracle) are excluded on purpose: a single name
 # would label a whole block of `output_dimension` rows.
-const _NAMED_CONSTRAINT = MOI.ConstraintIndex{<:_FUNCTIONS,<:_SETS}
+const _NAMED_CONSTRAINT = MOI.ConstraintIndex{<:_FUNCTIONS, <:_SETS}
 
 MOI.supports(::Optimizer, ::MOI.ConstraintName, ::Type{<:_NAMED_CONSTRAINT}) = true
 
 function MOI.set(
-    model::Optimizer,
-    ::MOI.ConstraintName,
-    ci::_NAMED_CONSTRAINT,
-    name::String,
-)
+        model::Optimizer,
+        ::MOI.ConstraintName,
+        ci::_NAMED_CONSTRAINT,
+        name::String,
+    )
     MOI.throw_if_not_valid(model, ci)
     if isempty(name)
         delete!(model.constraint_names, ci)
@@ -1001,7 +1001,7 @@ function MOI.get(model::Optimizer, ::Type{MOI.ConstraintIndex}, name::String)
 end
 
 function _rebuild_name_to_constraint_index(model::Optimizer)
-    model.name_to_constraint_index = Dict{String,Union{Nothing,MOI.ConstraintIndex}}()
+    model.name_to_constraint_index = Dict{String, Union{Nothing, MOI.ConstraintIndex}}()
     for (ci, name) in model.constraint_names
         if haskey(model.name_to_constraint_index, name)
             model.name_to_constraint_index[name] = nothing

--- a/ext/MadNLPMOI/MOI_wrapper.jl
+++ b/ext/MadNLPMOI/MOI_wrapper.jl
@@ -960,8 +960,7 @@ end
 # (bound) constraints are excluded so that MOI's fallback throws
 # `VariableIndexConstraintNameError`, mirroring Gurobi.jl/Xpress.jl. Vector
 # constraints (VectorNonlinearOracle) are excluded on purpose: a single name
-# would label a whole block of `output_dimension` rows, so per-row labelling is
-# deferred to the future KKT diagnostic rather than baked in here.
+# would label a whole block of `output_dimension` rows.
 const _NAMED_CONSTRAINT = MOI.ConstraintIndex{<:_FUNCTIONS,<:_SETS}
 
 MOI.supports(::Optimizer, ::MOI.ConstraintName, ::Type{<:_NAMED_CONSTRAINT}) = true

--- a/ext/MadNLPMOI/MOI_wrapper.jl
+++ b/ext/MadNLPMOI/MOI_wrapper.jl
@@ -955,13 +955,14 @@ end
 
 ### MOI.ConstraintName
 
-# The constraint types that may carry a name. `VariableIndex`-in-set (bound)
-# constraints are deliberately excluded so that MOI's fallback throws
-# `VariableIndexConstraintNameError`, mirroring Gurobi.jl/Xpress.jl.
-const _NAMED_CONSTRAINT = Union{
-    MOI.ConstraintIndex{<:_FUNCTIONS,<:_SETS},
-    MOI.ConstraintIndex{MOI.VectorOfVariables,MOI.VectorNonlinearOracle{Float64}},
-}
+# The constraint types that may carry a name: the scalar function/set blocks,
+# which map one ConstraintIndex to exactly one KKT row. `VariableIndex`-in-set
+# (bound) constraints are excluded so that MOI's fallback throws
+# `VariableIndexConstraintNameError`, mirroring Gurobi.jl/Xpress.jl. Vector
+# constraints (VectorNonlinearOracle) are excluded on purpose: a single name
+# would label a whole block of `output_dimension` rows, so per-row labelling is
+# deferred to the future KKT diagnostic rather than baked in here.
+const _NAMED_CONSTRAINT = MOI.ConstraintIndex{<:_FUNCTIONS,<:_SETS}
 
 MOI.supports(::Optimizer, ::MOI.ConstraintName, ::Type{<:_NAMED_CONSTRAINT}) = true
 

--- a/ext/MadNLPMOI/MOI_wrapper.jl
+++ b/ext/MadNLPMOI/MOI_wrapper.jl
@@ -41,6 +41,10 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
     variables::MOI.Utilities.VariablesContainer{Float64}
     list_of_variable_indices::Vector{MOI.VariableIndex}
     variable_primal_start::Vector{Union{Nothing,Float64}}
+    variable_names::Dict{MOI.VariableIndex,String}
+    constraint_names::Dict{MOI.ConstraintIndex,String}
+    name_to_variable::Union{Nothing,Dict{String,Union{Nothing,MOI.VariableIndex}}}
+    name_to_constraint_index::Union{Nothing,Dict{String,Union{Nothing,MOI.ConstraintIndex}}}
 
     nlp_data::MOI.NLPBlockData
     nlp_dual_start::Union{Nothing,Vector{Float64}}
@@ -83,6 +87,10 @@ function Optimizer(; kwargs...)
         MOI.Utilities.VariablesContainer{Float64}(),
         MOI.VariableIndex[],
         Union{Nothing,Float64}[],
+        Dict{MOI.VariableIndex,String}(),
+        Dict{MOI.ConstraintIndex,String}(),
+        nothing,
+        nothing,
         MOI.NLPBlockData([], _EmptyNLPEvaluator(), false),
         nothing,
         Dict{MOI.Nonlinear.ConstraintIndex,Float64}(),
@@ -145,6 +153,10 @@ function MOI.empty!(model::Optimizer)
     MOI.empty!(model.variables)
     empty!(model.list_of_variable_indices)
     empty!(model.variable_primal_start)
+    empty!(model.variable_names)
+    empty!(model.constraint_names)
+    model.name_to_variable = nothing
+    model.name_to_constraint_index = nothing
     model.nlp_data = MOI.NLPBlockData([], _EmptyNLPEvaluator(), false)
     model.nlp_dual_start = nothing
     empty!(model.mult_g_nlp)
@@ -885,6 +897,118 @@ function MOI.set(
     MOI.throw_if_not_valid(model, vi)
     model.variable_primal_start[column(vi)] = value
     model.needs_new_nlp = true
+    return
+end
+
+### MOI.VariableName
+
+MOI.supports(::Optimizer, ::MOI.VariableName, ::Type{MOI.VariableIndex}) = true
+
+function MOI.set(
+    model::Optimizer,
+    ::MOI.VariableName,
+    vi::MOI.VariableIndex,
+    name::String,
+)
+    MOI.throw_if_not_valid(model, vi)
+    if isempty(name)
+        delete!(model.variable_names, vi)
+    else
+        model.variable_names[vi] = name
+    end
+    # Names are non-numeric metadata: do not invalidate the NLP, only the
+    # lazily-built reverse lookup.
+    model.name_to_variable = nothing
+    return
+end
+
+function MOI.get(model::Optimizer, ::MOI.VariableName, vi::MOI.VariableIndex)
+    MOI.throw_if_not_valid(model, vi)
+    return get(model.variable_names, vi, "")
+end
+
+function MOI.get(model::Optimizer, ::Type{MOI.VariableIndex}, name::String)
+    if model.name_to_variable === nothing
+        _rebuild_name_to_variable(model)
+    end
+    if haskey(model.name_to_variable, name)
+        vi = model.name_to_variable[name]
+        if vi === nothing
+            error("Duplicate variable name detected: $(name)")
+        end
+        return vi
+    end
+    return nothing
+end
+
+function _rebuild_name_to_variable(model::Optimizer)
+    model.name_to_variable = Dict{String,Union{Nothing,MOI.VariableIndex}}()
+    for (vi, name) in model.variable_names
+        if haskey(model.name_to_variable, name)
+            model.name_to_variable[name] = nothing
+        else
+            model.name_to_variable[name] = vi
+        end
+    end
+    return
+end
+
+### MOI.ConstraintName
+
+# The constraint types that may carry a name. `VariableIndex`-in-set (bound)
+# constraints are deliberately excluded so that MOI's fallback throws
+# `VariableIndexConstraintNameError`, mirroring Gurobi.jl/Xpress.jl.
+const _NAMED_CONSTRAINT = Union{
+    MOI.ConstraintIndex{<:_FUNCTIONS,<:_SETS},
+    MOI.ConstraintIndex{MOI.VectorOfVariables,MOI.VectorNonlinearOracle{Float64}},
+}
+
+MOI.supports(::Optimizer, ::MOI.ConstraintName, ::Type{<:_NAMED_CONSTRAINT}) = true
+
+function MOI.set(
+    model::Optimizer,
+    ::MOI.ConstraintName,
+    ci::_NAMED_CONSTRAINT,
+    name::String,
+)
+    MOI.throw_if_not_valid(model, ci)
+    if isempty(name)
+        delete!(model.constraint_names, ci)
+    else
+        model.constraint_names[ci] = name
+    end
+    model.name_to_constraint_index = nothing
+    return
+end
+
+function MOI.get(model::Optimizer, ::MOI.ConstraintName, ci::_NAMED_CONSTRAINT)
+    MOI.throw_if_not_valid(model, ci)
+    return get(model.constraint_names, ci, "")
+end
+
+function MOI.get(model::Optimizer, ::Type{MOI.ConstraintIndex}, name::String)
+    if model.name_to_constraint_index === nothing
+        _rebuild_name_to_constraint_index(model)
+    end
+    if haskey(model.name_to_constraint_index, name)
+        ci = model.name_to_constraint_index[name]
+        if ci === nothing
+            error("Duplicate constraint name detected: $(name)")
+        end
+        return ci
+    end
+    return nothing
+end
+
+function _rebuild_name_to_constraint_index(model::Optimizer)
+    model.name_to_constraint_index = Dict{String,Union{Nothing,MOI.ConstraintIndex}}()
+    for (ci, name) in model.constraint_names
+        if haskey(model.name_to_constraint_index, name)
+            model.name_to_constraint_index[name] = nothing
+        else
+            model.name_to_constraint_index[name] = ci
+        end
+    end
     return
 end
 

--- a/test/MOI_interface_test.jl
+++ b/test/MOI_interface_test.jl
@@ -213,126 +213,126 @@ function test_Parameter_basic()
     return
 end
 
-function test_VariableName_supports_get_set()
-    model = MadNLP.Optimizer()
-    @test MOI.supports(model, MOI.VariableName(), MOI.VariableIndex)
-    x = MOI.add_variable(model)
-    @test MOI.get(model, MOI.VariableName(), x) == ""
-    MOI.set(model, MOI.VariableName(), x, "x1")
-    @test MOI.get(model, MOI.VariableName(), x) == "x1"
-    # Setting an empty name hits the `delete!` branch in `set`, dropping the
-    # dict entry; `get` then falls back to the default "".
-    MOI.set(model, MOI.VariableName(), x, "")
-    @test MOI.get(model, MOI.VariableName(), x) == ""
-    return
-end
+    function test_VariableName_supports_get_set()
+        model = MadNLP.Optimizer()
+        @test MOI.supports(model, MOI.VariableName(), MOI.VariableIndex)
+        x = MOI.add_variable(model)
+        @test MOI.get(model, MOI.VariableName(), x) == ""
+        MOI.set(model, MOI.VariableName(), x, "x1")
+        @test MOI.get(model, MOI.VariableName(), x) == "x1"
+        # Setting an empty name hits the `delete!` branch in `set`, dropping the
+        # dict entry; `get` then falls back to the default "".
+        MOI.set(model, MOI.VariableName(), x, "")
+        @test MOI.get(model, MOI.VariableName(), x) == ""
+        return
+    end
 
-function test_ConstraintName_linear()
-    model = MadNLP.Optimizer()
-    x = MOI.add_variable(model)
-    f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
-    ci = MOI.add_constraint(model, f, MOI.LessThan(1.0))
-    @test MOI.supports(model, MOI.ConstraintName(), typeof(ci))
-    @test MOI.get(model, MOI.ConstraintName(), ci) == ""
-    MOI.set(model, MOI.ConstraintName(), ci, "c1")
-    @test MOI.get(model, MOI.ConstraintName(), ci) == "c1"
-    return
-end
+    function test_ConstraintName_linear()
+        model = MadNLP.Optimizer()
+        x = MOI.add_variable(model)
+        f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
+        ci = MOI.add_constraint(model, f, MOI.LessThan(1.0))
+        @test MOI.supports(model, MOI.ConstraintName(), typeof(ci))
+        @test MOI.get(model, MOI.ConstraintName(), ci) == ""
+        MOI.set(model, MOI.ConstraintName(), ci, "c1")
+        @test MOI.get(model, MOI.ConstraintName(), ci) == "c1"
+        return
+    end
 
-function test_ConstraintName_quadratic()
-    model = MadNLP.Optimizer()
-    x = MOI.add_variable(model)
-    f = MOI.ScalarQuadraticFunction(
-        [MOI.ScalarQuadraticTerm(1.0, x, x)],
-        MOI.ScalarAffineTerm{Float64}[],
-        0.0,
-    )
-    ci = MOI.add_constraint(model, f, MOI.EqualTo(1.0))
-    @test MOI.supports(model, MOI.ConstraintName(), typeof(ci))
-    @test MOI.get(model, MOI.ConstraintName(), ci) == ""
-    MOI.set(model, MOI.ConstraintName(), ci, "q1")
-    @test MOI.get(model, MOI.ConstraintName(), ci) == "q1"
-    return
-end
+    function test_ConstraintName_quadratic()
+        model = MadNLP.Optimizer()
+        x = MOI.add_variable(model)
+        f = MOI.ScalarQuadraticFunction(
+            [MOI.ScalarQuadraticTerm(1.0, x, x)],
+            MOI.ScalarAffineTerm{Float64}[],
+            0.0,
+        )
+        ci = MOI.add_constraint(model, f, MOI.EqualTo(1.0))
+        @test MOI.supports(model, MOI.ConstraintName(), typeof(ci))
+        @test MOI.get(model, MOI.ConstraintName(), ci) == ""
+        MOI.set(model, MOI.ConstraintName(), ci, "q1")
+        @test MOI.get(model, MOI.ConstraintName(), ci) == "q1"
+        return
+    end
 
-function test_ConstraintName_scalar_nonlinear()
-    model = MadNLP.Optimizer()
-    x = MOI.add_variable(model)
-    f = MOI.ScalarNonlinearFunction(:sin, Any[x])
-    ci = MOI.add_constraint(model, f, MOI.EqualTo(0.0))
-    @test MOI.supports(model, MOI.ConstraintName(), typeof(ci))
-    @test MOI.get(model, MOI.ConstraintName(), ci) == ""
-    MOI.set(model, MOI.ConstraintName(), ci, "nl1")
-    @test MOI.get(model, MOI.ConstraintName(), ci) == "nl1"
-    return
-end
+    function test_ConstraintName_scalar_nonlinear()
+        model = MadNLP.Optimizer()
+        x = MOI.add_variable(model)
+        f = MOI.ScalarNonlinearFunction(:sin, Any[x])
+        ci = MOI.add_constraint(model, f, MOI.EqualTo(0.0))
+        @test MOI.supports(model, MOI.ConstraintName(), typeof(ci))
+        @test MOI.get(model, MOI.ConstraintName(), ci) == ""
+        MOI.set(model, MOI.ConstraintName(), ci, "nl1")
+        @test MOI.get(model, MOI.ConstraintName(), ci) == "nl1"
+        return
+    end
 
-function test_ConstraintName_not_supported_for_bounds()
-    model = MadNLP.Optimizer()
-    x = MOI.add_variable(model)
-    ci = MOI.add_constraint(model, x, MOI.GreaterThan(0.0))
-    # MOI guarantees ConstraintName is rejected for VariableIndex (bound)
-    # constraints: both `supports` and `set` throw VariableIndexConstraintNameError.
-    @test_throws MOI.UnsupportedAttribute MOI.supports(model, MOI.ConstraintName(), typeof(ci))
-    @test_throws MOI.UnsupportedAttribute MOI.set(model, MOI.ConstraintName(), ci, "b")
-    return
-end
+    function test_ConstraintName_not_supported_for_bounds()
+        model = MadNLP.Optimizer()
+        x = MOI.add_variable(model)
+        ci = MOI.add_constraint(model, x, MOI.GreaterThan(0.0))
+        # MOI guarantees ConstraintName is rejected for VariableIndex (bound)
+        # constraints: both `supports` and `set` throw VariableIndexConstraintNameError.
+        @test_throws MOI.UnsupportedAttribute MOI.supports(model, MOI.ConstraintName(), typeof(ci))
+        @test_throws MOI.UnsupportedAttribute MOI.set(model, MOI.ConstraintName(), ci, "b")
+        return
+    end
 
-function test_name_get_by_name()
-    model = MadNLP.Optimizer()
-    x = MOI.add_variable(model)
-    y = MOI.add_variable(model)
-    MOI.set(model, MOI.VariableName(), x, "x1")
-    f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
-    ci = MOI.add_constraint(model, f, MOI.LessThan(1.0))
-    MOI.set(model, MOI.ConstraintName(), ci, "c1")
-    @test MOI.get(model, MOI.VariableIndex, "x1") == x
-    @test MOI.get(model, MOI.ConstraintIndex, "c1") == ci
-    # Unknown names return nothing.
-    @test MOI.get(model, MOI.VariableIndex, "missing") === nothing
-    @test MOI.get(model, MOI.ConstraintIndex, "missing") === nothing
-    # Duplicate names error on lookup.
-    MOI.set(model, MOI.VariableName(), y, "x1")
-    @test_throws ErrorException MOI.get(model, MOI.VariableIndex, "x1")
-    return
-end
+    function test_name_get_by_name()
+        model = MadNLP.Optimizer()
+        x = MOI.add_variable(model)
+        y = MOI.add_variable(model)
+        MOI.set(model, MOI.VariableName(), x, "x1")
+        f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
+        ci = MOI.add_constraint(model, f, MOI.LessThan(1.0))
+        MOI.set(model, MOI.ConstraintName(), ci, "c1")
+        @test MOI.get(model, MOI.VariableIndex, "x1") == x
+        @test MOI.get(model, MOI.ConstraintIndex, "c1") == ci
+        # Unknown names return nothing.
+        @test MOI.get(model, MOI.VariableIndex, "missing") === nothing
+        @test MOI.get(model, MOI.ConstraintIndex, "missing") === nothing
+        # Duplicate names error on lookup.
+        MOI.set(model, MOI.VariableName(), y, "x1")
+        @test_throws ErrorException MOI.get(model, MOI.VariableIndex, "x1")
+        return
+    end
 
-function test_names_empty!()
-    model = MadNLP.Optimizer()
-    x = MOI.add_variable(model)
-    MOI.set(model, MOI.VariableName(), x, "x1")
-    f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
-    ci = MOI.add_constraint(model, f, MOI.LessThan(1.0))
-    MOI.set(model, MOI.ConstraintName(), ci, "c1")
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
-    @test isempty(model.variable_names)
-    @test isempty(model.constraint_names)
-    # Reverse caches are invalidated.
-    @test model.name_to_variable === nothing
-    @test model.name_to_constraint_index === nothing
-    # A re-added variable starts with the default empty name.
-    x2 = MOI.add_variable(model)
-    @test MOI.get(model, MOI.VariableName(), x2) == ""
-    return
-end
+    function test_names_empty!()
+        model = MadNLP.Optimizer()
+        x = MOI.add_variable(model)
+        MOI.set(model, MOI.VariableName(), x, "x1")
+        f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
+        ci = MOI.add_constraint(model, f, MOI.LessThan(1.0))
+        MOI.set(model, MOI.ConstraintName(), ci, "c1")
+        MOI.empty!(model)
+        @test MOI.is_empty(model)
+        @test isempty(model.variable_names)
+        @test isempty(model.constraint_names)
+        # Reverse caches are invalidated.
+        @test model.name_to_variable === nothing
+        @test model.name_to_constraint_index === nothing
+        # A re-added variable starts with the default empty name.
+        x2 = MOI.add_variable(model)
+        @test MOI.get(model, MOI.VariableName(), x2) == ""
+        return
+    end
 
-function test_name_copy_to_propagation()
-    src = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
-    x = MOI.add_variable(src)
-    MOI.set(src, MOI.VariableName(), x, "myvar")
-    f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
-    ci = MOI.add_constraint(src, f, MOI.LessThan(1.0))
-    MOI.set(src, MOI.ConstraintName(), ci, "mycon")
-    dest = MadNLP.Optimizer()
-    index_map = MOI.copy_to(dest, src)
-    # Names survive copy_to into the bare optimizer.
-    @test MOI.get(dest, MOI.VariableName(), index_map[x]) == "myvar"
-    @test MOI.get(dest, MOI.ConstraintName(), index_map[ci]) == "mycon"
-    @test dest.variable_names[index_map[x]] == "myvar"
-    @test dest.constraint_names[index_map[ci]] == "mycon"
-    return
-end
+    function test_name_copy_to_propagation()
+        src = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
+        x = MOI.add_variable(src)
+        MOI.set(src, MOI.VariableName(), x, "myvar")
+        f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
+        ci = MOI.add_constraint(src, f, MOI.LessThan(1.0))
+        MOI.set(src, MOI.ConstraintName(), ci, "mycon")
+        dest = MadNLP.Optimizer()
+        index_map = MOI.copy_to(dest, src)
+        # Names survive copy_to into the bare optimizer.
+        @test MOI.get(dest, MOI.VariableName(), index_map[x]) == "myvar"
+        @test MOI.get(dest, MOI.ConstraintName(), index_map[ci]) == "mycon"
+        @test dest.variable_names[index_map[x]] == "myvar"
+        @test dest.constraint_names[index_map[ci]] == "mycon"
+        return
+    end
 
 end
 

--- a/test/MOI_interface_test.jl
+++ b/test/MOI_interface_test.jl
@@ -213,6 +213,148 @@ function test_Parameter_basic()
     return
 end
 
+function test_VariableName_supports_get_set()
+    model = MadNLP.Optimizer()
+    @test MOI.supports(model, MOI.VariableName(), MOI.VariableIndex)
+    x = MOI.add_variable(model)
+    @test MOI.get(model, MOI.VariableName(), x) == ""
+    MOI.set(model, MOI.VariableName(), x, "x1")
+    @test MOI.get(model, MOI.VariableName(), x) == "x1"
+    # Setting an empty name hits the `delete!` branch in `set`, dropping the
+    # dict entry; `get` then falls back to the default "".
+    MOI.set(model, MOI.VariableName(), x, "")
+    @test MOI.get(model, MOI.VariableName(), x) == ""
+    return
+end
+
+function test_ConstraintName_linear()
+    model = MadNLP.Optimizer()
+    x = MOI.add_variable(model)
+    f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
+    ci = MOI.add_constraint(model, f, MOI.LessThan(1.0))
+    @test MOI.supports(model, MOI.ConstraintName(), typeof(ci))
+    @test MOI.get(model, MOI.ConstraintName(), ci) == ""
+    MOI.set(model, MOI.ConstraintName(), ci, "c1")
+    @test MOI.get(model, MOI.ConstraintName(), ci) == "c1"
+    return
+end
+
+function test_ConstraintName_quadratic()
+    model = MadNLP.Optimizer()
+    x = MOI.add_variable(model)
+    f = MOI.ScalarQuadraticFunction(
+        [MOI.ScalarQuadraticTerm(1.0, x, x)],
+        MOI.ScalarAffineTerm{Float64}[],
+        0.0,
+    )
+    ci = MOI.add_constraint(model, f, MOI.EqualTo(1.0))
+    @test MOI.supports(model, MOI.ConstraintName(), typeof(ci))
+    @test MOI.get(model, MOI.ConstraintName(), ci) == ""
+    MOI.set(model, MOI.ConstraintName(), ci, "q1")
+    @test MOI.get(model, MOI.ConstraintName(), ci) == "q1"
+    return
+end
+
+function test_ConstraintName_scalar_nonlinear()
+    model = MadNLP.Optimizer()
+    x = MOI.add_variable(model)
+    f = MOI.ScalarNonlinearFunction(:sin, Any[x])
+    ci = MOI.add_constraint(model, f, MOI.EqualTo(0.0))
+    @test MOI.supports(model, MOI.ConstraintName(), typeof(ci))
+    @test MOI.get(model, MOI.ConstraintName(), ci) == ""
+    MOI.set(model, MOI.ConstraintName(), ci, "nl1")
+    @test MOI.get(model, MOI.ConstraintName(), ci) == "nl1"
+    return
+end
+
+function test_ConstraintName_vector_oracle()
+    model = MadNLP.Optimizer()
+    x = MOI.add_variables(model, 2)
+    set = MOI.VectorNonlinearOracle(;
+        dimension = 2,
+        l = [0.0],
+        u = [0.0],
+        eval_f = (ret, y) -> (ret[1] = y[1]^2 - y[2]; return),
+        jacobian_structure = [(1, 1), (1, 2)],
+        eval_jacobian = (ret, y) -> (ret[1] = 2.0 * y[1]; ret[2] = -1.0; return),
+        hessian_lagrangian_structure = [(1, 1)],
+        eval_hessian_lagrangian = (ret, y, u) -> (ret[1] = 2.0 * u[1]; return),
+    )
+    ci = MOI.add_constraint(model, MOI.VectorOfVariables(x), set)
+    @test MOI.supports(model, MOI.ConstraintName(), typeof(ci))
+    @test MOI.get(model, MOI.ConstraintName(), ci) == ""
+    MOI.set(model, MOI.ConstraintName(), ci, "oracle1")
+    @test MOI.get(model, MOI.ConstraintName(), ci) == "oracle1"
+    return
+end
+
+function test_ConstraintName_not_supported_for_bounds()
+    model = MadNLP.Optimizer()
+    x = MOI.add_variable(model)
+    ci = MOI.add_constraint(model, x, MOI.GreaterThan(0.0))
+    # MOI guarantees ConstraintName is rejected for VariableIndex (bound)
+    # constraints: both `supports` and `set` throw VariableIndexConstraintNameError.
+    @test_throws MOI.UnsupportedAttribute MOI.supports(model, MOI.ConstraintName(), typeof(ci))
+    @test_throws MOI.UnsupportedAttribute MOI.set(model, MOI.ConstraintName(), ci, "b")
+    return
+end
+
+function test_name_get_by_name()
+    model = MadNLP.Optimizer()
+    x = MOI.add_variable(model)
+    y = MOI.add_variable(model)
+    MOI.set(model, MOI.VariableName(), x, "x1")
+    f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
+    ci = MOI.add_constraint(model, f, MOI.LessThan(1.0))
+    MOI.set(model, MOI.ConstraintName(), ci, "c1")
+    @test MOI.get(model, MOI.VariableIndex, "x1") == x
+    @test MOI.get(model, MOI.ConstraintIndex, "c1") == ci
+    # Unknown names return nothing.
+    @test MOI.get(model, MOI.VariableIndex, "missing") === nothing
+    @test MOI.get(model, MOI.ConstraintIndex, "missing") === nothing
+    # Duplicate names error on lookup.
+    MOI.set(model, MOI.VariableName(), y, "x1")
+    @test_throws ErrorException MOI.get(model, MOI.VariableIndex, "x1")
+    return
+end
+
+function test_names_empty!()
+    model = MadNLP.Optimizer()
+    x = MOI.add_variable(model)
+    MOI.set(model, MOI.VariableName(), x, "x1")
+    f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
+    ci = MOI.add_constraint(model, f, MOI.LessThan(1.0))
+    MOI.set(model, MOI.ConstraintName(), ci, "c1")
+    MOI.empty!(model)
+    @test MOI.is_empty(model)
+    @test isempty(model.variable_names)
+    @test isempty(model.constraint_names)
+    # Reverse caches are invalidated.
+    @test model.name_to_variable === nothing
+    @test model.name_to_constraint_index === nothing
+    # A re-added variable starts with the default empty name.
+    x2 = MOI.add_variable(model)
+    @test MOI.get(model, MOI.VariableName(), x2) == ""
+    return
+end
+
+function test_name_copy_to_propagation()
+    src = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
+    x = MOI.add_variable(src)
+    MOI.set(src, MOI.VariableName(), x, "myvar")
+    f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
+    ci = MOI.add_constraint(src, f, MOI.LessThan(1.0))
+    MOI.set(src, MOI.ConstraintName(), ci, "mycon")
+    dest = MadNLP.Optimizer()
+    index_map = MOI.copy_to(dest, src)
+    # Names survive copy_to into the bare optimizer.
+    @test MOI.get(dest, MOI.VariableName(), index_map[x]) == "myvar"
+    @test MOI.get(dest, MOI.ConstraintName(), index_map[ci]) == "mycon"
+    @test dest.variable_names[index_map[x]] == "myvar"
+    @test dest.constraint_names[index_map[ci]] == "mycon"
+    return
+end
+
 end
 
 TestMOIWrapper.runtests()

--- a/test/MOI_interface_test.jl
+++ b/test/MOI_interface_test.jl
@@ -267,27 +267,6 @@ function test_ConstraintName_scalar_nonlinear()
     return
 end
 
-function test_ConstraintName_vector_oracle()
-    model = MadNLP.Optimizer()
-    x = MOI.add_variables(model, 2)
-    set = MOI.VectorNonlinearOracle(;
-        dimension = 2,
-        l = [0.0],
-        u = [0.0],
-        eval_f = (ret, y) -> (ret[1] = y[1]^2 - y[2]; return),
-        jacobian_structure = [(1, 1), (1, 2)],
-        eval_jacobian = (ret, y) -> (ret[1] = 2.0 * y[1]; ret[2] = -1.0; return),
-        hessian_lagrangian_structure = [(1, 1)],
-        eval_hessian_lagrangian = (ret, y, u) -> (ret[1] = 2.0 * u[1]; return),
-    )
-    ci = MOI.add_constraint(model, MOI.VectorOfVariables(x), set)
-    @test MOI.supports(model, MOI.ConstraintName(), typeof(ci))
-    @test MOI.get(model, MOI.ConstraintName(), ci) == ""
-    MOI.set(model, MOI.ConstraintName(), ci, "oracle1")
-    @test MOI.get(model, MOI.ConstraintName(), ci) == "oracle1"
-    return
-end
-
 function test_ConstraintName_not_supported_for_bounds()
     model = MadNLP.Optimizer()
     x = MOI.add_variable(model)


### PR DESCRIPTION
@frapac To build a tool that identifies degenerate nonlinear programs, we need to be able to associate the constraint & variable names from the model with the internal col & row ids from MadNLP.

This PR adds attributes to the `Optimizer` struct in order to store the variable & constraints together with their associated MOI variable or constraint index. 

The attributes are mappings :
- from the variable index to the variable name
- from the constraint index to the constraint name
- from the variable name to the variable index
- from the constraint name to the constraint index

This is still a draft PR because I'm not sure whether the last two mappings are useful.