### PR TITLE
Always run runic and don't directly curl a script from the master branch

### DIFF
--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -2,7 +2,6 @@ name: 'Format'
 
 on:
   pull_request_target:
-    paths: ['**/*.jl']
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
@@ -36,8 +35,8 @@ jobs:
 
       - name: Install Runic
         run: |
-          julia --project=@runic -e 'using Pkg; Pkg.add("Runic")'
-          curl -o git-runic https://raw.githubusercontent.com/fredrikekre/Runic.jl/master/bin/git-runic
+          julia --project=@runic -e 'using Pkg; Pkg.add(name="Runic", version="1.7.0")'
+          curl -o git-runic https://raw.githubusercontent.com/fredrikekre/Runic.jl/v1.7.0/bin/git-runic
           chmod +x git-runic
           sudo mv git-runic /usr/local/bin
 


### PR DESCRIPTION
Two minor fixes to the `Format.yml` workflow:
1. Always run it. `git-runic` defaults to _only_ checking `*.jl` itself. 
2. Don't do the very scary thing of just curl-ing a script from the tip of a master branch! Instead we now use a tagged release (`v1.7.0`) of `Runic.jl`.

@amontoison I think I like this solution better. the runic workflow is cheap anyway.