### PR TITLE
Remove hard dependency on `MadNLPTests` in `MadNLPGPU` and `MadNLPHSL`

### DIFF
--- a/lib/MadNLPGPU/Project.toml
+++ b/lib/MadNLPGPU/Project.toml
@@ -9,7 +9,6 @@ GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
-MadNLPTests = "b52a2a03-04ab-4a5f-9698-6a2deff93217"
 Metis = "2679e427-3c69-5b7f-982b-ece356f1e94b"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 

--- a/lib/MadNLPGPU/Project.toml
+++ b/lib/MadNLPGPU/Project.toml
@@ -1,6 +1,6 @@
 name = "MadNLPGPU"
 uuid = "d72a61cc-809d-412f-99be-fd81f4b8a598"
-version = "0.10.1"
+version = "0.10.2"
 
 [deps]
 AMD = "14f7f29c-3bd6-536c-9a0b-7339e30b5a3e"

--- a/lib/MadNLPHSL/Project.toml
+++ b/lib/MadNLPHSL/Project.toml
@@ -1,6 +1,6 @@
 name = "MadNLPHSL"
 uuid = "7fb6135f-58fe-4112-84ca-653cf5be0c77"
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 HSL = "34c5aeac-e683-54a6-a0e9-6e0fdc586c50"

--- a/lib/MadNLPHSL/Project.toml
+++ b/lib/MadNLPHSL/Project.toml
@@ -6,7 +6,6 @@ version = "0.7.2"
 HSL = "34c5aeac-e683-54a6-a0e9-6e0fdc586c50"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
-MadNLPTests = "b52a2a03-04ab-4a5f-9698-6a2deff93217"
 
 [compat]
 HSL = "0.5.3"


### PR DESCRIPTION
This reverts changes added in [`f99a4ad`](https://github.com/MadNLP/MadNLP.jl/commit/f99a4ad105107d60751155ddcd9692fea3740e94) which would now cause `libMad` to pull in and ship the entirety of `JuMP` as a transitive dependency of `MadNLPTests`