### PR TITLE
docs: migrate ExaModels examples to the add_var/add_obj/add_con API

### DIFF
--- a/docs/src/tutorials/gpu.md
+++ b/docs/src/tutorials/gpu.md
@@ -51,13 +51,13 @@ function airport_model(T, backend)
     IJ = [(i, j) for i in 1:N-1 for j in i+1:N]
     # Write model using ExaModels
     core = ExaModels.ExaCore(T; backend=backend)
-    x = ExaModels.variable(core, 1:N, lvar = -10.0, uvar=10.0)
-    y = ExaModels.variable(core, 1:N, lvar = -10.0, uvar=10.0)
-    ExaModels.objective(
+    ExaModels.@add_var(core, x, 1:N; lvar = -10.0, uvar = 10.0)
+    ExaModels.@add_var(core, y, 1:N; lvar = -10.0, uvar = 10.0)
+    ExaModels.@add_obj(
         core,
         ((x[i] - x[j])^2 + (y[i] - y[j])^2) for (i, j) in IJ
     )
-    ExaModels.constraint(core, (x[i]-dcx)^2 + (y[i] - dcy)^2 - dr for (i, dcx, dcy, dr) in data; lcon=-Inf)
+    ExaModels.@add_con(core, (x[i]-dcx)^2 + (y[i] - dcy)^2 - dr for (i, dcx, dcy, dr) in data; lcon=-Inf)
     return ExaModels.ExaModel(core)
 end
 ```

--- a/docs/src/tutorials/multiprecision.md
+++ b/docs/src/tutorials/multiprecision.md
@@ -42,13 +42,13 @@ function airport_model(T)
     IJ = [(i, j) for i in 1:N-1 for j in i+1:N]
     # Write model using ExaModels
     core = ExaModels.ExaCore(T)
-    x = ExaModels.variable(core, 1:N, lvar = -10.0, uvar=10.0)
-    y = ExaModels.variable(core, 1:N, lvar = -10.0, uvar=10.0)
-    ExaModels.objective(
+    ExaModels.@add_var(core, x, 1:N; lvar = -10.0, uvar = 10.0)
+    ExaModels.@add_var(core, y, 1:N; lvar = -10.0, uvar = 10.0)
+    ExaModels.@add_obj(
         core,
         ((x[i] - x[j])^2 + (y[i] - y[j])^2) for (i, j) in IJ
     )
-    ExaModels.constraint(core, (x[i]-dcx)^2 + (y[i] - dcy)^2 - dr for (i, dcx, dcy, dr) in data; lcon=-Inf)
+    ExaModels.@add_con(core, (x[i]-dcx)^2 + (y[i] - dcy)^2 - dr for (i, dcx, dcy, dr) in data; lcon=-Inf)
     return ExaModels.ExaModel(core)
 end
 ```

--- a/docs/src/tutorials/quasi_newton.md
+++ b/docs/src/tutorials/quasi_newton.md
@@ -36,14 +36,14 @@ function elec_model(np)
     phi = pi .* rand(np)
 
     core = ExaModels.ExaCore(Float64)
-    x = ExaModels.variable(core, 1:np; start = [cos(theta[i])*sin(phi[i]) for i=1:np])
-    y = ExaModels.variable(core, 1:np; start = [sin(theta[i])*sin(phi[i]) for i=1:np])
-    z = ExaModels.variable(core, 1:np; start = [cos(phi[i]) for i=1:np])
+    ExaModels.@add_var(core, x, 1:np; start = [cos(theta[i])*sin(phi[i]) for i=1:np])
+    ExaModels.@add_var(core, y, 1:np; start = [sin(theta[i])*sin(phi[i]) for i=1:np])
+    ExaModels.@add_var(core, z, 1:np; start = [cos(phi[i]) for i=1:np])
     # Coulomb potential
     itr = [(i,j) for i in 1:np-1 for j in i+1:np]
-    ExaModels.objective(core, 1.0 / sqrt((x[i] - x[j])^2 + (y[i] - y[j])^2 + (z[i] - z[j])^2) for (i,j) in itr)
+    ExaModels.@add_obj(core, 1.0 / sqrt((x[i] - x[j])^2 + (y[i] - y[j])^2 + (z[i] - z[j])^2) for (i,j) in itr)
     # Unit-ball
-    ExaModels.constraint(core, x[i]^2 + y[i]^2 + z[i]^2 - 1 for i=1:np)
+    ExaModels.@add_con(core, x[i]^2 + y[i]^2 + z[i]^2 - 1 for i=1:np)
 
     return ExaModels.ExaModel(core)
 end


### PR DESCRIPTION
## Problem

The docs build fails on `master` ([example run](https://github.com/madsuite-org/MadNLP.jl/actions/runs/32697802345/job/97343164928)).

ExaModels v0.12.0 removed the legacy `variable`, `objective` and `constraint` entry points, so every `@example` block that builds a model dies with:

```
UndefVarError: `variable` not defined in `ExaModels`
```

There are 6 such root failures, in `docs/src/tutorials/{gpu,multiprecision,quasi_newton}.md`. The remaining 19 reported failures are cascades from them (`UndefVarError: nlp not defined`, `results not defined`, ...), and `makedocs` then terminates with `encountered an error [:example_block]`.

## Fix

Replace the three removed entry points with the current macro API — `@add_var`, `@add_obj`, `@add_con` — which is what the ExaModels v0.12 guide uses. `ExaCore(T; backend = ...)` is unchanged.

One subtlety worth flagging for future migrations: the bounds have to be passed as keyword arguments *after a semicolon*. In a macro call, `lvar = -10.0` following a comma parses as a positional argument rather than a keyword, so the model builds fine and the bound is silently dropped (`lvar` stays at `-Inf`). The first draft of this change had exactly that bug and it was caught only by asserting on `get_lvar`.

## Verification

Since the change is a rewrite of model-building code, it was checked for semantic equivalence rather than just for compiling. The model functions were extracted programmatically from the markdown files (so the thing under test is the doc, not a transcription) and compared against the same functions running the legacy API on ExaModels v0.11.2, where `variable` still exists.

Compared: `nvar`, `ncon`, `nnzj`, `nnzh`, `lvar`/`uvar`/`lcon`/`ucon`, `x0`, and the objective, gradient, constraints, Jacobian and Hessian evaluated at a fixed deterministic point. Cases: `airport_model` in `Float64` and `Float32`, and `elec_model(10)`.

- All fingerprints are **identical** before and after.
- Controls: the same comparison run against unedited `master` fails at extraction; dropping `lvar`/`uvar` from one `@add_var` makes the comparison go red — so the check is capable of failing.
- `gpu.md` was additionally run with a real `CUDABackend()`: `x0` is a `CuArray` as the surrounding text claims, the bounds are applied on device, and the objective and constraint values agree with the CPU reference.

No prose changes were needed; the models are unchanged, so the iteration counts quoted in the tutorials still hold.