### PR TITLE
Add doc preview cleanup workflow

### DIFF
--- a/.github/workflows/DocsCleanup.yml
+++ b/.github/workflows/DocsCleanup.yml
@@ -1,0 +1,33 @@
+name: Doc Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+concurrency:
+  group: doc-preview-cleanup
+  cancel-in-progress: false
+
+jobs:
+  doc-preview-cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Delete preview and history + push changes
+        run: |
+          if [ -d "previews/PR$PRNUM" ]; then
+              git config user.name "MadNLP.jl"
+              git config user.email "documenter@juliadocs.github.io"
+              git rm -rf "previews/PR$PRNUM"
+              git commit -m "delete preview"
+              git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+              git push --force origin gh-pages-new:gh-pages
+          fi
+        env:
+          PRNUM: ${{ github.event.number }}


### PR DESCRIPTION
Deletes `previews/PR<num>` from `gh-pages` when a PR closes and squashes the branch history to a single commit, so stale previews stop accumulating. Adapted from [ExaPF.jl's DocsCleanup workflow](https://github.com/exanauts/ExaPF.jl/blob/main/.github/workflows/DocsCleanup.yml), with a guard for PRs that never deployed a preview, `contents: write` permissions for the `GITHUB_TOKEN` push, a concurrency group to avoid racing force-pushes, and `actions/checkout@v4`.

Context: `gh-pages` had accumulated ~500 MB of previews from 213 closed PRs (back to PR #170), which made Documenter's deploy checkout run the self-hosted runners out of disk (see the docs CI failure on #623). A one-time prune of the stale previews accompanies this PR; this workflow keeps it from happening again.